### PR TITLE
Ticket2535 oscillating collimator (minimal)

### DIFF
--- a/run_all_tests.bat
+++ b/run_all_tests.bat
@@ -168,3 +168,9 @@ echo TESTING EUROTHRM Dev Sim
 call %PYTHON% "%EPICS_KIT_ROOT%\support\IocTestFramework\master\run_tests.py" -pf %MYPVPREFIX%  -d eurotherm -p %EPICS_KIT_ROOT%\ioc\master\EUROTHRM\iocBoot\iocEUROTHRM-IOC-01 -e %PYTHONDIR%\Scripts -ea %EPICS_KIT_ROOT%\support\DeviceEmulator\master -ek lewis_emulators
 echo ---------------------------------------
 echo;
+
+echo ---------------------------------------
+echo TESTING OSCILLATING COLLIMATOR Dev Sim
+call %PYTHON% "%EPICS_KIT_ROOT%\support\IocTestFramework\master\run_tests.py" -pf %MYPVPREFIX%  -d oscillating_collimator -p %EPICS_KIT_ROOT%\ioc\master\GALIL\iocBoot\iocGALIL-IOC-01
+echo ---------------------------------------
+echo;

--- a/tests/oscillating_collimator.py
+++ b/tests/oscillating_collimator.py
@@ -1,0 +1,117 @@
+import unittest
+
+from utils.channel_access import ChannelAccess
+from utils.ioc_launcher import IOCRegister
+
+# IP address of device
+GALIL_ADDR = "128.0.0.0"
+
+# MACROS to use for the IOC
+MACROS = {"GALILADDR01": GALIL_ADDR}
+PREFIX = "MOT:OSCCOL"
+
+# Commonly used PVs
+ANGLE = "ANGLE:SP"
+FREQUENCY = "FREQ:SP"
+RADIUS = "RADIUS:SP"
+VELOCITY = "VEL:SP"
+DISTANCE = "DIST:SP"
+DISCRIMINANT = "VEL:SP:DISC:CHECK"
+
+
+class Oscillating_collimatorTests(unittest.TestCase):
+    """
+    Tests for the LET Oscillating collimator.
+
+    The CA.Client.Exceptions these tests generate are expected because of a workaround we had to make in the DB
+    file to prevent a hang in the case of using asynFloat64 for the SP types. Issue described in ticket #2736
+    """
+    def setUp(self):
+        self._ioc = IOCRegister.get_running("oscillating_collimator")
+        ChannelAccess().wait_for("MOT:MTR0101", timeout=30)
+        self.ca = ChannelAccess(device_prefix=PREFIX)
+        self.ca.wait_for("VEL:SP", timeout=30)
+
+    def test_GIVEN_angle_frequency_and_radius_WHEN_set_THEN_distance_and_velocity_match_LabView_generated_values(self):
+
+        # Arrange
+        # Dictionary outputs[(angle, frequency, radius)] = (distance, velocity)
+        # Values confirmed via LabView VI
+        outputs = dict()
+
+        outputs[(2.0, 0.5, 10.0)] = (281, 283)
+        outputs[(1.0, 0.5, 10.0)] = (140, 140)
+        outputs[(0.5, 0.5, 10.0)] = (70, 70)
+
+        outputs[(2.0, 0.1, 10.0)] = (279, 56)
+        outputs[(1.0, 0.1, 10.0)] = (140, 28)
+        outputs[(0.5, 0.1, 10.0)] = (70, 14)
+
+        outputs[(2.0, 0.5, 50.0)] = (1442, 1487)
+        outputs[(1.0, 0.5, 50.0)] = (709, 719)
+        outputs[(0.5, 0.5, 50.0)] = (352, 354)
+
+        outputs[(2.0, 0.1, 50.0)] = (1398, 280)
+        outputs[(1.0, 0.1, 50.0)] = (699, 140)
+        outputs[(0.5, 0.1, 50.0)] = (349, 70)
+
+        tolerance = 0.5
+
+        for key in outputs.keys():
+            # Act
+            self.ca.set_pv_value(ANGLE, key[0])
+            self.ca.set_pv_value(FREQUENCY, key[1])
+            self.ca.set_pv_value(RADIUS, key[2])
+
+            # Assert
+            self.ca.assert_that_pv_is_number("DIST:SP", outputs[key][0], tolerance)
+            self.ca.assert_that_pv_is_number("VEL:SP", outputs[key][1], tolerance)
+
+    def test_WHEN_angle_set_negative_THEN_angle_is_zero(self):
+        self.ca.set_pv_value(ANGLE, -1.0)
+        self.ca.assert_that_pv_is_number(ANGLE, 0.0)
+
+    def test_WHEN_angle_set_greater_than_two_THEN_angle_is_two(self):
+        self.ca.set_pv_value(ANGLE, 5.0)
+        self.ca.assert_that_pv_is_number(ANGLE, 2.0)
+
+    def test_WHEN_frequency_set_negative_THEN_angle_is_zero(self):
+        self.ca.set_pv_value(FREQUENCY, -1.0)
+        self.ca.assert_that_pv_is_number(FREQUENCY, 0.0)
+
+    def test_WHEN_angle_set_greater_than_half_THEN_angle_is_half(self):
+        self.ca.set_pv_value(FREQUENCY, 1.0)
+        self.ca.assert_that_pv_is_number(FREQUENCY, 0.5)
+
+    def test_WHEN_frq_set_greater_than_two_THEN_angle_is_two(self):
+        self.ca.set_pv_value(ANGLE, 5.0)
+        self.ca.assert_that_pv_is_number(ANGLE, 2.0)
+
+    def test_WHEN_mounting_radius_set_negative_THEN_mounting_radius_is_zero(self):
+        self.ca.set_pv_value(RADIUS, -1.0)
+        self.ca.assert_that_pv_is_number(RADIUS, 0.0)
+
+    def test_WHEN_input_values_cause_discriminant_to_be_negative_THEN_discriminant_pv_is_one(self):
+
+        # Act
+        self.ca.set_pv_value(ANGLE, 2.0)
+        self.ca.set_pv_value(FREQUENCY, 0.5)
+        self.ca.set_pv_value(RADIUS, 1000.0)
+
+        # Assert
+        self.ca.assert_that_pv_is_number(DISCRIMINANT, 1.0)
+
+    def test_WHEN_input_values_cause_discriminant_to_be_positive_THEN_discriminant_pv_is_zero(self):
+
+        # Act
+        self.ca.set_pv_value(ANGLE, 2.0)
+        self.ca.set_pv_value(FREQUENCY, 0.5)
+        self.ca.set_pv_value(RADIUS, 1.0)
+
+        # Assert
+        self.ca.assert_that_pv_is_number(DISCRIMINANT, 0.0)
+
+    def test_WHEN_collimator_running_THEN_thread_is_not_on_reserved_thread(self):
+        # Threads 0 and 1 are reserved for homing under IBEX
+        self.ca.assert_that_pv_is_not("THREAD", "0")
+        self.ca.assert_that_pv_is_not("THREAD", "1")

--- a/utils/channel_access.py
+++ b/utils/channel_access.py
@@ -175,7 +175,7 @@ class ChannelAccess(object):
 
         :param pv: name of the pv (no prefix)
         :param restricted_value: value PV should not have
-        :return: None if they don't match; error string stating the difference if they do
+        :return: None if they don't match; error string if they do
         """
         pv_value = self.get_pv_value(pv)
         if pv_value != restricted_value:


### PR DESCRIPTION
### Description of work

Added IOC tests for the oscillating collimator. These are DEVSIM tests only owing to the restriction of using the motor record.

This PR does not contain any work on the IOC test framework stability at large. The previous PR had some work for this but the changes to the genie_python dependencies (namely CA channel) require this to be looked at again and shouldn't inhibit this change.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2535

### Acceptance criteria

- All tests pass reliably (run 3 times to be sure)
- Sensible test coverage
- ** Existing tests still run successfully **

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Did any existing tests break as a result of the current changes? 
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

