### PR TITLE
Ticket3275: Add testing for SP2XX IOC.

### DIFF
--- a/tests/sp2xx.py
+++ b/tests/sp2xx.py
@@ -14,7 +14,7 @@ IOCS = [
         "name": DEVICE_PREFIX,
         "directory": get_default_ioc_dir("SP2XX"),
         "macros": {},
-        "emulator": "Sp2Xx",
+        "emulator": "Sp2XX",
     },
 ]
 
@@ -24,10 +24,10 @@ TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
 
 class Sp2XxTests(unittest.TestCase):
     """
-    Tests for the Sp2Xx IOC.
+    Tests for the Sp2XX IOC.
     """
     def setUp(self):
-        self._lewis, self._ioc = get_running_lewis_and_ioc("Sp2Xx", DEVICE_PREFIX)
+        self._lewis, self._ioc = get_running_lewis_and_ioc("Sp2XX", DEVICE_PREFIX)
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
 
     def test_that_fails(self):

--- a/tests/sp2xx.py
+++ b/tests/sp2xx.py
@@ -58,3 +58,31 @@ class Sp2XxRunCommandTests(unittest.TestCase):
 
         # Then:
         self.ca.assert_that_pv_is("STATUS", "Infusing")
+
+class Sp2XxStopCommandTests(unittest.TestCase):
+    """
+    Tests for the Sp2XX IOC stop command.
+    """
+    def setUp(self):
+        # Given
+        self._lewis, self._ioc = get_running_lewis_and_ioc("sp2xx", DEVICE_PREFIX)
+        self.ca = ChannelAccess(20, device_prefix=DEVICE_PREFIX)
+        self._lewis.backdoor_run_function_on_device("set_running_status_via_the_back_door", ["Stopped"])
+
+    def tearDown(self):
+        self._lewis.backdoor_run_function_on_device("set_running_status_via_the_back_door", ["Stopped"])
+
+    def _start_running(self):
+        self._lewis.backdoor_run_function_on_device("set_running_status_via_the_back_door", ["Infusing"])
+
+    def _stop_running(self):
+        self._lewis.backdoor_run_function_on_device("stop_device_via_the_back_door")
+
+    def test_that_GIVEN_a_running_pump_THEN_the_pump_stops(self):
+        # Given
+        self._start_running()
+        # When:
+        self._stop_running()
+        # Then:
+        self.ca.assert_that_pv_is("STATUS", "Stopped")
+

--- a/tests/sp2xx.py
+++ b/tests/sp2xx.py
@@ -1,0 +1,34 @@
+import unittest
+
+from utils.channel_access import ChannelAccess
+from utils.ioc_launcher import get_default_ioc_dir
+from utils.test_modes import TestModes
+from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
+
+
+DEVICE_PREFIX = "SP2XX_01"
+
+
+IOCS = [
+    {
+        "name": DEVICE_PREFIX,
+        "directory": get_default_ioc_dir("SP2XX"),
+        "macros": {},
+        "emulator": "Sp2Xx",
+    },
+]
+
+
+TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
+
+
+class Sp2XxTests(unittest.TestCase):
+    """
+    Tests for the Sp2Xx IOC.
+    """
+    def setUp(self):
+        self._lewis, self._ioc = get_running_lewis_and_ioc("Sp2Xx", DEVICE_PREFIX)
+        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
+
+    def test_that_fails(self):
+        self.fail("You haven't implemented any tests!")

--- a/tests/sp2xx.py
+++ b/tests/sp2xx.py
@@ -30,13 +30,13 @@ class Sp2XxRunCommandTests(unittest.TestCase):
         # Given
         self._lewis, self._ioc = get_running_lewis_and_ioc("sp2xx", DEVICE_PREFIX)
         self.ca = ChannelAccess(20, device_prefix=DEVICE_PREFIX)
-        self._lewis.backdoor_run_function_on_device("set_running_status_via_the_back_door", ["Stopped"])
+        self._lewis.backdoor_run_function_on_device("stop_device")
 
     def tearDown(self):
-        self._lewis.backdoor_run_function_on_device("set_running_status_via_the_back_door", ["Stopped"])
+        self._lewis.backdoor_run_function_on_device("stop_device")
 
     def _start_running(self):
-        self._lewis.backdoor_run_function_on_device("set_running_status_via_the_back_door", ["Infusing"])
+        self._lewis.backdoor_run_function_on_device("start_device")
 
     def test_that_GIVEN_an_initialized_pump_THEN_it_is_stopped(self):
         # Then:
@@ -67,20 +67,22 @@ class Sp2XxStopCommandTests(unittest.TestCase):
         # Given
         self._lewis, self._ioc = get_running_lewis_and_ioc("sp2xx", DEVICE_PREFIX)
         self.ca = ChannelAccess(20, device_prefix=DEVICE_PREFIX)
