### PR TITLE
Ticket3214 ioc tpg300

### DIFF
--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -35,9 +35,11 @@ class Tpg300Tests(unittest.TestCase):
 
         self.ca = ChannelAccess(20, device_prefix=DEVICE_PREFIX)
 
-    def _set_pressure(self, expected_pressure, letter, channel):
-        pv = "SIM:PRESSURE"
-        prop = "pressure_{}{}".format(letter, channel)
+        self.channel_names = ("A1", "A2", "B1", "B2")
+
+    def _set_pressure(self, expected_pressure, channel):
+        prop = "pressure_" + channel.lower()
+        pv = "SIM:" + prop.upper()
         self._lewis.backdoor_set_on_device(prop, expected_pressure)
         self._ioc.set_simulated_value(pv, expected_pressure)
 
@@ -55,31 +57,50 @@ class Tpg300Tests(unittest.TestCase):
 
     def test_GIVEN_floating_point_pressure_value_WHEN_pressure_a1_is_read_THEN_pressure_a1_value_is_same_as_backdoor(self):
         expected_pressure = 1.23
-        self._set_pressure(expected_pressure, "a", 1)
 
-        self.ca.assert_that_pv_is("PRESSURE_A1", expected_pressure)
+        for channel in self.channel_names:
+            pv = "PRESSURE_" + channel.upper()
+
+            self._set_pressure(expected_pressure, channel)
+
+            self.ca.assert_that_pv_is(pv, expected_pressure)
 
     def test_GIVEN_negative_floating_point_pressure_value_WHEN_pressure_a1_is_read_THEN_pressure_a1_value_is_same_as_backdoor(self):
         expected_pressure = -10.23
-        self._set_pressure(expected_pressure, "a", 1)
 
-        self.ca.assert_that_pv_is("PRESSURE_A1", expected_pressure)
+        for channel in self.channel_names:
+            pv = "PRESSURE_" + channel.upper()
+
+            self._set_pressure(expected_pressure, channel)
+
+            self.ca.assert_that_pv_is(pv, expected_pressure)
 
     def test_GIVEN_integer_pressure_WHEN_pressure_a1_is_read_THEN_pressure_A1_value_is_same_as_backdoor(self):
         expected_pressure = 8
-        self._set_pressure(expected_pressure, "a", 1)
 
-        self.ca.assert_that_pv_is("PRESSURE_A1", expected_pressure)
+        for channel in self.channel_names:
+            pv = "PRESSURE_" + channel.upper()
+
+            self._set_pressure(expected_pressure, channel)
+
+            self.ca.assert_that_pv_is(pv, expected_pressure)
 
     def test_GIVEN_pressure_in_negative_exponential_form_WHEN_pressure_a1_is_read_THEN_pressure_A1_value_is_same_as_backdoor(self):
         expected_pressure = 1e-6
-        self._set_pressure(expected_pressure, "a", 1)
 
-        self.ca.assert_that_pv_is("PRESSURE_A1", expected_pressure)
+        for channel in self.channel_names:
+            pv = "PRESSURE_" + channel.upper()
+
+            self._set_pressure(expected_pressure, channel)
+
+            self.ca.assert_that_pv_is(pv, expected_pressure)
 
     def test_GIVEN_pressure_in_positive_exponential_form_WHEN_pressure_a1_is_read_THEN_pressure_A1_value_is_same_as_backdoor(self):
         expected_pressure = 1e+6
-        self._set_pressure(expected_pressure, "a", 1)
 
-        self.ca.assert_that_pv_is("PRESSURE_A1", expected_pressure)
+        for channel in self.channel_names:
+            pv = "PRESSURE_" + channel.upper()
+            self._set_pressure(expected_pressure, channel)
+
+            self.ca.assert_that_pv_is(pv, expected_pressure)
 

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -56,10 +56,10 @@ class Tpg300Tests(unittest.TestCase):
         self._ioc.set_simulated_value("SIM:UNITS", unit.name)
 
     def _connect_emulator(self):
-        self._lewis.backdoor_set_on_device("connected", True)
+        self._lewis.backdoor_run_function_on_device("connect")
 
     def _disconnect_emulator(self):
