### PR TITLE
Ticket3223 ioc lakeshore 218

### DIFF
--- a/tests/keithley_2700.py
+++ b/tests/keithley_2700.py
@@ -83,7 +83,7 @@ class Keithley_2700Tests(unittest.TestCase):
         self._lewis.backdoor_set_on_device("buffer_range_readings", 10)
         self.ca.set_pv_value("CH:START", 2)
         self.ca.set_pv_value("COUNT", 4)
-        self.ca.set_pv_value("BUFF:READ.PROC", 1)
+        self.ca.process_pv("BUFF:READ")
         expected_string = self.ca.get_pv_value("BUFF:READ")
         self.assertNotEquals(expected_string, "[]")
 

--- a/tests/kepco.py
+++ b/tests/kepco.py
@@ -109,5 +109,5 @@ class KepcoTests(unittest.TestCase):
         expected_idn = "000000000000000000111111111111111111111"
         self._set_IDN(expected_idn)
         # Made Proc field force scan as IDN scan is passive
-        self.ca.set_pv_value("IDN.PROC", 1)
+        self.ca.process_pv("IDN")
         self.ca.assert_that_pv_is("IDN", expected_idn)

--- a/tests/lksh218.py
+++ b/tests/lksh218.py
@@ -36,13 +36,26 @@ class Lksh218Tests(unittest.TestCase):
         self._lewis.backdoor_run_function_on_device("set_temp", [number, temperature])
         self._ioc.set_simulated_value(pv, temperature)
 
+    def _set_sensor(self, number, value):
+        pv = "SIM:SENSOR{}".format(number)
+        self._lewis.backdoor_run_function_on_device("set_sensor", [number, value])
+        self._ioc.set_simulated_value(pv, value)
+
     def test_WHEN_ioc_started_THEN_ioc_is_not_disabled(self):
         self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")
 
-    def test_that_GIVEN_temp_float_WHEN_read_THEN_temp_is_as_expected(self):
+    def test_that_GIVEN_temp_float_WHEN_temp_pvs_are_read_THEN_temp_is_as_expected(self):
         expected_value = 10.586
 
         for index in range(1, 9):
             pv = "TEMP{}".format(index)
             self._set_temperature(index, expected_value)
+            self.ca.assert_that_pv_is(pv, expected_value)
+
+    def test_that_GIVEN_sensor_float_WHEN_sensor_pvs_are_read_THEN_sensor_is_as_expected(self):
+        expected_value = 11.386
+
+        for index in range(1, 9):
+            pv = "SENSOR{}".format(index)
+            self._set_sensor(index, expected_value)
             self.ca.assert_that_pv_is(pv, expected_value)

--- a/tests/lksh218.py
+++ b/tests/lksh218.py
@@ -59,3 +59,10 @@ class Lksh218Tests(unittest.TestCase):
             pv = "SENSOR{}".format(index)
             self._set_sensor(index, expected_value)
             self.ca.assert_that_pv_is(pv, expected_value)
+
+    def test_that_WHEN_reading_all_temps_pvs_THEN_all_temp_pvs_are_as_expected(self):
+        expected_value = 10.4869
+        self._lewis.backdoor_run_function_on_device("set_temp_all", [expected_value])
+        self._ioc.set_simulated_value("TEMPALL", expected_value)
+
+        self.ca.assert_that_pv_is("TEMPALL", str(expected_value))

--- a/tests/lksh218.py
+++ b/tests/lksh218.py
@@ -4,7 +4,6 @@ from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
 from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
-from lewis.core.logging import has_log
 
 
 DEVICE_PREFIX = "LKSH218_01"
