### PR TITLE
Ticket 3086: Added tests for limits on gem beamscrapers

### DIFF
--- a/tests/gem_jaws.py
+++ b/tests/gem_jaws.py
@@ -94,6 +94,7 @@ class GemJawsTests(unittest.TestCase):
 
     def _test_set_point(self, underlying_motor, calibrated_axis, to_write_func, x):
         self.ca.set_pv_value(calibrated_axis, x)
+        self.ca.assert_that_pv_is_number(underlying_motor + ".DMOV", 1)  # Wait for axis to finish moving
         self.ca.assert_that_pv_is_number(underlying_motor + ".VAL", to_write_func(x), TOLERANCE)
 
     def test_WHEN_underlying_quadratic_motor_set_to_a_position_THEN_calibrated_axis_as_expected(self):

--- a/tests/gem_jaws.py
+++ b/tests/gem_jaws.py
@@ -1,12 +1,11 @@
 import unittest
-import math
 import time
-from itertools import starmap
 
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import IOCRegister, get_default_ioc_dir
 from utils.test_modes import TestModes
 
+VELOCITY = 1000
 
 IOCS = [
     {
@@ -19,10 +18,10 @@ IOCS = [
             "AXIS4": "yes",
             "MTRCTRL": "01",
             "IFGEMJAWS": " ",
-            "VELO1": 1000,
-            "VELO2": 1000,
-            "VELO3": 1000,
-            "VELO4": 1000,
+            "VELO1": VELOCITY,
+            "VELO2": VELOCITY,
+            "VELO3": VELOCITY,
+            "VELO4": VELOCITY,
         },
     },
 ]
@@ -57,6 +56,7 @@ TEST_POSITIONS = [MIN_POSITION, MID_POSITION, MAX_POSITION]
 QUADRATIC_COEFFICIENTS = 0.03331, 0.07169, -0.13376
 LINEAR_COEFFICIENTS = 1.025, 0
 
+
 def calc_expected_quad_read(x):
     a, b, c = QUADRATIC_COEFFICIENTS
     return a * pow(x, 2) + b * x + c
@@ -79,21 +79,17 @@ def calc_expected_linear_write(y):
 
 class GemJawsTests(unittest.TestCase):
     """
-    Tests for the gem beamscrapper jaws
+    Tests for the gem beamscraper jaws
     """
     def setUp(self):
         self._ioc = IOCRegister.get_running("gem_jaws")
         self.ca = ChannelAccess(default_timeout=30)
 
         [self.ca.wait_for(mot) for mot in all_motors]
-        self._stop_all_motors()
 
-    def _stop_all_motors(self):
-        [self.ca.set_pv_value(mtr + ".STOP", 1) for mtr in all_motors]
-
-    def _test_readback(self, calibrated_axis, to_read_func, x):
-        # Uses a sim record to save the time for the simulated motor to stop
-        self.ca.set_pv_value(calibrated_axis + ":SIM:MTR:RBV", x)
+    def _test_readback(self, underlying_motor, calibrated_axis, to_read_func, x):
+        self.ca.set_pv_value(underlying_motor, x)
+        self.ca.assert_that_pv_is_number(underlying_motor + ".DMOV", 1)  # Wait for axis to finish moving
         self.ca.assert_that_pv_is_number(calibrated_axis + ".RBV", to_read_func(x), TOLERANCE)
 
     def _test_set_point(self, underlying_motor, calibrated_axis, to_write_func, x):
@@ -101,35 +97,39 @@ class GemJawsTests(unittest.TestCase):
         self.ca.assert_that_pv_is_number(underlying_motor + ".VAL", to_write_func(x), TOLERANCE)
 
     def test_WHEN_underlying_quadratic_motor_set_to_a_position_THEN_calibrated_axis_as_expected(self):
-        for motor in [MOTOR_W, MOTOR_E]:
+        motors = {MOTOR_E: UNDERLYING_MTR_EAST, MOTOR_W: UNDERLYING_MTR_WEST}
+        for mot, underlying in motors.items():
             for position in TEST_POSITIONS:
-                self._test_readback(motor, calc_expected_quad_read, position)
+                self._test_readback(underlying, mot, calc_expected_quad_read, position)
 
     def test_WHEN_calibrated_quadratic_motor_set_to_a_position_THEN_underlying_motor_as_expected(self):
         motors = {MOTOR_E: UNDERLYING_MTR_EAST, MOTOR_W: UNDERLYING_MTR_WEST}
         for mot, underlying in motors.items():
             for position in TEST_POSITIONS:
                 self._test_set_point(underlying, mot, calc_expected_quad_write, position)
-                self._stop_all_motors()
 
     def test_WHEN_underlying_linear_motor_set_to_a_position_THEN_calibrated_axis_as_expected(self):
-        for motor in [MOTOR_N, MOTOR_S]:
+        motors = {MOTOR_N: UNDERLYING_MTR_NORTH, MOTOR_S: UNDERLYING_MTR_SOUTH}
+        for mot, underlying in motors.items():
             for position in TEST_POSITIONS:
-                self._test_readback(motor, calc_expected_linear_read, position)
-                self._stop_all_motors()
+                self._test_readback(underlying, mot, calc_expected_linear_read, position)
 
     def test_WHEN_calibrated_linear_motor_set_to_a_position_THEN_underlying_motor_as_expected(self):
         motors = {MOTOR_N: UNDERLYING_MTR_NORTH, MOTOR_S: UNDERLYING_MTR_SOUTH}
         for mot, underlying in motors.items():
             for position in TEST_POSITIONS:
                 self._test_set_point(underlying, mot, calc_expected_linear_write, position)
-                self._stop_all_motors()
 
-    def test_WHEN_underlying_motor_stops_THEN_calibrated_motor_stops(self):
-        # Move motor
-        test_position = 7
-        self.ca.set_pv_value(MOTOR_W, test_position)
+    def test_GIVEN_quad_calibrated_motor_limits_set_THEN_underlying_motor_limits_set(self):
+        for lim in [".DLLM", ".DHLM"]:
+            underlying_limit = self.ca.get_pv_value(UNDERLYING_MTR_WEST + lim)
 
-        self.ca.set_pv_value(UNDERLYING_MTR_WEST + ".STOP", 1)
-        self.ca.assert_that_pv_is(MOTOR_W + ".DMOV", 1)
-        self.ca.assert_that_pv_is_not_number(MOTOR_W + ".RBV", test_position, TOLERANCE)
+            self.ca.assert_that_pv_is_number(MOTOR_W + lim, calc_expected_quad_read(underlying_limit),
+                                             TOLERANCE)
+
+    def test_GIVEN_linear_calibrated_motor_limits_set_THEN_underlying_motor_limits_set(self):
+        for lim in [".DLLM", ".DHLM"]:
+            underlying_limit = self.ca.get_pv_value(UNDERLYING_MTR_NORTH + lim)
+
+            self.ca.assert_that_pv_is_number(MOTOR_N + lim, calc_expected_linear_read(underlying_limit),
+                                             TOLERANCE)


### PR DESCRIPTION
Added test for limits and simplified some of the other tests.

I have removed the stopping test as it was previously passing with a false positive. I spent some time trying to fix it but the IOC Test Framework cannot seem to stop simulated motors (see attached test). If a reviewer agrees that this doesn't work I'll add a new ticket.
[motor_sim.zip](https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework/files/1885395/motor_sim.zip)