-        self._lewis.backdoor_run_function_on_device("set_running_status_via_the_back_door", ["Stopped"])
+        self._stop_running()
 
     def tearDown(self):
-        self._lewis.backdoor_run_function_on_device("set_running_status_via_the_back_door", ["Stopped"])
+        self._stop_running()
 
     def _start_running(self):
-        self._lewis.backdoor_run_function_on_device("set_running_status_via_the_back_door", ["Infusing"])
+        self._lewis.backdoor_run_function_on_device("start_device")
 
     def _stop_running(self):
-        self._lewis.backdoor_run_function_on_device("stop_device_via_the_back_door")
+        self._lewis.backdoor_run_function_on_device("stop_device")
 
     def test_that_GIVEN_a_running_pump_THEN_the_pump_stops(self):
         # Given
         self._start_running()
+        self.ca.assert_that_pv_is("STATUS", "Infusing")
+
         # When:
         self._stop_running()
         # Then:

--- a/tests/sp2xx.py
+++ b/tests/sp2xx.py
@@ -1,5 +1,4 @@
 import unittest
-
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
@@ -14,21 +13,48 @@ IOCS = [
         "name": DEVICE_PREFIX,
         "directory": get_default_ioc_dir("SP2XX"),
         "macros": {},
-        "emulator": "Sp2XX",
-    },
+        "emulator": "sp2xx",
+        "emulator_protocol": "stream"
+    }
 ]
 
 
-TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
+TEST_MODES = [TestModes.DEVSIM] #TestModes.RECSIM,
 
 
-class Sp2XxTests(unittest.TestCase):
+class Sp2XxRunCommandTests(unittest.TestCase):
     """
-    Tests for the Sp2XX IOC.
+    Tests for the Sp2XX IOC run command.
     """
     def setUp(self):
-        self._lewis, self._ioc = get_running_lewis_and_ioc("Sp2XX", DEVICE_PREFIX)
-        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
+        # Given
+        self._lewis, self._ioc = get_running_lewis_and_ioc("sp2xx", DEVICE_PREFIX)
+        self.ca = ChannelAccess(20, device_prefix=DEVICE_PREFIX)
+        self._lewis.backdoor_run_function_on_device("set_running_status_via_the_back_door", ["Stopped"])
 
-    def test_that_fails(self):
-        self.fail("You haven't implemented any tests!")
+    def tearDown(self):
+        self._lewis.backdoor_run_function_on_device("set_running_status_via_the_back_door", ["Stopped"])
+
+    def _start_running(self):
+        self._lewis.backdoor_run_function_on_device("set_running_status_via_the_back_door", ["Infusing"])
+
+    def test_that_GIVEN_an_initialized_pump_THEN_it_is_stopped(self):
+        # Then:
+        self.ca.assert_that_pv_is("STATUS", "Stopped")
+
+    def test_that_GIVEN_a_pump_in_infusion_mode_which_is_not_running_THEN_the_pump_starts_running_(self):
+        # When
+        self._start_running()
+
+        # Then:
+        self.ca.assert_that_pv_is("STATUS", "Infusing")
+
+    def test_that_GIVEN_the_pump_is_running_infusion_mode_WHEN_told_to_run_THEN_the_pump_is_still_running_in_infusion_mode(self):
+        # Given
+        self._start_running()
+
+        # When
+        self._start_running()
+
+        # Then:
+        self.ca.assert_that_pv_is("STATUS", "Infusing")

--- a/tests/sp2xx.py
+++ b/tests/sp2xx.py
@@ -1,4 +1,7 @@
 import unittest
+from parameterized import parameterized
+import re
+from enum import Enum
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
@@ -19,10 +22,21 @@ IOCS = [
 ]
 
 
-TEST_MODES = [TestModes.DEVSIM] #TestModes.RECSIM,
+class LastError(Enum):
+    No_error = 0
+    Communication_error = 1
+    Stall = 2
+    Communication_error_and_stall = 3
+    Serial_overrun = 4
+    Serial_error_and_overrun = 5
+    Stall_and_serial_overrun = 6
+    Stall_and_serial_error_and_overrun = 7
 
 
-class Sp2XxRunCommandTests(unittest.TestCase):
+TEST_MODES = [TestModes.DEVSIM] # TestModes.RECSIM,
+
+
+class RunCommandTests(unittest.TestCase):
     """
     Tests for the Sp2XX IOC run command.
     """
@@ -31,12 +45,17 @@ class Sp2XxRunCommandTests(unittest.TestCase):
         self._lewis, self._ioc = get_running_lewis_and_ioc("sp2xx", DEVICE_PREFIX)
         self.ca = ChannelAccess(20, device_prefix=DEVICE_PREFIX)
         self._lewis.backdoor_run_function_on_device("stop_device")
+        self._reset_device()
 
     def tearDown(self):