@@ -22,7 +21,6 @@ IOCS = [
 TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
 
 
-@has_log
 class Lksh218Tests(unittest.TestCase):
     """
     Tests for the Lksh218 IOC.
@@ -81,7 +79,7 @@ class Lksh218Tests(unittest.TestCase):
         self.ca.assert_that_pv_is("SENSORALL", expected_string)
 
     @skip_if_recsim("In rec sim this test fails.")
-    def test_that_WHEN_the_emulator_is_disconnected_THEN_an_alarm_is_raised_on_TEMP1_and_SENSOR1(self):
+    def test_that_WHEN_the_emulator_is_disconnected_THEN_an_alarm_is_raised_on_TEMP_and_SENSOR(self):
         self._lewis.backdoor_set_on_device("connected", False)
 
         for i in range(1, 9):

--- a/tests/lksh218.py
+++ b/tests/lksh218.py
@@ -68,4 +68,10 @@ class Lksh218Tests(unittest.TestCase):
         self.ca.process_pv("TEMPALL")
         self.ca.assert_that_pv_is("TEMPALL", expected_string)
 
+    def test_that_WHEN_reading_sensor_all_pv_THEN_sensor_all_pv_returns_as_expected(self):
+        expected_string = "12.129"
+        self._lewis.backdoor_set_on_device("sensor_all", expected_string)
+        self._ioc.set_simulated_value("SIM:SENSORALL", expected_string)
 
+        self.ca.process_pv("SENSORALL")
+        self.ca.assert_that_pv_is("SENSORALL", expected_string)

--- a/tests/lksh218.py
+++ b/tests/lksh218.py
@@ -60,9 +60,12 @@ class Lksh218Tests(unittest.TestCase):
             self._set_sensor(index, expected_value)
             self.ca.assert_that_pv_is(pv, expected_value)
 
-    def test_that_WHEN_reading_all_temps_pvs_THEN_all_temp_pvs_are_as_expected(self):
-        expected_value = 10.4869
-        self._lewis.backdoor_run_function_on_device("set_temp_all", [expected_value])
-        self._ioc.set_simulated_value("TEMPALL", expected_value)
+    def test_that_WHEN_reading_all_temps_pv_THEN_all_temp_pv_are_as_expected(self):
+        expected_string = "10.4869"
+        self._lewis.backdoor_set_on_device("temp_all", expected_string)
+        self._ioc.set_simulated_value("SIM:TEMPALL", expected_string)
 
-        self.ca.assert_that_pv_is("TEMPALL", str(expected_value))
+        self.ca.process_pv("TEMPALL")
+        self.ca.assert_that_pv_is("TEMPALL", expected_string)
+
+

--- a/tests/lksh218.py
+++ b/tests/lksh218.py
@@ -78,7 +78,7 @@ class Lksh218Tests(unittest.TestCase):
         self.ca.process_pv("SENSORALL")
         self.ca.assert_that_pv_is("SENSORALL", expected_string)
 
-    @skip_if_recsim("In rec sim this test fails.")
+    @skip_if_recsim("Recsim is unable to simulate a disconnected device.")
     def test_that_WHEN_the_emulator_is_disconnected_THEN_an_alarm_is_raised_on_TEMP_and_SENSOR(self):
         self._lewis.backdoor_set_on_device("connected", False)
 
@@ -86,14 +86,14 @@ class Lksh218Tests(unittest.TestCase):
             self.ca.assert_pv_alarm_is("TEMP{}".format(i), ChannelAccess.ALARM_INVALID)
             self.ca.assert_pv_alarm_is("SENSOR{}".format(i), ChannelAccess.ALARM_INVALID)
 
-    @skip_if_recsim("In rec sim this test fails.")
+    @skip_if_recsim("Recsim is unable to simulate a disconnected device.")
     def test_that_WHEN_the_emulator_is_disconnected_THEN_an_alarm_is_raised_on_SENSORALL(self):
         self._lewis.backdoor_set_on_device("connected", False)
 
         self.ca.process_pv("SENSORALL")
         self.ca.assert_pv_alarm_is("SENSORALL", ChannelAccess.ALARM_INVALID)
 
-    @skip_if_recsim("In rec sim this test fails.")
+    @skip_if_recsim("Recsim is unable to simulate a disconnected device.")
     def test_that_WHEN_the_emulator_is_disconnected_THEN_an_alarm_is_raised_on_TEMPALL(self):
         self._lewis.backdoor_set_on_device("connected", False)
 

--- a/tests/lksh218.py
+++ b/tests/lksh218.py
@@ -94,3 +94,10 @@ class Lksh218Tests(unittest.TestCase):
 
         self.ca.process_pv("SENSORALL")
         self.ca.assert_pv_alarm_is("SENSORALL", ChannelAccess.ALARM_INVALID)
+
+    @skip_if_recsim("In rec sim this test fails.")
+    def test_that_WHEN_the_emulator_is_disconnected_THEN_an_alarm_is_raised_on_TEMPALL(self):
+        self._lewis.backdoor_set_on_device("connected", False)
+
+        self.ca.process_pv("TEMPALL")
+        self.ca.assert_pv_alarm_is("TEMPALL", ChannelAccess.ALARM_INVALID)

--- a/tests/lksh218.py
+++ b/tests/lksh218.py
@@ -18,8 +18,7 @@ IOCS = [
     },
 ]
 
-
-TEST_MODES = [TestModes.RECSIM]
+TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
 
 
 class Lksh218Tests(unittest.TestCase):
@@ -30,8 +29,10 @@ class Lksh218Tests(unittest.TestCase):
         self._lewis, self._ioc = get_running_lewis_and_ioc("Lksh218", DEVICE_PREFIX)
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
 
-    def test_GIVEN_temp_set__WHEN_read_THEN_temp_is_as_expected(self):
+    def test_WHEN_ioc_started_THEN_ioc_is_not_disabled(self):
+        self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")
+
+    def test_that_GIVEN_temp_set__WHEN_read_THEN_temp_is_as_expected(self):
         test_value = 50
         self.ca.set_pv_value("SIM:TEMP1", test_value)
         self.ca.assert_that_pv_is("SIM:TEMP1", test_value)
-        

--- a/tests/lksh218.py
+++ b/tests/lksh218.py
@@ -29,10 +29,15 @@ class Lksh218Tests(unittest.TestCase):
         self._lewis, self._ioc = get_running_lewis_and_ioc("Lksh218", DEVICE_PREFIX)
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
 
+    def _set_temperature(self, number, temperature):
+        pv = "SIM:TEMP{}".format(number)
+        self._lewis.backdoor_run_function_on_device("set_temp", [number, temperature])
+        self._ioc.set_simulated_value(pv, temperature)
+
     def test_WHEN_ioc_started_THEN_ioc_is_not_disabled(self):
         self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")
 
-    def test_that_GIVEN_temp_set__WHEN_read_THEN_temp_is_as_expected(self):
-        test_value = 50
-        self.ca.set_pv_value("SIM:TEMP1", test_value)
-        self.ca.assert_that_pv_is("SIM:TEMP1", test_value)
+    def test_that_GIVEN_temp1_set__WHEN_read_in_devsim_THEN_temp1_is_as_expected(self):
+        expected_value = 1.23
+        self._set_temperature(1, expected_value)
+        self.ca.assert_that_pv_is("TEMP1", expected_value)

--- a/tests/lksh218.py
+++ b/tests/lksh218.py
@@ -4,6 +4,7 @@ from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
 from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
+from lewis.core.logging import has_log
 
 
 DEVICE_PREFIX = "LKSH218_01"
@@ -21,6 +22,7 @@ IOCS = [
 TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
 
 
+@has_log
 class Lksh218Tests(unittest.TestCase):
     """
     Tests for the Lksh218 IOC.
@@ -37,7 +39,10 @@ class Lksh218Tests(unittest.TestCase):
     def test_WHEN_ioc_started_THEN_ioc_is_not_disabled(self):
         self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")
 
-    def test_that_GIVEN_temp1_set__WHEN_read_in_devsim_THEN_temp1_is_as_expected(self):
-        expected_value = 1.23
-        self._set_temperature(1, expected_value)
-        self.ca.assert_that_pv_is("TEMP1", expected_value)
+    def test_that_GIVEN_temp_float_WHEN_read_THEN_temp_is_as_expected(self):
+        expected_value = 10.586
+
+        for index in range(1, 9):
+            pv = "TEMP{}".format(index)
+            self._set_temperature(index, expected_value)
+            self.ca.assert_that_pv_is(pv, expected_value)

--- a/tests/lksh218.py
+++ b/tests/lksh218.py
@@ -75,3 +75,12 @@ class Lksh218Tests(unittest.TestCase):
 
         self.ca.process_pv("SENSORALL")
         self.ca.assert_that_pv_is("SENSORALL", expected_string)
+
+    @skip_if_recsim("In rec sim this test fails.")
+    def test_that_WHEN_the_emulator_is_disconnected_THEN_an_alarm_is_raised_on_TEMP1_and_SENSOR1(self):
+        self._lewis.backdoor_set_on_device("connected", False)
+
+        self.ca.assert_pv_alarm_is("TEMP1", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_pv_alarm_is("SENSOR1", ChannelAccess.ALARM_INVALID)
+
+        self._lewis.backdoor_set_on_device("connected", True)

--- a/tests/readascii.py
+++ b/tests/readascii.py
@@ -100,7 +100,7 @@ class ReadasciiTests(unittest.TestCase):
 
         # The LUTON PV is FLNK'ed to by the IOCs that use ReadASCII after the setpoint changes.
         # Here we're not using any particular IOC so have to trigger the processing manually.
-        self.ca.set_pv_value("LUTON.PROC", 1)
+        self.ca.process_pv("LUTON")
 
         self.ca.assert_that_pv_is_number("OUT_P", p, tolerance=TOLERANCE)
         self.ca.assert_that_pv_is_number("OUT_I", i, tolerance=TOLERANCE)

--- a/utils/channel_access.py
+++ b/utils/channel_access.py
@@ -68,6 +68,16 @@ class ChannelAccess(object):
         """
         return self.ca.get_pv_value(self._create_pv_with_prefix(pv))
 
+    def process_pv(self, pv):
+        """
+        Makes the pv process once.
+
+        :param pv: the EPICS PV name
+        :return: None
+        """
+        pv_proc = "{}.PROC".format(pv)
+        return self.ca.set_pv_value(pv_proc, 1)
+
     def assert_that_pv_is(self, pv, expected_value, timeout=None, msg=""):
         """
         Assert that the pv has the expected value or that it becomes the expected value within the timeout.

--- a/utils/channel_access.py
+++ b/utils/channel_access.py
@@ -75,7 +75,7 @@ class ChannelAccess(object):
         :param pv: the EPICS PV name
         :return: None
         """
-        pv_proc = "{}.PROC".format(pv)
+        pv_proc = "{}.PROC".format(self._create_pv_with_prefix(pv))
         return self.ca.set_pv_value(pv_proc, 1)
 
     def assert_that_pv_is(self, pv, expected_value, timeout=None, msg=""):


### PR DESCRIPTION
### Description of Work

- Added tests of all TEMP# and SENSOR# pvs in Lakeshore 218.
- Added tests ofTEMPALL and SENSORALL pvs in Lakeshore 218.
- Added tests of the disconnected functionality.

### To Test

[#3223](https://github.com/ISISComputingGroup/IBEX/issues/3223)

### Acceptance Criteria

1. All functions of the lakeshore 218 are tested.
2.  Disconnection function is tested.