-        self._lewis.backdoor_set_on_device("connected", False)
+        self._lewis.backdoor_run_function_on_device("disconnect")
 
     def test_that_WHEN_ioc_started_THEN_ioc_is_not_disabled(self):
         self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -61,24 +61,24 @@ class Tpg300Tests(unittest.TestCase):
     def _disconnect_emulator(self):
         self._lewis.backdoor_run_function_on_device("disconnect")
 
-    def test_that_WHEN_ioc_started_THEN_ioc_is_not_disabled(self):
+    def test_that_GIVEN_a_connected_emulator_WHEN_ioc_started_THEN_ioc_is_not_disabled(self):
         self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")
 
-    def test_that_WHEN_units_are_set_THEN_unit_is_the_same_as_backdoor(self):
+    def test_that_GIVEN_a_connected_emulator_WHEN_units_are_set_THEN_unit_is_the_same_as_backdoor(self):
         for unit in Units:
             self._set_units(unit)
 
             expected_unit = unit.name
             self.ca.assert_that_pv_is("UNITS", expected_unit)
 
-    def test_that_GIVEN_pressure_value_WHEN_set_via_backdoor_THEN_updates_in_ioc(self):
+    def test_that_GIVEN_a_connected_emulator_and_pressure_value_WHEN_set_pressure_is_set_THEN_the_ioc_is_updated(self):
         for expected_pressure, channel in product(TEST_PRESSURES, CHANNELS):
             pv = "PRESSURE_{}".format(channel)
             self._set_pressure(expected_pressure, channel)
             self.ca.assert_that_pv_is(pv, expected_pressure)
 
     @skip_if_recsim("Recsim is unable to simulate a disconnected device")
-    def test_GIVEN_asked_for_units_WHEN_emulator_is_disconnected_THEN_ca_alarm_shows_disconnected(self):
+    def test_that_GIVEN_a_disconnected_emulator_WHEN_getting_pressure_THEN_INVALID_alarm_shows(self):
         self._disconnect_emulator()
 
         for channel in CHANNELS:

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -41,10 +41,14 @@ class Tpg300Tests(unittest.TestCase):
         self._lewis.backdoor_set_on_device(prop, expected_pressure)
         self._ioc.set_simulated_value(pv, expected_pressure)
 
+    def _set_units(self, unit):
+        self._lewis.backdoor_set_on_device("units", unit)
+        self._ioc.set_simulated_value("SIM:UNITS", unit)
+
     def test_WHEN_ioc_started_THEN_ioc_is_not_disabled(self):
         self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")
 
-    def test_WHEN_units_are_set_THEN_unit_readback_is_the_value_that_was_just_set(self):
+    def test_WHEN_units_are_set_THEN_unit_is_the_same_as_backdoor(self):
         for unit in UNITS:
             self._set_units(unit)
             self.ca.assert_that_pv_is("UNITS", unit)

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -38,7 +38,7 @@ class Tpg300Tests(unittest.TestCase):
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("tpg300", DEVICE_PREFIX)
         self.ca = ChannelAccess(20, device_prefix=DEVICE_PREFIX)
-        self._reset_values()
+        self._reset_emulators_values()
 
     def _reset_emulators_values(self):
         self._lewis.backdoor_set_on_device("pressure_a1", 1.0)

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -46,7 +46,7 @@ class Tpg300Tests(unittest.TestCase):
 
     def test_WHEN_units_are_set_THEN_unit_readback_is_the_value_that_was_just_set(self):
         for unit in UNITS:
-            self.ca.set_pv_value("UNITS:SP", unit)
+            self._set_units(unit)
             self.ca.assert_that_pv_is("UNITS", unit)
 
     def test_GIVEN_floating_point_pressure_value_WHEN_pressure_a1_is_read_THEN_pressure_a1_value_is_same_as_backdoor(self):
@@ -66,3 +66,16 @@ class Tpg300Tests(unittest.TestCase):
         self._set_pressure(expected_pressure, "a", 1)
 
         self.ca.assert_that_pv_is("PRESSURE_A1", expected_pressure)
