### PR TITLE
Ticket2856 Commission FZJ DD Fermi Chopper - IOC Test modifications

### DIFF
--- a/tests/fzj_dd_fermi_chopper.py
+++ b/tests/fzj_dd_fermi_chopper.py
@@ -33,7 +33,6 @@ CW_CCW = {True: "CW", False: "CCW"}
 # SIMULATED_VALUES = { backdoor_parameter, pv_name, true_value, false_value }
 
 SIMULATED_VALUES = {
-#    "frequency_reference": ("frequency_reference", "SIM:FREQ:REF"),
     "frequency_setpoint": ("frequency_setpoint", "SIM:FREQ:SP:RBV"),
     "frequency": ("frequency", "SIM:FREQ"),
     "phase_setpoint": ("phase_setpoint", "SIM:PHAS:SP:RBV"),
@@ -41,20 +40,15 @@ SIMULATED_VALUES = {
     "phase_status_is_ok": ("phase_status_is_ok", "SIM:PHAS:STAT", OK_NOK[True], OK_NOK[False]),
     "magnetic_bearing_is_on": ("magnetic_bearing_is_on", "SIM:MB", ON_OFF[True], ON_OFF[False]),
     "magnetic_bearing_status_is_ok": ("magnetic_bearing_status_is_ok", "SIM:MB:STAT", OK_NOK[True], OK_NOK[False]),
-#    "magnetic_bearing_integrator": ("magnetic_bearing_integrator", "SIM:MB:INT"),
     "drive_is_on": ("drive_is_on", "SIM:DRIVE", ON_OFF[True], ON_OFF[False]),
     "drive_mode_is_start": ("drive_mode_is_start", "SIM:DRIVE:MODE", START_STOP[True], START_STOP[False]),
     "drive_l1_current": ("drive_l1_current", "SIM:DRIVE:L1:CURR"),
     "drive_l2_current": ("drive_l2_current", "SIM:DRIVE:L2:CURR"),
     "drive_l3_current": ("drive_l3_current", "SIM:DRIVE:L3:CURR"),
     "drive_direction_is_cw": ("drive_direction_is_cw", "SIM:DRIVE:DIR", CW_CCW[True], CW_CCW[False]),
-#    "parked_open_status_is_ok": ("parked_open_status_is_ok", "SIM:PARKED:OPEN:STAT", OK_NOK[True], OK_NOK[False]),
     "drive_temperature": ("drive_temperature", "SIM:DRIVE:TEMP"),
-#    "input_clock": ("input_clock", "SIM:INPUTCLOCK"),
     "phase_outage": ("phase_outage", "SIM:PHAS:OUTAGE"),
-#    "master_chopper": ("master_chopper", "SIM:MASTER"),
     "logging_is_on": ("logging_is_on", "SIM:LOGGING", ON_OFF[True], ON_OFF[False]),
-#    "lmsr_status_is_ok": ("lmsr_status_is_ok", "SIM:LMSR:STAT", OK_NOK[True], OK_NOK[False]),
     "dsp_status_is_ok": ("dsp_status_is_ok", "SIM:DSP:STAT", OK_NOK[True], OK_NOK[False]),
     "interlock_er_status_is_ok": ("interlock_er_status_is_ok", "SIM:INTERLOCK:ER:STAT", OK_NOK[True], OK_NOK[False]),
     "interlock_vacuum_status_is_ok": ("interlock_vacuum_status_is_ok", "SIM:INTERLOCK:VAC:STAT", OK_NOK[True], 
@@ -128,14 +122,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._ioc.set_simulated_value(pv_name, value)
         self._lewis.backdoor_set_on_device(backdoor_parameter, value)
 
-    # @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
-    # def test_GIVEN_frequency_reference_WHEN_read_all_status_THEN_value_is_as_expected(self):
-    #     expected_value = 50.62
-    #     self._set_simulated_value("frequency_reference", expected_value)
-    #
-    #     self.ca.assert_that_pv_is("FREQ:REF", expected_value)
-    #     self.ca.assert_pv_alarm_is("FREQ:REF", ChannelAccess.ALARM_NONE)
-
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_frequency_setpoint_WHEN_read_all_status_THEN_value_is_as_expected(self):
         expected_value = 100
@@ -167,14 +153,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
 
             self.ca.assert_that_pv_is("MB:STAT", expected_value)
             self.ca.assert_pv_alarm_is("MB:STAT", ChannelAccess.ALARM_NONE)
-
-    # @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
-    # def test_GIVEN_magnetic_bearing_integrator_WHEN_read_all_status_THEN_value_is_as_expected(self):
-    #     expected_value = -27.4
-    #     self._set_simulated_value("magnetic_bearing_integrator", expected_value)
-    #
-    #     self.ca.assert_that_pv_is("MB:INT", expected_value)
-    #     self.ca.assert_pv_alarm_is("MB:INT", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_magnetic_bearing_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -232,14 +210,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("DRIVE:DIR", expected_value)
             self.ca.assert_pv_alarm_is("DRIVE:DIR", ChannelAccess.ALARM_NONE)
 
-    # @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
-    # def test_GIVEN_parked_open_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
-    #     for boolean_value, expected_value in OK_NOK.items():
-    #         self._set_simulated_value("parked_open_status_is_ok", boolean_value)
-    #
-    #         self.ca.assert_that_pv_is("PARKED:OPEN:STAT", expected_value)
-    #         self.ca.assert_pv_alarm_is("PARKED:OPEN:STAT", ChannelAccess.ALARM_NONE)
-
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_temperature_WHEN_read_all_status_THEN_value_is_as_expected(self):
         expected_value = 86.31
@@ -247,14 +217,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
 
         self.ca.assert_that_pv_is("DRIVE:TEMP", expected_value)
         self.ca.assert_pv_alarm_is("DRIVE:TEMP", ChannelAccess.ALARM_NONE)
-
-    # @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
-    # def test_GIVEN_input_clock_WHEN_read_all_status_THEN_value_is_as_expected(self):
-    #     expected_value = 34.94
-    #     self._set_simulated_value("input_clock", expected_value)
-    #
-    #     self.ca.assert_that_pv_is("INPUTCLOCK", expected_value)
-    #     self.ca.assert_pv_alarm_is("INPUTCLOCK", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_phase_outage_WHEN_read_all_status_THEN_value_is_as_expected(self):
@@ -264,14 +226,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is("PHAS:OUTAGE", expected_value)
         self.ca.assert_pv_alarm_is("PHAS:OUTAGE", ChannelAccess.ALARM_NONE)
 
-    # @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
-    # def test_GIVEN_master_chopper_WHEN_read_all_status_THEN_value_is_as_expected(self):
-    #     expected_value = "C2B"
-    #     self._set_simulated_value("master_chopper", expected_value)
-    #
-    #     self.ca.assert_that_pv_is("MASTER", expected_value)
-    #     self.ca.assert_pv_alarm_is("MASTER", ChannelAccess.ALARM_NONE)
-
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_logging_WHEN_read_all_status_THEN_status_is_as_expected(self):
         for boolean_value, expected_value in ON_OFF.items():
@@ -279,14 +233,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
 
             self.ca.assert_that_pv_is("LOGGING", expected_value)
             self.ca.assert_pv_alarm_is("LOGGING", ChannelAccess.ALARM_NONE)
-
-    # @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
-    # def test_GIVEN_lmsr_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
-    #     for boolean_value, expected_value in OK_NOK.items():
-    #         self._set_simulated_value("lmsr_status_is_ok", boolean_value)
-    #
-    #         self.ca.assert_that_pv_is("LMSR:STAT", expected_value)
-    #         self.ca.assert_pv_alarm_is("LMSR:STAT", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_dsp_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -601,28 +547,22 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
     def test_GIVEN_device_is_not_communicating_WHEN_read_all_status_THEN_values_have_error(self):
         self._lewis.backdoor_set_on_device("disconnected", True)
 
-        for pv in [# "FREQ:REF",
-                   "FREQ:SP:RBV",
+        for pv in ["FREQ:SP:RBV",
                    "FREQ",
                    "PHAS:SP:RBV",
                    "PHAS",
                    "PHAS:STAT",
                    "MB",
                    "MB:STAT",
-                   # "MB:INT",
                    "DRIVE",
                    "DRIVE:MODE",
                    "DRIVE:L1:CURR",
                    "DRIVE:L2:CURR",
                    "DRIVE:L3:CURR",
                    "DRIVE:DIR",
-                   # "PARKED:OPEN:STAT",
                    "DRIVE:TEMP",
-                   # "INPUTCLOCK",
                    "PHAS:OUTAGE",
-                   # "MASTER",
                    "LOGGING",
-                   # "LMSR:STAT",
                    "DSP:STAT",
                    "INTERLOCK:ER:STAT",
                    "INTERLOCK:VAC:STAT",

--- a/tests/fzj_dd_fermi_chopper.py
+++ b/tests/fzj_dd_fermi_chopper.py
@@ -22,7 +22,6 @@ IOCS = [
     },
 ]
 
-
 TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
 
 OK_NOK = {True: "OK", False: "NOK"}
@@ -34,7 +33,7 @@ CW_CCW = {True: "CW", False: "CCW"}
 # SIMULATED_VALUES = { backdoor_parameter, pv_name, true_value, false_value }
 
 SIMULATED_VALUES = {
-    "frequency_reference": ("frequency_reference", "SIM:FREQ:REF"),
+#    "frequency_reference": ("frequency_reference", "SIM:FREQ:REF"),
     "frequency_setpoint": ("frequency_setpoint", "SIM:FREQ:SP:RBV"),
     "frequency": ("frequency", "SIM:FREQ"),
     "phase_setpoint": ("phase_setpoint", "SIM:PHAS:SP:RBV"),
@@ -42,20 +41,20 @@ SIMULATED_VALUES = {
     "phase_status_is_ok": ("phase_status_is_ok", "SIM:PHAS:STAT", OK_NOK[True], OK_NOK[False]),
     "magnetic_bearing_is_on": ("magnetic_bearing_is_on", "SIM:MB", ON_OFF[True], ON_OFF[False]),
     "magnetic_bearing_status_is_ok": ("magnetic_bearing_status_is_ok", "SIM:MB:STAT", OK_NOK[True], OK_NOK[False]),
-    "magnetic_bearing_integrator": ("magnetic_bearing_integrator", "SIM:MB:INT"),
+#    "magnetic_bearing_integrator": ("magnetic_bearing_integrator", "SIM:MB:INT"),
     "drive_is_on": ("drive_is_on", "SIM:DRIVE", ON_OFF[True], ON_OFF[False]),
     "drive_mode_is_start": ("drive_mode_is_start", "SIM:DRIVE:MODE", START_STOP[True], START_STOP[False]),
     "drive_l1_current": ("drive_l1_current", "SIM:DRIVE:L1:CURR"),
     "drive_l2_current": ("drive_l2_current", "SIM:DRIVE:L2:CURR"),
     "drive_l3_current": ("drive_l3_current", "SIM:DRIVE:L3:CURR"),
     "drive_direction_is_cw": ("drive_direction_is_cw", "SIM:DRIVE:DIR", CW_CCW[True], CW_CCW[False]),
-    "parked_open_status_is_ok": ("parked_open_status_is_ok", "SIM:PARKED:OPEN:STAT", OK_NOK[True], OK_NOK[False]),
+#    "parked_open_status_is_ok": ("parked_open_status_is_ok", "SIM:PARKED:OPEN:STAT", OK_NOK[True], OK_NOK[False]),
     "drive_temperature": ("drive_temperature", "SIM:DRIVE:TEMP"),
-    "input_clock": ("input_clock", "SIM:INPUTCLOCK"),
+#    "input_clock": ("input_clock", "SIM:INPUTCLOCK"),
     "phase_outage": ("phase_outage", "SIM:PHAS:OUTAGE"),
-    "master_chopper": ("master_chopper", "SIM:MASTER"),
+#    "master_chopper": ("master_chopper", "SIM:MASTER"),
     "logging_is_on": ("logging_is_on", "SIM:LOGGING", ON_OFF[True], ON_OFF[False]),
-    "lmsr_status_is_ok": ("lmsr_status_is_ok", "SIM:LMSR:STAT", OK_NOK[True], OK_NOK[False]),
+#    "lmsr_status_is_ok": ("lmsr_status_is_ok", "SIM:LMSR:STAT", OK_NOK[True], OK_NOK[False]),
     "dsp_status_is_ok": ("dsp_status_is_ok", "SIM:DSP:STAT", OK_NOK[True], OK_NOK[False]),
     "interlock_er_status_is_ok": ("interlock_er_status_is_ok", "SIM:INTERLOCK:ER:STAT", OK_NOK[True], OK_NOK[False]),
     "interlock_vacuum_status_is_ok": ("interlock_vacuum_status_is_ok", "SIM:INTERLOCK:VAC:STAT", OK_NOK[True], 
@@ -129,17 +128,17 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._ioc.set_simulated_value(pv_name, value)
         self._lewis.backdoor_set_on_device(backdoor_parameter, value)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
-    def test_GIVEN_frequency_reference_WHEN_read_all_status_THEN_value_is_as_expected(self):
-        expected_value = 50.62
-        self._set_simulated_value("frequency_reference", expected_value)
-
-        self.ca.assert_that_pv_is("FREQ:REF", expected_value)
-        self.ca.assert_pv_alarm_is("FREQ:REF", ChannelAccess.ALARM_NONE)
+    # @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
+    # def test_GIVEN_frequency_reference_WHEN_read_all_status_THEN_value_is_as_expected(self):
+    #     expected_value = 50.62
+    #     self._set_simulated_value("frequency_reference", expected_value)
+    #
+    #     self.ca.assert_that_pv_is("FREQ:REF", expected_value)
+    #     self.ca.assert_pv_alarm_is("FREQ:REF", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_frequency_setpoint_WHEN_read_all_status_THEN_value_is_as_expected(self):
-        expected_value = 60.97
+        expected_value = 100
         self._set_simulated_value("frequency_setpoint", expected_value)
 
         self.ca.assert_that_pv_is("FREQ:SP:RBV", expected_value)
@@ -147,7 +146,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_phase_setpoint_WHEN_read_all_status_THEN_value_is_as_expected(self):
-        expected_value = 45.27
+        expected_value = 45.2
         self._set_simulated_value("phase_setpoint", expected_value)
 
         self.ca.assert_that_pv_is("PHAS:SP:RBV", expected_value)
@@ -169,13 +168,13 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("MB:STAT", expected_value)
             self.ca.assert_pv_alarm_is("MB:STAT", ChannelAccess.ALARM_NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
-    def test_GIVEN_magnetic_bearing_integrator_WHEN_read_all_status_THEN_value_is_as_expected(self):
-        expected_value = -27.4
-        self._set_simulated_value("magnetic_bearing_integrator", expected_value)
-
-        self.ca.assert_that_pv_is("MB:INT", expected_value)
-        self.ca.assert_pv_alarm_is("MB:INT", ChannelAccess.ALARM_NONE)
+    # @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
+    # def test_GIVEN_magnetic_bearing_integrator_WHEN_read_all_status_THEN_value_is_as_expected(self):
+    #     expected_value = -27.4
+    #     self._set_simulated_value("magnetic_bearing_integrator", expected_value)
+    #
+    #     self.ca.assert_that_pv_is("MB:INT", expected_value)
+    #     self.ca.assert_pv_alarm_is("MB:INT", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_magnetic_bearing_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -233,13 +232,13 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("DRIVE:DIR", expected_value)
             self.ca.assert_pv_alarm_is("DRIVE:DIR", ChannelAccess.ALARM_NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
-    def test_GIVEN_parked_open_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
-        for boolean_value, expected_value in OK_NOK.items():
-            self._set_simulated_value("parked_open_status_is_ok", boolean_value)
-
-            self.ca.assert_that_pv_is("PARKED:OPEN:STAT", expected_value)
-            self.ca.assert_pv_alarm_is("PARKED:OPEN:STAT", ChannelAccess.ALARM_NONE)
+    # @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
+    # def test_GIVEN_parked_open_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
+    #     for boolean_value, expected_value in OK_NOK.items():
+    #         self._set_simulated_value("parked_open_status_is_ok", boolean_value)
+    #
+    #         self.ca.assert_that_pv_is("PARKED:OPEN:STAT", expected_value)
+    #         self.ca.assert_pv_alarm_is("PARKED:OPEN:STAT", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_temperature_WHEN_read_all_status_THEN_value_is_as_expected(self):
@@ -249,13 +248,13 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is("DRIVE:TEMP", expected_value)
         self.ca.assert_pv_alarm_is("DRIVE:TEMP", ChannelAccess.ALARM_NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
-    def test_GIVEN_input_clock_WHEN_read_all_status_THEN_value_is_as_expected(self):
-        expected_value = 34.94
-        self._set_simulated_value("input_clock", expected_value)
-
-        self.ca.assert_that_pv_is("INPUTCLOCK", expected_value)
-        self.ca.assert_pv_alarm_is("INPUTCLOCK", ChannelAccess.ALARM_NONE)
+    # @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
+    # def test_GIVEN_input_clock_WHEN_read_all_status_THEN_value_is_as_expected(self):
+    #     expected_value = 34.94
+    #     self._set_simulated_value("input_clock", expected_value)
+    #
+    #     self.ca.assert_that_pv_is("INPUTCLOCK", expected_value)
+    #     self.ca.assert_pv_alarm_is("INPUTCLOCK", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_phase_outage_WHEN_read_all_status_THEN_value_is_as_expected(self):
@@ -265,13 +264,13 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is("PHAS:OUTAGE", expected_value)
         self.ca.assert_pv_alarm_is("PHAS:OUTAGE", ChannelAccess.ALARM_NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
-    def test_GIVEN_master_chopper_WHEN_read_all_status_THEN_value_is_as_expected(self):
-        expected_value = "C2B"
-        self._set_simulated_value("master_chopper", expected_value)
-
-        self.ca.assert_that_pv_is("MASTER", expected_value)
-        self.ca.assert_pv_alarm_is("MASTER", ChannelAccess.ALARM_NONE)
+    # @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
+    # def test_GIVEN_master_chopper_WHEN_read_all_status_THEN_value_is_as_expected(self):
+    #     expected_value = "C2B"
+    #     self._set_simulated_value("master_chopper", expected_value)
+    #
+    #     self.ca.assert_that_pv_is("MASTER", expected_value)
+    #     self.ca.assert_pv_alarm_is("MASTER", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_logging_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -281,13 +280,13 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("LOGGING", expected_value)
             self.ca.assert_pv_alarm_is("LOGGING", ChannelAccess.ALARM_NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
-    def test_GIVEN_lmsr_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
-        for boolean_value, expected_value in OK_NOK.items():
-            self._set_simulated_value("lmsr_status_is_ok", boolean_value)
-
-            self.ca.assert_that_pv_is("LMSR:STAT", expected_value)
-            self.ca.assert_pv_alarm_is("LMSR:STAT", ChannelAccess.ALARM_NONE)
+    # @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
+    # def test_GIVEN_lmsr_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
+    #     for boolean_value, expected_value in OK_NOK.items():
+    #         self._set_simulated_value("lmsr_status_is_ok", boolean_value)
+    #
+    #         self.ca.assert_that_pv_is("LMSR:STAT", expected_value)
+    #         self.ca.assert_pv_alarm_is("LMSR:STAT", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_dsp_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -453,7 +452,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
 
         self.ca.set_pv_value("DRIVE:MODE:SP", START_STOP[True])
 
-        phase = 65.72
+        phase = 65.7
         self.ca.set_pv_value("PHAS:SP", phase)
 
         self.ca.assert_that_pv_is_number("PHAS", phase, timeout=30)
@@ -464,7 +463,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
 
         self.ca.set_pv_value("DRIVE:MODE:SP", START_STOP[False])
 
-        phase = 65.72
+        phase = 65.7
         self.ca.set_pv_value("PHAS:SP", phase)
 
         self.ca.assert_that_pv_is_number("PHAS", 0, timeout=30)
@@ -473,7 +472,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
     @skip_if_recsim("Uses LeWIS to implement state machine.  Depends on current state.")
     def test_GIVEN_phase_setpoint_is_set_WHEN_drive_mode_is_start_THEN_phase_reaches_setpoint(self):
 
-        phase = 65.72
+        phase = 65.7
         self.ca.set_pv_value("PHAS:SP", phase)
 
         self.ca.set_pv_value("DRIVE:MODE:SP", START_STOP[True])
@@ -484,7 +483,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
     @skip_if_recsim("Uses LeWIS to implement state machine.  Depends on current state.")
     def test_GIVEN_phase_setpoint_is_set_WHEN_drive_mode_is_stop_THEN_phase_is_zero(self):
 
-        phase = 65.72
+        phase = 65.7
         self.ca.set_pv_value("PHAS:SP", phase)
 
         self.ca.set_pv_value("DRIVE:MODE:SP", START_STOP[False])
@@ -494,7 +493,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
 
     @skip_if_recsim("PHAS:SP:RBV pushed from protocol")
     def test_WHEN_phase_setpoint_is_set_THEN_readback_updates(self):
-        phase = 243.85
+        phase = 243.8
         self.ca.set_pv_value("PHAS:SP", phase)
 
         self.ca.assert_that_pv_is("PHAS:SP", phase)
@@ -504,7 +503,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
 
     @skip_if_recsim("Uses LeWIS backdoor command to set error")
     def test_GIVEN_error_WHEN_set_phase_THEN_error_is_handled(self):
-        phase = 243.85
+        phase = 243.8
         expected_error = "09;CxxNOK;SETPOINT_PHASE_OUT_OF_RANGE"
         self._lewis.backdoor_set_on_device("error_on_set_phase", expected_error)
         self.ca.set_pv_value("PHAS:SP", phase)
@@ -514,7 +513,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
 
     @skip_if_recsim("Uses LeWIS backdoor command to set error")
     def test_GIVEN_error_then_no_error_WHEN_set_phase_THEN_error_is_cleared(self):
-        phase = 243.85
+        phase = 243.8
         expected_error = "09;CxxNOK;SETPOINT_PHASE_OUT_OF_RANGE"
         self._lewis.backdoor_set_on_device("error_on_set_phase", expected_error)
         self.ca.set_pv_value("PHAS:SP", phase)
@@ -528,6 +527,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
 
     # Magnetic Bearing
 
+    @skip_if_recsim("Uses protocol file to push value to PV")
     def test_WHEN_magnetic_bearing_is_set_THEN_readback_updates(self):
         for magnetic_bearing in [ON_OFF[True], ON_OFF[False]]:
             self.ca.set_pv_value("MB:SP", magnetic_bearing)
@@ -563,6 +563,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
 
     # Drive
 
+    @skip_if_recsim("Uses protocol file to push value to PV")
     def test_WHEN_drive_mode_is_set_THEN_readback_updates(self):
         for drive_mode in [START_STOP[True], START_STOP[False]]:
             self.ca.set_pv_value("DRIVE:MODE:SP", drive_mode)
@@ -600,7 +601,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
     def test_GIVEN_device_is_not_communicating_WHEN_read_all_status_THEN_values_have_error(self):
         self._lewis.backdoor_set_on_device("disconnected", True)
 
-        for pv in ["FREQ:REF",
+        for pv in [# "FREQ:REF",
                    "FREQ:SP:RBV",
                    "FREQ",
                    "PHAS:SP:RBV",
@@ -608,20 +609,20 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
                    "PHAS:STAT",
                    "MB",
                    "MB:STAT",
-                   "MB:INT",
+                   # "MB:INT",
                    "DRIVE",
                    "DRIVE:MODE",
                    "DRIVE:L1:CURR",
                    "DRIVE:L2:CURR",
                    "DRIVE:L3:CURR",
                    "DRIVE:DIR",
-                   "PARKED:OPEN:STAT",
+                   # "PARKED:OPEN:STAT",
                    "DRIVE:TEMP",
-                   "INPUTCLOCK",
+                   # "INPUTCLOCK",
                    "PHAS:OUTAGE",
-                   "MASTER",
+                   # "MASTER",
                    "LOGGING",
-                   "LMSR:STAT",
+                   # "LMSR:STAT",
                    "DSP:STAT",
                    "INTERLOCK:ER:STAT",
                    "INTERLOCK:VAC:STAT",


### PR DESCRIPTION
### Description of work

Modifications to the tests for the FZJ DD Fermi Chopper due to changes to the IOC undertaken during initial hasty commissioning.

### To test

Full details in https://github.com/ISISComputingGroup/IBEX/issues/2856

### Acceptance criteria

Successful tests for the above device.