-        self._lewis.backdoor_run_function_on_device("stop_device")
+        self._reset_device()
 
     def _start_running(self):
         self._lewis.backdoor_run_function_on_device("start_device")
+
+    def _reset_device(self):
+        self._lewis.backdoor_run_function_on_device("stop_device")
+        self._lewis.backdoor_run_function_on_device("clear_last_error")
 
     def test_that_GIVEN_an_initialized_pump_THEN_it_is_stopped(self):
         # Then:
@@ -59,7 +78,8 @@ class Sp2XxRunCommandTests(unittest.TestCase):
         # Then:
         self.ca.assert_that_pv_is("STATUS", "Infusing")
 
-class Sp2XxStopCommandTests(unittest.TestCase):
+
+class StopCommandTests(unittest.TestCase):
     """
     Tests for the Sp2XX IOC stop command.
     """
@@ -67,16 +87,22 @@ class Sp2XxStopCommandTests(unittest.TestCase):
         # Given
         self._lewis, self._ioc = get_running_lewis_and_ioc("sp2xx", DEVICE_PREFIX)
         self.ca = ChannelAccess(20, device_prefix=DEVICE_PREFIX)
-        self._stop_running()
+        self._reset_device()
 
     def tearDown(self):
-        self._stop_running()
+        self._reset_device()
 
     def _start_running(self):
         self._lewis.backdoor_run_function_on_device("start_device")
+        self.ca.set_pv_value("RUN:SP", 1)
 
     def _stop_running(self):
         self._lewis.backdoor_run_function_on_device("stop_device")
+        self.ca.set_pv_value("STOP:SP", 1)
+
+    def _reset_device(self):
+        self._stop_running()
+        self._lewis.backdoor_run_function_on_device("clear_last_error")
 
     def test_that_GIVEN_a_running_pump_THEN_the_pump_stops(self):
         # Given
@@ -88,3 +114,59 @@ class Sp2XxStopCommandTests(unittest.TestCase):
         # Then:
         self.ca.assert_that_pv_is("STATUS", "Stopped")
 
+    def test_that_GIVEN_a_stopped_pump_THEN_the_pump_remains_stopped(self):
+        # Given
+        self._stop_running()
+
+        # When:
+        self._stop_running()
+
+        # Then:
+        self.ca.assert_that_pv_is("STATUS", "Stopped")
+
+
+class ErrorTests(unittest.TestCase):
+    """
+    Tests for the Sp2XX IOC stop command.
+    """
+    def setUp(self):
+        # Given
+        self._lewis, self._ioc = get_running_lewis_and_ioc("sp2xx", DEVICE_PREFIX)
+        self.ca = ChannelAccess(20, device_prefix=DEVICE_PREFIX)
+        self._reset_device()
+
+    def tearDown(self):
+        self._reset_device()
+
+    def _start_running(self):
+        self._lewis.backdoor_run_function_on_device("start_device")
+
+    def _stop_running(self):
+        self._lewis.backdoor_run_function_on_device("stop_device")
+
+    def _reset_device(self):
+        self._lewis.backdoor_run_function_on_device("stop_device")
+        self._lewis.backdoor_run_function_on_device("clear_last_error")
+
+    def test_that_GIVEN_an_initialized_pump_THEN_the_device_has_no_error(self):
+        # Then:
+        self.ca.process_pv("ERROR")
+        self.ca.assert_that_pv_is("ERROR", "No error")
+        self.ca.assert_pv_alarm_is("ERROR", ChannelAccess.ALARM_NONE)
+
+    @parameterized.expand([(error_type.name, error_type) for error_type in LastError])
+    def test_that_GIVEN_a_device_with_an_error_WHEN_trying_to_start_the_device_THEN_the_error_pv_is_updated(self, _, error_type):
+        # Given:
+        self._lewis.backdoor_run_function_on_device("throw_error", [error_type.value])
+
+        # When:
+        self._start_running()
+
+        # Then:
+        if error_type.value == 7:
+            self.ca.assert_that_pv_is("ERROR", "Stall, serial error and overrun")
+            self.ca.assert_pv_alarm_is("ERROR", ChannelAccess.ALARM_INVALID)
+        else:
+            expected = re.sub("_", " ", error_type.name)
+            self.ca.assert_that_pv_is("ERROR", expected)
+            self.ca.assert_pv_alarm_is("ERROR", ChannelAccess.ALARM_INVALID)


### PR DESCRIPTION
Related Tickets: [#3275](https://github.com/ISISComputingGroup/IBEX/issues/3275) and [#3261](https://github.com/ISISComputingGroup/IBEX/issues/3261).

Added [parameterized testing](https://github.com/ISISComputingGroup/genie_python/pull/135) using parameterized (https://github.com/wolever/parameterized).

Tests start, stop and error handling functionality.