+
+    def test_GIVEN_pressure_in_negative_exponential_form_WHEN_pressure_a1_is_read_THEN_pressure_A1_value_is_same_as_backdoor(self):
+        expected_pressure = 1e-6
+        self._set_pressure(expected_pressure, "a", 1)
+
+        self.ca.assert_that_pv_is("PRESSURE_A1", expected_pressure)
+
+    def test_GIVEN_pressure_in_positive_exponential_form_WHEN_pressure_a1_is_read_THEN_pressure_A1_value_is_same_as_backdoor(self):
+        expected_pressure = 1e+6
+        self._set_pressure(expected_pressure, "a", 1)
+
+        self.ca.assert_that_pv_is("PRESSURE_A1", expected_pressure)
+

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -50,6 +50,9 @@ class Tpg300Tests(unittest.TestCase):
         self._lewis.backdoor_set_on_device("units", unit)
         self._ioc.set_simulated_value("SIM:UNITS", UNITS[unit])
 
+    def _set_connected(self, connected):
+        self._lewis.backdoor_set_on_device("connected", connected)
+
     def test_WHEN_ioc_started_THEN_ioc_is_not_disabled(self):
         self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")
 
@@ -58,6 +61,7 @@ class Tpg300Tests(unittest.TestCase):
             expected_unit = unit_string
             self._set_units(unit_flag)
             self.ca.assert_that_pv_is("UNITS", expected_unit)
+
 
     def test_GIVEN_floating_point_pressure_value_WHEN_pressure_is_read_THEN_pressure_value_is_same_as_backdoor(self):
         expected_pressure = 1.23
@@ -109,3 +113,8 @@ class Tpg300Tests(unittest.TestCase):
 
             self.ca.assert_that_pv_is(pv, expected_pressure)
 
+    @skip_if_recsim("This test fails in recsim")
+    def test_GIVEN_asked_for_units_WHEN_emulator_is_disconnected_THEN_ca_alarm_shows_disconnected(self):
+        self._set_connected(False)
+        self.ca.assert_pv_alarm_is('PRESSURE_A1', ChannelAccess.ALARM_INVALID)
+        self._set_connected(True)

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -49,8 +49,20 @@ class Tpg300Tests(unittest.TestCase):
             self.ca.set_pv_value("UNITS:SP", unit)
             self.ca.assert_that_pv_is("UNITS", unit)
 
-    def test_WHEN_read_pressure_A1_THEN_pressure_A1_value_is_same_as_backdoor(self):
+    def test_GIVEN_floating_point_pressure_value_WHEN_pressure_a1_is_read_THEN_pressure_a1_value_is_same_as_backdoor(self):
         expected_pressure = 1.23
+        self._set_pressure(expected_pressure, "a", 1)
+
+        self.ca.assert_that_pv_is("PRESSURE_A1", expected_pressure)
+
+    def test_GIVEN_negative_floating_point_pressure_value_WHEN_pressure_a1_is_read_THEN_pressure_a1_value_is_same_as_backdoor(self):
+        expected_pressure = -10.23
+        self._set_pressure(expected_pressure, "a", 1)
+
+        self.ca.assert_that_pv_is("PRESSURE_A1", expected_pressure)
+
+    def test_GIVEN_integer_pressure_WHEN_pressure_a1_is_read_THEN_pressure_A1_value_is_same_as_backdoor(self):
+        expected_pressure = 8
         self._set_pressure(expected_pressure, "a", 1)
 
         self.ca.assert_that_pv_is("PRESSURE_A1", expected_pressure)

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -5,7 +5,7 @@ from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
 from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
 from enum import Enum
-
+from itertools import product
 
 DEVICE_PREFIX = "TPG300_01"
 
@@ -28,7 +28,9 @@ class Units(Enum):
     Torr = 2
     Pa = 3
 
-CHANNELS = ("A1", "A2", "B1", "B2")
+
+CHANNELS = "A1", "A2", "B1", "B2"
+TEST_PRESSURES = 1.23, -10.23, 8, 1e-6, 1e+6
 
 
 class Tpg300Tests(unittest.TestCase):
@@ -70,54 +72,10 @@ class Tpg300Tests(unittest.TestCase):
             self._set_units(unit)
             self.ca.assert_that_pv_is("UNITS", expected_unit)
 
-    def test_GIVEN_floating_point_pressure_value_WHEN_pressure_is_read_THEN_pressure_value_is_same_as_backdoor(self):
-        expected_pressure = 1.23
-
-        for channel in CHANNELS:
-            pv = "PRESSURE_{}".format(channel.upper())
-
+    def test_that_GIVEN_pressure_value_WHEN_set_via_backdoor_THEN_updates_in_ioc(self):
+        for expected_pressure, channel in product(TEST_PRESSURES, CHANNELS):
+            pv = "PRESSURE_{}".format(channel)
             self._set_pressure(expected_pressure, channel)
