### PR TITLE
Add test for <0 mbar. Adjust PVs as per IOC changes. Couple of PEP8 c…

### DIFF
--- a/tests/ieg.py
+++ b/tests/ieg.py
@@ -44,7 +44,7 @@ class IegTests(unittest.TestCase):
 
     @staticmethod
     def _get_raw_from_actual(value):
-        return int(round((value - CALIBRATION_B) - CALIBRATION_A))
+        return int(round((value - CALIBRATION_B) / CALIBRATION_A))
 
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("ieg")

--- a/tests/ieg.py
+++ b/tests/ieg.py
@@ -5,13 +5,11 @@ from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import IOCRegister
 from utils.testing import get_running_lewis_and_ioc
 
-from time import sleep
-
-
 CALIBRATION_A = 1.23
 CALIBRATION_B = -4.56
 
-MACROS = { "CALIBRATION_A": str(CALIBRATION_A), "CALIBRATION_B": str(CALIBRATION_B)}
+MACROS = {"CALIBRATION_A": str(CALIBRATION_A), "CALIBRATION_B": str(CALIBRATION_B)}
+
 
 class IegTests(unittest.TestCase):
     """
@@ -140,7 +138,13 @@ class IegTests(unittest.TestCase):
     @skipIf(IOCRegister.uses_rec_sim, "Uses lewis backdoor command")
     def test_WHEN_pressure_is_over_350_THEN_displayed_as_greater_than_350_mBar(self):
         self._lewis.backdoor_set_on_device("sample_pressure", self._get_raw_from_actual(400))
-        self.ca.assert_that_pv_is("PRESSURE:GUI.OSV", "> 350 mbar")
+        self.ca.assert_that_pv_is("PRESSURE:GUI.OSV", ">350 mbar")
+        self.ca.assert_pv_alarm_is("PRESSURE:GUI", self.ca.ALARM_MAJOR)
+
+    @skipIf(IOCRegister.uses_rec_sim, "Uses lewis backdoor command")
+    def test_WHEN_pressure_is_less_than_0_THEN_displayed_as_less_than_0_mBar(self):
+        self._lewis.backdoor_set_on_device("sample_pressure", self._get_raw_from_actual(-10))
+        self.ca.assert_that_pv_is("PRESSURE:GUI.OSV", "<0 mbar")
         self.ca.assert_pv_alarm_is("PRESSURE:GUI", self.ca.ALARM_MAJOR)
 
     @skipIf(IOCRegister.uses_rec_sim, "Uses lewis backdoor command")
@@ -149,5 +153,6 @@ class IegTests(unittest.TestCase):
             actual_pressure = self._get_actual_from_raw(raw_pressure)
 
             self._lewis.backdoor_set_on_device("sample_pressure", raw_pressure)
-            self.ca.assert_that_pv_is_number("PRESSURE", actual_pressure, tolerance=0.05)
+            # PRESSURE is restricted to use [0-350]. PRESSURE:CALC is unrestricted
+            self.ca.assert_that_pv_is_number("PRESSURE:CALC", actual_pressure, tolerance=0.05)
             self.ca.assert_pv_alarm_is("PRESSURE", self.ca.ALARM_NONE if .0 < actual_pressure < 350 else self.ca.ALARM_MAJOR)


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/2758

- Add a test to check output in case <0 mbar
- Adjust feedback messages in line with IOC changes
- Adjust PVs in line with changes to IOC
- Couple of PEP8 corrections
- **No** tests for exactly 0 and 350 mbar as they cannot be produced with this calibration and the calibration can only be set once as it is done as a macro.