### PR TITLE
Make XY beamstop ioc tests not hang indefinitely

### DIFF
--- a/tests/xyarmbeamstop.py
+++ b/tests/xyarmbeamstop.py
@@ -63,8 +63,8 @@ class XyarmbeamstopTests(unittest.TestCase):
     """
     def setUp(self):
         self._ioc = IOCRegister.get_running("xyarmbeamstop")
-        self.ca = ChannelAccess()
-        self.ca.wait_for(MOTOR_X, timeout=30)
+        self.ca = ChannelAccess(default_timeout=30)
+        self.ca.wait_for(MOTOR_X, timeout=60)
         self._set_pv_value(STORE_SP, ACTIVE)
         self._assert_setpoint_and_readback_reached(ACTIVE_X, ACTIVE_Y)
 

--- a/utils/channel_access.py
+++ b/utils/channel_access.py
@@ -43,7 +43,10 @@ class ChannelAccess(object):
         :param pv: the EPICS PV name
         :param value: the value to set
         """
-        self.ca.set_pv_value(self._create_pv_with_prefix(pv), value, wait=True, timeout=None)
+        # Don't use wait=True because it will cause an infinite wait if the value never gets set successfully
+        # In that case the test should fail (because the correct value is not set)
+        # but it should not hold up all the other tests
+        self.ca.set_pv_value(self._create_pv_with_prefix(pv), value, wait=False, timeout=self._default_timeout)
         # Need to give Lewis time to process
         time.sleep(1)
 


### PR DESCRIPTION
Fixes the XY beamstop tests.

The hang was caused by the `wait=True` argument to genie_python's set pv. If the write failed for whatever reason then this would hang forever.

To test:
- Run the beamstop tests many times (e.g. 5-10) and check that they don't hang. You'll need to do several repeats as this bug didn't seem to happen all the time.
- I don't seem to be able to get the tests to pass consistently on my machine, it might be that my machine isn't set up quite right. Could the reviewer check if the tests pass consistently on their machine.

We also now occasionally get messages from the underlying CA layer, there is already a ticket for this: https://github.com/ISISComputingGroup/IBEX/issues/1188