-
-            self.ca.assert_that_pv_is(pv, expected_pressure)
-
-    def test_GIVEN_negative_floating_point_pressure_value_WHEN_pressure_is_read_THEN_pressure_value_is_same_as_backdoor(self):
-        expected_pressure = -10.23
-
-        for channel in CHANNELS:
-            pv = "PRESSURE_{}".format(channel.upper())
-
-            self._set_pressure(expected_pressure, channel)
-
-            self.ca.assert_that_pv_is(pv, expected_pressure)
-
-    def test_GIVEN_integer_pressure_value_WHEN_pressure_is_read_THEN_pressure_value_is_same_as_backdoor(self):
-        expected_pressure = 8
-
-        for channel in CHANNELS:
-            pv = "PRESSURE_{}".format(channel.upper())
-
-            self._set_pressure(expected_pressure, channel)
-
-            self.ca.assert_that_pv_is(pv, expected_pressure)
-
-    def test_GIVEN_pressure_in_negative_exponential_form_WHEN_pressure_is_read_THEN_pressure_value_is_same_as_backdoor(self):
-        expected_pressure = 1e-6
-
-        for channel in CHANNELS:
-            pv = "PRESSURE_{}".format(channel.upper())
-
-            self._set_pressure(expected_pressure, channel)
-
-            self.ca.assert_that_pv_is(pv, expected_pressure)
-
-    def test_GIVEN_pressure_in_positive_exponential_form_WHEN_pressure_is_read_THEN_pressure_value_is_same_as_backdoor(self):
-        expected_pressure = 1e+6
-
-        for channel in CHANNELS:
-            pv = "PRESSURE_{}".format(channel.upper())
-
-            self._set_pressure(expected_pressure, channel)
-
             self.ca.assert_that_pv_is(pv, expected_pressure)
 
     @skip_if_recsim("Recsim is unable to simulate a disconnected device")

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -37,9 +37,14 @@ class Tpg300Tests(unittest.TestCase):
 
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("tpg300", DEVICE_PREFIX)
-
         self.ca = ChannelAccess(20, device_prefix=DEVICE_PREFIX)
+        self._reset_values()
 
+    def _reset_values(self):
+        self._lewis.backdoor_set_on_device("pressure_a1", 1.0)
+        self._lewis.backdoor_set_on_device("pressure_a2", 2.0)
+        self._lewis.backdoor_set_on_device("pressure_b1", 3.0)
+        self._lewis.backdoor_set_on_device("pressure_b2", 4.0)
         self._set_connected(True)
 
     def _set_pressure(self, expected_pressure, channel):
@@ -63,7 +68,6 @@ class Tpg300Tests(unittest.TestCase):
             expected_unit = unit_string
             self._set_units(unit_flag)
             self.ca.assert_that_pv_is("UNITS", expected_unit)
-
 
     def test_GIVEN_floating_point_pressure_value_WHEN_pressure_is_read_THEN_pressure_value_is_same_as_backdoor(self):
         expected_pressure = 1.23

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -59,7 +59,7 @@ class Tpg300Tests(unittest.TestCase):
             self._set_units(unit_flag)
             self.ca.assert_that_pv_is("UNITS", expected_unit)
 
-    def test_GIVEN_floating_point_pressure_value_WHEN_pressure_a1_is_read_THEN_pressure_a1_value_is_same_as_backdoor(self):
+    def test_GIVEN_floating_point_pressure_value_WHEN_pressure_is_read_THEN_pressure_value_is_same_as_backdoor(self):
         expected_pressure = 1.23
 
         for channel in self.channel_names:
@@ -69,7 +69,7 @@ class Tpg300Tests(unittest.TestCase):
 
             self.ca.assert_that_pv_is(pv, expected_pressure)
 
-    def test_GIVEN_negative_floating_point_pressure_value_WHEN_pressure_a1_is_read_THEN_pressure_a1_value_is_same_as_backdoor(self):
+    def test_GIVEN_negative_floating_point_pressure_value_WHEN_pressure_is_read_THEN_pressure_value_is_same_as_backdoor(self):
         expected_pressure = -10.23
 
         for channel in self.channel_names:
@@ -79,7 +79,7 @@ class Tpg300Tests(unittest.TestCase):
 
             self.ca.assert_that_pv_is(pv, expected_pressure)
 
