### PR TITLE
Ticket3007 add ioc fins

### DIFF
--- a/tests/fins.py
+++ b/tests/fins.py
@@ -1,0 +1,34 @@
+import unittest
+
+from utils.channel_access import ChannelAccess
+from utils.ioc_launcher import get_default_ioc_dir
+from utils.test_modes import TestModes
+from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
+
+
+DEVICE_PREFIX = "FINS_01"
+
+
+IOCS = [
+    {
+        "name": DEVICE_PREFIX,
+        "directory": get_default_ioc_dir("FINS"),
+        "macros": {},
+        "emulator": "Fins",
+    },
+]
+
+
+TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
+
+
+class FinsTests(unittest.TestCase):
+    """
+    Tests for the Fins IOC.
+    """
+    def setUp(self):
+        self._lewis, self._ioc = get_running_lewis_and_ioc("Fins", DEVICE_PREFIX)
+        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
+
+    def test_that_fails(self):
+        self.fail("You haven't implemented any tests!")

--- a/tests/fins.py
+++ b/tests/fins.py
@@ -3,7 +3,7 @@ import unittest
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
-from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
+from utils.testing import get_running_lewis_and_ioc, skip_if_recsim, skip_if_devsim
 
 
 DEVICE_PREFIX = "FINS_01"
@@ -13,7 +13,7 @@ IOCS = [
     {
         "name": DEVICE_PREFIX,
         "directory": get_default_ioc_dir("FINS"),
-        "macros": {},
+        "macros": { "PLCIP" : "127.0.0.1" },
         "emulator": "Fins",
     },
 ]
@@ -30,5 +30,7 @@ class FinsTests(unittest.TestCase):
         self._lewis, self._ioc = get_running_lewis_and_ioc("Fins", DEVICE_PREFIX)
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
 
-    def test_that_fails(self):
-        self.fail("You haven't implemented any tests!")
+    @skip_if_devsim("In dev sim this test fails")
+    def test_GIVEN_fins_THEN_has_flow_pv(self):
+        self.ca.assert_that_pv_is_not("BENCH:FLOW1", "")
+


### PR DESCRIPTION
This adds a test for the FINS IOC in recsim mode, it needs the following PRs to work:
 
https://github.com/ISISComputingGroup/EPICS-ioc/pull/253
https://github.com/ISISComputingGroup/EPICS-FINS/pull/5

Part of ISISComputingGroup/IBEX#3007