-    def test_GIVEN_integer_pressure_WHEN_pressure_a1_is_read_THEN_pressure_A1_value_is_same_as_backdoor(self):
+    def test_GIVEN_integer_pressure_value_WHEN_pressure_is_read_THEN_pressure_value_is_same_as_backdoor(self):
         expected_pressure = 8
 
         for channel in self.channel_names:
@@ -89,7 +89,7 @@ class Tpg300Tests(unittest.TestCase):
 
             self.ca.assert_that_pv_is(pv, expected_pressure)
 
-    def test_GIVEN_pressure_in_negative_exponential_form_WHEN_pressure_a1_is_read_THEN_pressure_A1_value_is_same_as_backdoor(self):
+    def test_GIVEN_pressure_in_negative_exponential_form_WHEN_pressure_is_read_THEN_pressure_value_is_same_as_backdoor(self):
         expected_pressure = 1e-6
 
         for channel in self.channel_names:
@@ -99,7 +99,7 @@ class Tpg300Tests(unittest.TestCase):
 
             self.ca.assert_that_pv_is(pv, expected_pressure)
 
-    def test_GIVEN_pressure_in_positive_exponential_form_WHEN_pressure_a1_is_read_THEN_pressure_A1_value_is_same_as_backdoor(self):
+    def test_GIVEN_pressure_in_positive_exponential_form_WHEN_pressure_is_read_THEN_pressure_value_is_same_as_backdoor(self):
         expected_pressure = 1e+6
 
         for channel in self.channel_names:

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -60,8 +60,11 @@ class Tpg300Tests(unittest.TestCase):
         self._lewis.backdoor_set_on_device("units", unit.value)
         self._ioc.set_simulated_value("SIM:UNITS", unit.name)
 
-    def _set_connected(self, connected):
-        self._lewis.backdoor_set_on_device("connected", connected)
+    def _connect_emulator(self):
+        self._lewis.backdoor_set_on_device("connected", True)
+
+    def _disconnect_emulator(self):
+        self._lewis.backdoor_set_on_device("connected", False)
 
     def test_WHEN_ioc_started_THEN_ioc_is_not_disabled(self):
         self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")
@@ -80,7 +83,7 @@ class Tpg300Tests(unittest.TestCase):
 
     @skip_if_recsim("Recsim is unable to simulate a disconnected device")
     def test_GIVEN_asked_for_units_WHEN_emulator_is_disconnected_THEN_ca_alarm_shows_disconnected(self):
-        self._set_connected(False)
+        self._disconnect_emulator()
 
         for channel in CHANNELS:
             pv = "PRESSURE_{}".format(channel.upper())

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -43,3 +43,7 @@ class Tpg300Tests(unittest.TestCase):
         for unit in UNITS:
             self.ca.set_pv_value("UNITS:SP", unit)
             self.ca.assert_that_pv_is("UNITS", unit)
+
+    def test_WHEN_read_pressure_A1_THEN_pressure_A1_value_is_same_as_backdoor(self):
+        expected_pressure = 10.0
+        self.ca.assert_that_pv_is(PA1_PV, expected_pressure)

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -1,16 +1,12 @@
 import unittest
 
 from utils.channel_access import ChannelAccess
-from utils.ioc_launcher import get_default_ioc_dir, IOCRegister
+from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
 from utils.testing import get_running_lewis_and_ioc
 
 
 DEVICE_PREFIX = "TPG300_01"
-
-#PV names
-PA1 = "PRESSURE_A1"
-
 
 IOCS = [
     {
@@ -55,5 +51,6 @@ class Tpg300Tests(unittest.TestCase):
 
     def test_WHEN_read_pressure_A1_THEN_pressure_A1_value_is_same_as_backdoor(self):
         expected_pressure = 1.23
-        self._set_pressure(1.23, "a", 1)
+        self._set_pressure(expected_pressure, "a", 1)
+
         self.ca.assert_that_pv_is("PRESSURE_A1", expected_pressure)

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -3,7 +3,7 @@ import unittest
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
-from utils.testing import get_running_lewis_and_ioc
+from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
 
 
 DEVICE_PREFIX = "TPG300_01"
@@ -39,6 +39,8 @@ class Tpg300Tests(unittest.TestCase):
         self.ca = ChannelAccess(20, device_prefix=DEVICE_PREFIX)
 
         self.channel_names = ("A1", "A2", "B1", "B2")
+
+        self._set_connected(True)
 
     def _set_pressure(self, expected_pressure, channel):
         prop = "pressure_" + channel.lower()
@@ -117,4 +119,3 @@ class Tpg300Tests(unittest.TestCase):
     def test_GIVEN_asked_for_units_WHEN_emulator_is_disconnected_THEN_ca_alarm_shows_disconnected(self):
         self._set_connected(False)
         self.ca.assert_pv_alarm_is('PRESSURE_A1', ChannelAccess.ALARM_INVALID)
-        self._set_connected(True)

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -40,7 +40,7 @@ class Tpg300Tests(unittest.TestCase):
         self.ca = ChannelAccess(20, device_prefix=DEVICE_PREFIX)
         self._reset_values()
 
-    def _reset_values(self):
+    def _reset_emulators_values(self):
         self._lewis.backdoor_set_on_device("pressure_a1", 1.0)
         self._lewis.backdoor_set_on_device("pressure_a2", 2.0)
         self._lewis.backdoor_set_on_device("pressure_b1", 3.0)

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -82,6 +82,6 @@ class Tpg300Tests(unittest.TestCase):
         self._disconnect_emulator()
 
         for channel in CHANNELS:
-            pv = "PRESSURE_{}".format(channel.upper())
+            pv = "PRESSURE_{}".format(channel)
             self.ca.assert_pv_alarm_is(pv, ChannelAccess.ALARM_INVALID)
 

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -41,14 +41,9 @@ class Tpg300Tests(unittest.TestCase):
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("tpg300", DEVICE_PREFIX)
         self.ca = ChannelAccess(20, device_prefix=DEVICE_PREFIX)
-        self._reset_emulators_values()
 
-    def _reset_emulators_values(self):
-        self._lewis.backdoor_set_on_device("pressure_a1", 1.0)
-        self._lewis.backdoor_set_on_device("pressure_a2", 2.0)
-        self._lewis.backdoor_set_on_device("pressure_b1", 3.0)
-        self._lewis.backdoor_set_on_device("pressure_b2", 4.0)
-        self._set_connected(True)
+    def tearDown(self):
+        self._connect_emulator()
 
     def _set_pressure(self, expected_pressure, channel):
         prop = "pressure_{}".format(channel.lower())

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -119,7 +119,7 @@ class Tpg300Tests(unittest.TestCase):
 
             self.ca.assert_that_pv_is(pv, expected_pressure)
 
-    @skip_if_recsim("This test fails in recsim")
+    @skip_if_recsim("Recsim is unable to simulate a disconnected device")
     def test_GIVEN_asked_for_units_WHEN_emulator_is_disconnected_THEN_ca_alarm_shows_disconnected(self):
         self._set_connected(False)
 

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -122,5 +122,8 @@ class Tpg300Tests(unittest.TestCase):
     @skip_if_recsim("This test fails in recsim")
     def test_GIVEN_asked_for_units_WHEN_emulator_is_disconnected_THEN_ca_alarm_shows_disconnected(self):
         self._set_connected(False)
-        self.ca.assert_pv_alarm_is('PRESSURE_A1', ChannelAccess.ALARM_INVALID)
+
+        for channel in CHANNELS:
+            pv = "PRESSURE_{}".format(channel.upper())
+            self.ca.assert_pv_alarm_is(pv, ChannelAccess.ALARM_INVALID)
 

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -42,7 +42,7 @@ class Tpg300Tests(unittest.TestCase):
 
     def _set_pressure(self, expected_pressure, channel):
         prop = "pressure_" + channel.lower()
-        pv = "SIM:" + prop.upper()
+        pv = "SIM:PRESSURE"
         self._lewis.backdoor_set_on_device(prop, expected_pressure)
         self._ioc.set_simulated_value(pv, expected_pressure)
 
@@ -104,6 +104,7 @@ class Tpg300Tests(unittest.TestCase):
 
         for channel in self.channel_names:
             pv = "PRESSURE_" + channel.upper()
+
             self._set_pressure(expected_pressure, channel)
 
             self.ca.assert_that_pv_is(pv, expected_pressure)

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -54,6 +54,6 @@ class Tpg300Tests(unittest.TestCase):
             self.ca.assert_that_pv_is("UNITS", unit)
 
     def test_WHEN_read_pressure_A1_THEN_pressure_A1_value_is_same_as_backdoor(self):
-        expected_pressure = 1.12
+        expected_pressure = 1.23
         self._set_pressure(1.23, "a", 1)
         self.ca.assert_that_pv_is("PRESSURE_A1", expected_pressure)

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -20,7 +20,7 @@ IOCS = [
 ]
 
 
-TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
+TEST_MODES = [TestModes.DEVSIM, TestModes.RECSIM]
 
 
 class Units(Enum):
@@ -52,7 +52,7 @@ class Tpg300Tests(unittest.TestCase):
         self._ioc.set_simulated_value(pv, expected_pressure)
 
     def _set_units(self, unit):
-        self._lewis.backdoor_set_on_device("units", unit.value)
+        self._lewis.backdoor_run_function_on_device("backdoor_set_unit", [unit.value])
         self._ioc.set_simulated_value("SIM:UNITS", unit.name)
 
     def _connect_emulator(self):
@@ -61,13 +61,14 @@ class Tpg300Tests(unittest.TestCase):
     def _disconnect_emulator(self):
         self._lewis.backdoor_set_on_device("connected", False)
 
-    def test_WHEN_ioc_started_THEN_ioc_is_not_disabled(self):
+    def test_that_WHEN_ioc_started_THEN_ioc_is_not_disabled(self):
         self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")
 
-    def test_WHEN_units_are_set_THEN_unit_is_the_same_as_backdoor(self):
+    def test_that_WHEN_units_are_set_THEN_unit_is_the_same_as_backdoor(self):
         for unit in Units:
-            expected_unit = unit.name
             self._set_units(unit)
+
+            expected_unit = unit.name
             self.ca.assert_that_pv_is("UNITS", expected_unit)
 
     def test_that_GIVEN_pressure_value_WHEN_set_via_backdoor_THEN_updates_in_ioc(self):

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -4,6 +4,7 @@ from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
 from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
+from enum import Enum
 
 
 DEVICE_PREFIX = "TPG300_01"
@@ -21,11 +22,11 @@ IOCS = [
 
 TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
 
-UNITS = {
-    1: "mbar",
-    2: "Torr",
-    3: "Pa"
-}
+
+class Units(Enum):
+    mbar = 1
+    Torr = 2
+    Pa = 3
 
 CHANNELS = ("A1", "A2", "B1", "B2")
 
@@ -54,8 +55,8 @@ class Tpg300Tests(unittest.TestCase):
         self._ioc.set_simulated_value(pv, expected_pressure)
 
     def _set_units(self, unit):
-        self._lewis.backdoor_set_on_device("units", unit)
-        self._ioc.set_simulated_value("SIM:UNITS", UNITS[unit])
+        self._lewis.backdoor_set_on_device("units", unit.value)
+        self._ioc.set_simulated_value("SIM:UNITS", unit.name)
 
     def _set_connected(self, connected):
         self._lewis.backdoor_set_on_device("connected", connected)
@@ -64,9 +65,9 @@ class Tpg300Tests(unittest.TestCase):
         self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")
 
     def test_WHEN_units_are_set_THEN_unit_is_the_same_as_backdoor(self):
-        for unit_flag, unit_string in UNITS.items():
-            expected_unit = unit_string
-            self._set_units(unit_flag)
+        for unit in Units:
+            expected_unit = unit.name
+            self._set_units(unit)
             self.ca.assert_that_pv_is("UNITS", expected_unit)
 
     def test_GIVEN_floating_point_pressure_value_WHEN_pressure_is_read_THEN_pressure_value_is_same_as_backdoor(self):

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -26,7 +26,7 @@ IOCS = [
 TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
 
 
-UNITS = ["mbar", "Torr"]
+UNITS = ["mbar", "Torr", "Pa"]
 
 
 class Tpg300Tests(unittest.TestCase):


### PR DESCRIPTION
### Issue

[#3214](https://github.com/ISISComputingGroup/IBEX/issues/3214).

### Description of Work Done

Adds tests for an emulator of TPG300 using DEVSIM and using the SIM record files using RECSIM.

### Tests

- IOC is not disabled on start
- The correct units are set on PV using SIM and emulator. 
- Postive floats are set correctly.
- Negative floats are set correctly.
- Integers are set correctly.
- Exponential values are set correctly.
- Alarm flags when the emulator is disconnected.
