### PR TITLE
Refactor assertions

### DIFF
--- a/common_tests/fermichopper.py
+++ b/common_tests/fermichopper.py
@@ -35,7 +35,7 @@ class FermichopperBase(unittest.TestCase):
         self._lewis, self._ioc = get_running_lewis_and_ioc("fermichopper", self._get_device_prefix())
 
         self.ca = ChannelAccess(device_prefix=self._get_device_prefix(), default_timeout=30)
-        self.ca.wait_for("SPEED")
+        self.ca.assert_that_pv_exists("SPEED")
 
         self.ca.set_pv_value("DELAY:SP", 0)
         self.ca.set_pv_value("GATEWIDTH:SP", 0)
@@ -73,34 +73,34 @@ class FermichopperBase(unittest.TestCase):
         for speed in self.test_chopper_speeds:
             self.ca.set_pv_value("SPEED:SP", speed)
             self.ca.assert_that_pv_is("SPEED:SP", speed)
-            self.ca.assert_pv_alarm_is("SPEED:SP", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("SPEED:SP", self.ca.Alarms.NONE)
             self.ca.assert_that_pv_is("SPEED:SP:RBV", speed)
-            self.ca.assert_pv_alarm_is("SPEED:SP:RBV", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("SPEED:SP:RBV", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Recsim does not handle this")
     def test_WHEN_speed_setpoint_is_set_via_gui_pv_THEN_readback_updates(self):
         for speed in self.test_chopper_speeds:
             self.ca.set_pv_value("SPEED:SP:GUI", "{} Hz".format(speed))
             self.ca.assert_that_pv_is("SPEED:SP", speed)
-            self.ca.assert_pv_alarm_is("SPEED:SP", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("SPEED:SP", self.ca.Alarms.NONE)
             self.ca.assert_that_pv_is("SPEED:SP:RBV", speed)
-            self.ca.assert_pv_alarm_is("SPEED:SP:RBV", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("SPEED:SP:RBV", self.ca.Alarms.NONE)
 
     def test_WHEN_delay_setpoint_is_set_THEN_readback_updates(self):
         for value in self.test_delay_durations:
             self.ca.set_pv_value("DELAY:SP", value)
             self.ca.assert_that_pv_is("DELAY:SP", value)
-            self.ca.assert_pv_alarm_is("DELAY:SP", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("DELAY:SP", self.ca.Alarms.NONE)
             self.ca.assert_that_pv_is_number("DELAY:SP:RBV", value, tolerance=0.05)
-            self.ca.assert_pv_alarm_is("DELAY:SP:RBV", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("DELAY:SP:RBV", self.ca.Alarms.NONE)
 
     def test_WHEN_gatewidth_is_set_THEN_readback_updates(self):
         for value in self.test_gatewidth_values:
             self.ca.set_pv_value("GATEWIDTH:SP", value)
             self.ca.assert_that_pv_is("GATEWIDTH:SP", value)
-            self.ca.assert_pv_alarm_is("GATEWIDTH:SP", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("GATEWIDTH:SP", self.ca.Alarms.NONE)
             self.ca.assert_that_pv_is_number("GATEWIDTH", value, tolerance=0.05)
-            self.ca.assert_pv_alarm_is("GATEWIDTH", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("GATEWIDTH", self.ca.Alarms.NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_WHEN_autozero_voltages_are_set_via_backdoor_THEN_pvs_update(self):
@@ -109,14 +109,14 @@ class FermichopperBase(unittest.TestCase):
                 for value in self.test_autozero_values:
                     self._lewis.backdoor_set_on_device("autozero_{n}_{b}".format(n=number, b=boundary), value)
                     self.ca.assert_that_pv_is_number("AUTOZERO:{n}:{b}".format(n=number, b=boundary.upper()), value, tolerance=0.05)
-                    self.ca.assert_pv_alarm_is("AUTOZERO:{n}:{b}".format(n=number, b=boundary.upper()), self.ca.Alarms.NONE)
+                    self.ca.assert_that_pv_alarm_is("AUTOZERO:{n}:{b}".format(n=number, b=boundary.upper()), self.ca.Alarms.NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_WHEN_drive_current_is_set_via_backdoor_THEN_pv_updates(self):
         for current in self.test_current_values:
             self._lewis.backdoor_set_on_device("current", current)
             self.ca.assert_that_pv_is_number("CURRENT", current, tolerance=0.1)
-            self.ca.assert_pv_alarm_is("CURRENT", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("CURRENT", self.ca.Alarms.NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_GIVEN_a_stopped_chopper_WHEN_start_command_is_sent_THEN_chopper_goes_to_setpoint(self):
@@ -249,7 +249,7 @@ class FermichopperBase(unittest.TestCase):
         self.ca.assert_that_pv_is_number("DELAY:SP:RBV", test_value, tolerance=tolerance)
 
         with self._lie_about_delay_setpoint_readback():
-            self.ca.assert_pv_value_causes_func_to_return_true("DELAY:SP:RBV", lambda v: abs(v - test_value) > tolerance)
+            self.ca.assert_that_pv_value_causes_func_to_return_true("DELAY:SP:RBV", lambda v: abs(v - test_value) > tolerance)
 
             # Some time later the driver should resend the setpoint which causes the device to behave properly again:
             self.ca.assert_that_pv_is_number("DELAY:SP:RBV", test_value, tolerance=tolerance)
@@ -264,7 +264,7 @@ class FermichopperBase(unittest.TestCase):
         self.ca.assert_that_pv_is_number("GATEWIDTH", test_value, tolerance=tolerance)
 
         with self._lie_about_gatewidth():
-            self.ca.assert_pv_value_causes_func_to_return_true("GATEWIDTH", lambda v: abs(v - test_value) > tolerance)
+            self.ca.assert_that_pv_value_causes_func_to_return_true("GATEWIDTH", lambda v: abs(v - test_value) > tolerance)
 
             # Some time later the driver should resend the setpoint which causes the device to behave properly again:
             self.ca.assert_that_pv_is_number("GATEWIDTH", test_value, tolerance=tolerance)
@@ -345,7 +345,7 @@ class FermichopperBase(unittest.TestCase):
                 # Assert that the last command is zero as expected
                 self.ca.assert_that_pv_is("LASTCOMMAND", "0000")
                 # Check that the last command is not being set to something else by the IOC
-                self.ca.assert_pv_value_is_unchanged("LASTCOMMAND", wait=10)
+                self.ca.assert_that_pv_value_is_unchanged("LASTCOMMAND", wait=10)
 
                 # Set autozero voltage too high and set device moving
                 self._lewis.backdoor_set_on_device("autozero_{n}_{p}".format(n=number, p=position), 3.2)

--- a/common_tests/fermichopper.py
+++ b/common_tests/fermichopper.py
@@ -73,34 +73,34 @@ class FermichopperBase(unittest.TestCase):
         for speed in self.test_chopper_speeds:
             self.ca.set_pv_value("SPEED:SP", speed)
             self.ca.assert_that_pv_is("SPEED:SP", speed)
-            self.ca.assert_pv_alarm_is("SPEED:SP", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("SPEED:SP", self.ca.Alarms.NONE)
             self.ca.assert_that_pv_is("SPEED:SP:RBV", speed)
-            self.ca.assert_pv_alarm_is("SPEED:SP:RBV", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("SPEED:SP:RBV", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Recsim does not handle this")
     def test_WHEN_speed_setpoint_is_set_via_gui_pv_THEN_readback_updates(self):
         for speed in self.test_chopper_speeds:
             self.ca.set_pv_value("SPEED:SP:GUI", "{} Hz".format(speed))
             self.ca.assert_that_pv_is("SPEED:SP", speed)
-            self.ca.assert_pv_alarm_is("SPEED:SP", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("SPEED:SP", self.ca.Alarms.NONE)
             self.ca.assert_that_pv_is("SPEED:SP:RBV", speed)
-            self.ca.assert_pv_alarm_is("SPEED:SP:RBV", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("SPEED:SP:RBV", self.ca.Alarms.NONE)
 
     def test_WHEN_delay_setpoint_is_set_THEN_readback_updates(self):
         for value in self.test_delay_durations:
             self.ca.set_pv_value("DELAY:SP", value)
             self.ca.assert_that_pv_is("DELAY:SP", value)
-            self.ca.assert_pv_alarm_is("DELAY:SP", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("DELAY:SP", self.ca.Alarms.NONE)
             self.ca.assert_that_pv_is_number("DELAY:SP:RBV", value, tolerance=0.05)
-            self.ca.assert_pv_alarm_is("DELAY:SP:RBV", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("DELAY:SP:RBV", self.ca.Alarms.NONE)
 
     def test_WHEN_gatewidth_is_set_THEN_readback_updates(self):
         for value in self.test_gatewidth_values:
             self.ca.set_pv_value("GATEWIDTH:SP", value)
             self.ca.assert_that_pv_is("GATEWIDTH:SP", value)
-            self.ca.assert_pv_alarm_is("GATEWIDTH:SP", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("GATEWIDTH:SP", self.ca.Alarms.NONE)
             self.ca.assert_that_pv_is_number("GATEWIDTH", value, tolerance=0.05)
-            self.ca.assert_pv_alarm_is("GATEWIDTH", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("GATEWIDTH", self.ca.Alarms.NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_WHEN_autozero_voltages_are_set_via_backdoor_THEN_pvs_update(self):
@@ -109,14 +109,14 @@ class FermichopperBase(unittest.TestCase):
                 for value in self.test_autozero_values:
                     self._lewis.backdoor_set_on_device("autozero_{n}_{b}".format(n=number, b=boundary), value)
                     self.ca.assert_that_pv_is_number("AUTOZERO:{n}:{b}".format(n=number, b=boundary.upper()), value, tolerance=0.05)
-                    self.ca.assert_pv_alarm_is("AUTOZERO:{n}:{b}".format(n=number, b=boundary.upper()), self.ca.ALARM_NONE)
+                    self.ca.assert_pv_alarm_is("AUTOZERO:{n}:{b}".format(n=number, b=boundary.upper()), self.ca.Alarms.NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_WHEN_drive_current_is_set_via_backdoor_THEN_pv_updates(self):
         for current in self.test_current_values:
             self._lewis.backdoor_set_on_device("current", current)
             self.ca.assert_that_pv_is_number("CURRENT", current, tolerance=0.1)
-            self.ca.assert_pv_alarm_is("CURRENT", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("CURRENT", self.ca.Alarms.NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_GIVEN_a_stopped_chopper_WHEN_start_command_is_sent_THEN_chopper_goes_to_setpoint(self):

--- a/common_tests/riken_changeover.py
+++ b/common_tests/riken_changeover.py
@@ -164,22 +164,22 @@ class RikenChangeover(unittest.TestCase):
 
     def test_GIVEN_a_power_supply_is_in_alarm_THEN_the_power_any_pv_is_also_in_alarm(self):
         for supply in self.get_power_supplies():
-            with self.ca.put_simulated_record_into_alarm("{}:POWER".format(supply), self.ca.ALARM_INVALID):
-                self.ca.assert_pv_alarm_is("{}:PSUS:POWER".format(self.get_prefix()), self.ca.ALARM_INVALID)
-            self.ca.assert_pv_alarm_is("{}:PSUS:POWER".format(self.get_prefix()), self.ca.ALARM_NONE)
+            with self.ca.put_simulated_record_into_alarm("{}:POWER".format(supply), self.ca.Alarms.INVALID):
+                self.ca.assert_pv_alarm_is("{}:PSUS:POWER".format(self.get_prefix()), self.ca.Alarms.INVALID)
+            self.ca.assert_pv_alarm_is("{}:PSUS:POWER".format(self.get_prefix()), self.ca.Alarms.NONE)
 
     def test_GIVEN_all_power_supply_are_in_alarm_THEN_the_power_any_pv_is_also_in_alarm(self):
         with ExitStack() as stack:
             for supply in self.get_power_supplies():
                 stack.enter_context(
-                    self.ca.put_simulated_record_into_alarm("{}:POWER".format(supply), self.ca.ALARM_INVALID)
+                    self.ca.put_simulated_record_into_alarm("{}:POWER".format(supply), self.ca.Alarms.INVALID)
                 )
-            self.ca.assert_pv_alarm_is("{}:PSUS:POWER".format(self.get_prefix()), self.ca.ALARM_INVALID)
-        self.ca.assert_pv_alarm_is("{}:PSUS:POWER".format(self.get_prefix()), self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("{}:PSUS:POWER".format(self.get_prefix()), self.ca.Alarms.INVALID)
+        self.ca.assert_pv_alarm_is("{}:PSUS:POWER".format(self.get_prefix()), self.ca.Alarms.NONE)
 
     def test_GIVEN_a_power_supply_is_in_alarm_THEN_the_power_any_pv_reports_that_psus_are_active(self):
         for supply in self.get_power_supplies():
-            with self.ca.put_simulated_record_into_alarm("{}:POWER".format(supply), self.ca.ALARM_INVALID):
+            with self.ca.put_simulated_record_into_alarm("{}:POWER".format(supply), self.ca.Alarms.INVALID):
                 self.ca.assert_that_pv_is_number("{}:PSUS:POWER".format(self.get_prefix()), 1)
             self.ca.assert_that_pv_is_number("{}:PSUS:POWER".format(self.get_prefix()), 0)
 
@@ -187,7 +187,7 @@ class RikenChangeover(unittest.TestCase):
         with ExitStack() as stack:
             for supply in self.get_power_supplies():
                 stack.enter_context(
-                    self.ca.put_simulated_record_into_alarm("{}:POWER".format(supply), self.ca.ALARM_INVALID)
+                    self.ca.put_simulated_record_into_alarm("{}:POWER".format(supply), self.ca.Alarms.INVALID)
                 )
             self.ca.assert_that_pv_is_number("{}:PSUS:POWER".format(self.get_prefix()), 1)
         self.ca.assert_that_pv_is_number("{}:PSUS:POWER".format(self.get_prefix()), 0)

--- a/common_tests/riken_changeover.py
+++ b/common_tests/riken_changeover.py
@@ -108,11 +108,11 @@ class RikenChangeover(unittest.TestCase):
         self.ca = ChannelAccess()
 
         # Wait for PVs that we care about to exist.
-        self.ca.wait_for("{}:PSUS:DISABLE".format(self.get_prefix()), timeout=30)
-        self.ca.wait_for(self.get_input_pv(), timeout=30)
-        self.ca.wait_for(self.get_acknowledgement_pv(), timeout=30)
+        self.ca.assert_that_pv_exists("{}:PSUS:DISABLE".format(self.get_prefix()), timeout=30)
+        self.ca.assert_that_pv_exists(self.get_input_pv(), timeout=30)
+        self.ca.assert_that_pv_exists(self.get_acknowledgement_pv(), timeout=30)
         for id in self.get_power_supplies():
-            self.ca.wait_for("{}:POWER".format(id), timeout=30)
+            self.ca.assert_that_pv_exists("{}:POWER".format(id), timeout=30)
 
         self._set_input_pv(True)
         self._set_all_power_supply_states(False)
@@ -165,8 +165,8 @@ class RikenChangeover(unittest.TestCase):
     def test_GIVEN_a_power_supply_is_in_alarm_THEN_the_power_any_pv_is_also_in_alarm(self):
         for supply in self.get_power_supplies():
             with self.ca.put_simulated_record_into_alarm("{}:POWER".format(supply), self.ca.Alarms.INVALID):
-                self.ca.assert_pv_alarm_is("{}:PSUS:POWER".format(self.get_prefix()), self.ca.Alarms.INVALID)
-            self.ca.assert_pv_alarm_is("{}:PSUS:POWER".format(self.get_prefix()), self.ca.Alarms.NONE)
+                self.ca.assert_that_pv_alarm_is("{}:PSUS:POWER".format(self.get_prefix()), self.ca.Alarms.INVALID)
+            self.ca.assert_that_pv_alarm_is("{}:PSUS:POWER".format(self.get_prefix()), self.ca.Alarms.NONE)
 
     def test_GIVEN_all_power_supply_are_in_alarm_THEN_the_power_any_pv_is_also_in_alarm(self):
         with ExitStack() as stack:
@@ -174,8 +174,8 @@ class RikenChangeover(unittest.TestCase):
                 stack.enter_context(
                     self.ca.put_simulated_record_into_alarm("{}:POWER".format(supply), self.ca.Alarms.INVALID)
                 )
-            self.ca.assert_pv_alarm_is("{}:PSUS:POWER".format(self.get_prefix()), self.ca.Alarms.INVALID)
-        self.ca.assert_pv_alarm_is("{}:PSUS:POWER".format(self.get_prefix()), self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("{}:PSUS:POWER".format(self.get_prefix()), self.ca.Alarms.INVALID)
+        self.ca.assert_that_pv_alarm_is("{}:PSUS:POWER".format(self.get_prefix()), self.ca.Alarms.NONE)
 
     def test_GIVEN_a_power_supply_is_in_alarm_THEN_the_power_any_pv_reports_that_psus_are_active(self):
         for supply in self.get_power_supplies():

--- a/tests/ag33220a.py
+++ b/tests/ag33220a.py
@@ -26,7 +26,7 @@ TEST_MODES = [TestModes.DEVSIM]
 class Ag33220aTests(unittest.TestCase):
     def setUp(self):
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
-        self.ca.wait_for("DISABLE", timeout=30)
+        self.ca.assert_that_pv_exists("DISABLE", timeout=30)
         self.reset_values()
 
     def reset_values(self):

--- a/tests/ag3631a.py
+++ b/tests/ag3631a.py
@@ -28,7 +28,7 @@ class Ag3631aTests(unittest.TestCase):
         self._ioc = IOCRegister.get_running(DEVICE_PREFIX)
 
         self.ca = ChannelAccess(20, DEVICE_PREFIX)
-        self.ca.wait_for("DISABLE", timeout=30)
+        self.ca.assert_that_pv_exists("DISABLE", timeout=30)
 
     def test_WHEN_ioc_is_started_THEN_ioc_is_not_disabled(self):
         self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")

--- a/tests/ag53220a.py
+++ b/tests/ag53220a.py
@@ -28,7 +28,7 @@ class Ag53220ATests(unittest.TestCase):
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("Ag53220A", DEVICE_PREFIX)
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
-        self.ca.wait_for("DISABLE", timeout=30)
+        self.ca.assert_that_pv_exists("DISABLE", timeout=30)
 
     def test_WHEN_ioc_is_started_THEN_ioc_is_not_disabled(self):
         self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")

--- a/tests/amint2l.py
+++ b/tests/amint2l.py
@@ -48,7 +48,7 @@ class Amint2lTests(unittest.TestCase):
         self._set_pressure(expected_pressure)
 
         self.ca.assert_that_pv_is("PRESSURE", expected_pressure)
-        self.ca.assert_that_pv_alarm_is("PRESSURE", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("PRESSURE", self.ca.Alarms.NONE)
         self.ca.assert_that_pv_is("RANGE:ERROR", "No Error")
 
     def test_GIVEN_negative_pressure_set_WHEN_read_THEN_pressure_is_as_expected(self):
@@ -68,7 +68,7 @@ class Amint2lTests(unittest.TestCase):
         expected_pressure = "OR"
         self._set_pressure(expected_pressure)
 
-        self.ca.assert_that_pv_alarm_is("PRESSURE", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("PRESSURE", self.ca.Alarms.INVALID)
         self.ca.assert_that_pv_is("RANGE:ERROR", "Over Range")
 
     @skip_if_recsim("In rec sim this test fails")
@@ -76,7 +76,7 @@ class Amint2lTests(unittest.TestCase):
         expected_pressure = "UR"
         self._set_pressure(expected_pressure)
 
-        self.ca.assert_that_pv_alarm_is("PRESSURE", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("PRESSURE", self.ca.Alarms.INVALID)
         self.ca.assert_that_pv_is("RANGE:ERROR", "Under Range")
 
     @skip_if_recsim("In rec sim this test fails")
@@ -85,4 +85,4 @@ class Amint2lTests(unittest.TestCase):
         # Setting none simulates no response from device which is like pulling the serial cable. Disconnecting the
         # emulator using the backdoor makes the record go udf not timeout which is what the actual device does.
 
-        self.ca.assert_that_pv_alarm_is("PRESSURE", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("PRESSURE", self.ca.Alarms.INVALID)

--- a/tests/amint2l.py
+++ b/tests/amint2l.py
@@ -48,7 +48,7 @@ class Amint2lTests(unittest.TestCase):
         self._set_pressure(expected_pressure)
 
         self.ca.assert_that_pv_is("PRESSURE", expected_pressure)
-        self.ca.assert_pv_alarm_is("PRESSURE", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("PRESSURE", ChannelAccess.ALARM_NONE)
         self.ca.assert_that_pv_is("RANGE:ERROR", "No Error")
 
     def test_GIVEN_negative_pressure_set_WHEN_read_THEN_pressure_is_as_expected(self):
@@ -68,7 +68,7 @@ class Amint2lTests(unittest.TestCase):
         expected_pressure = "OR"
         self._set_pressure(expected_pressure)
 
-        self.ca.assert_pv_alarm_is("PRESSURE", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("PRESSURE", ChannelAccess.ALARM_INVALID)
         self.ca.assert_that_pv_is("RANGE:ERROR", "Over Range")
 
     @skip_if_recsim("In rec sim this test fails")
@@ -76,7 +76,7 @@ class Amint2lTests(unittest.TestCase):
         expected_pressure = "UR"
         self._set_pressure(expected_pressure)
 
-        self.ca.assert_pv_alarm_is("PRESSURE", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("PRESSURE", ChannelAccess.ALARM_INVALID)
         self.ca.assert_that_pv_is("RANGE:ERROR", "Under Range")
 
     @skip_if_recsim("In rec sim this test fails")
@@ -85,4 +85,4 @@ class Amint2lTests(unittest.TestCase):
         # Setting none simulates no response from device which is like pulling the serial cable. Disconnecting the
         # emulator using the backdoor makes the record go udf not timeout which is what the actual device does.
 
-        self.ca.assert_pv_alarm_is("PRESSURE", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("PRESSURE", ChannelAccess.ALARM_INVALID)

--- a/tests/cybaman.py
+++ b/tests/cybaman.py
@@ -37,12 +37,12 @@ class CybamanTests(unittest.TestCase):
         self._lewis, self._ioc = get_running_lewis_and_ioc("cybaman", DEVICE_PREFIX)
 
         self.ca = ChannelAccess(default_timeout=20, device_prefix=DEVICE_PREFIX)
-        self.ca.wait_for("INITIALIZE", timeout=30)
+        self.ca.assert_that_pv_exists("INITIALIZE", timeout=30)
 
         # Check that all the relevant PVs are up.
         for axis in self.AXES:
-            self.ca.wait_for(axis)
-            self.ca.wait_for("{}:SP".format(axis))
+            self.ca.assert_that_pv_exists(axis)
+            self.ca.assert_that_pv_exists("{}:SP".format(axis))
 
         # Initialize the device, do this in setup to avoid doing it in every test
         self.ca.set_pv_value("INITIALIZE", 1)
@@ -76,7 +76,7 @@ class CybamanTests(unittest.TestCase):
         self.ca.assert_that_pv_is("INITIALIZED", "FALSE")
         self.ca.set_pv_value("INITIALIZE", 1)
         self.ca.assert_that_pv_is("INITIALIZED", "TRUE")
-        self.ca.assert_pv_value_over_time("INITIALIZED", 10, operator.eq)
+        self.ca.assert_that_pv_value_over_time_satisfies_comparator("INITIALIZED", 10, operator.eq)
 
         original = {}
         for axis in self.AXES:
@@ -188,7 +188,7 @@ class CybamanTests(unittest.TestCase):
         # Wait for homing to start
         sleep(2)
         # Assert that A has stopped moving (i.e. homing is finished)
-        self.ca.assert_pv_value_over_time("A", 5, operator.eq)
+        self.ca.assert_that_pv_value_over_time_satisfies_comparator("A", 5, operator.eq)
         home_position = self.ca.get_pv_value("A")
 
         # Modify an unrelated setpoint
@@ -197,4 +197,4 @@ class CybamanTests(unittest.TestCase):
 
         # Verify that A has not changed from it's home position
         self.ca.assert_that_pv_is_number("A", home_position, tolerance=0.01)
-        self.ca.assert_pv_value_over_time("A", 5, operator.eq)
+        self.ca.assert_that_pv_value_over_time_satisfies_comparator("A", 5, operator.eq)

--- a/tests/cybaman.py
+++ b/tests/cybaman.py
@@ -76,7 +76,7 @@ class CybamanTests(unittest.TestCase):
         self.ca.assert_that_pv_is("INITIALIZED", "FALSE")
         self.ca.set_pv_value("INITIALIZE", 1)
         self.ca.assert_that_pv_is("INITIALIZED", "TRUE")
-        self.ca.assert_that_pv_value_over_time_satisfies_comparator("INITIALIZED", 10, operator.eq)
+        self.ca.assert_that_pv_value_is_unchanged("INITIALIZED", 10)
 
         original = {}
         for axis in self.AXES:
@@ -188,7 +188,7 @@ class CybamanTests(unittest.TestCase):
         # Wait for homing to start
         sleep(2)
         # Assert that A has stopped moving (i.e. homing is finished)
-        self.ca.assert_that_pv_value_over_time_satisfies_comparator("A", 5, operator.eq)
+        self.ca.assert_that_pv_value_is_unchanged("A", 5)
         home_position = self.ca.get_pv_value("A")
 
         # Modify an unrelated setpoint
@@ -197,4 +197,4 @@ class CybamanTests(unittest.TestCase):
 
         # Verify that A has not changed from it's home position
         self.ca.assert_that_pv_is_number("A", home_position, tolerance=0.01)
-        self.ca.assert_that_pv_value_over_time_satisfies_comparator("A", 5, operator.eq)
+        self.ca.assert_that_pv_value_is_unchanged("A", 5)

--- a/tests/egxcolim.py
+++ b/tests/egxcolim.py
@@ -31,7 +31,7 @@ class EgxcolimTests(unittest.TestCase):
         self._ioc = IOCRegister.get_running(DEVICE_PREFIX)
 
         self.ca = ChannelAccess(20, device_prefix=DEVICE_PREFIX)
-        self.ca.wait_for("DISABLE", timeout=30)
+        self.ca.assert_that_pv_exists("DISABLE", timeout=30)
 
     def test_WHEN_ioc_is_started_THEN_ioc_is_not_disabled(self):
         self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")

--- a/tests/eurotherm.py
+++ b/tests/eurotherm.py
@@ -46,8 +46,8 @@ class EurothermTests(unittest.TestCase):
     def _setup_lewis_and_channel_access(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("eurotherm", DEVICE)
         self.ca = ChannelAccess(device_prefix=PREFIX)
-        self.ca.wait_for(RBV_PV, timeout=30)
-        self.ca.wait_for("CAL:SEL", timeout=10)
+        self.ca.assert_that_pv_exists(RBV_PV, timeout=30)
+        self.ca.assert_that_pv_exists("CAL:SEL", timeout=10)
         self._lewis.backdoor_set_on_device("address", ADDRESS)
 
     def _reset_device_state(self):
@@ -65,7 +65,7 @@ class EurothermTests(unittest.TestCase):
         self._set_setpoint_and_current_temperature(intial_temp)
         self.ca.assert_that_pv_is("TEMP", intial_temp)
         # Ensure the temperature isn't being changed by a ramp any more
-        self.ca.assert_pv_value_is_unchanged("TEMP", 5)
+        self.ca.assert_that_pv_value_is_unchanged("TEMP", 5)
 
     def _set_setpoint_and_current_temperature(self, temperature):
         if IOCRegister.uses_rec_sim:

--- a/tests/fermi_chopper_lifter.py
+++ b/tests/fermi_chopper_lifter.py
@@ -33,7 +33,7 @@ class FermiChopperLifterTests(unittest.TestCase):
     def setUp(self):
         self._ioc = IOCRegister.get_running("GALIL_01")
         self.ca = ChannelAccess(default_timeout=30)
-        self.ca.wait_for("MOT:CHOPLIFT:STATUS", timeout=60)
+        self.ca.assert_that_pv_exists("MOT:CHOPLIFT:STATUS", timeout=60)
 
     def test_WHEN_ioc_is_run_THEN_status_record_exists(self):
         # Simulated galil user variables are initialized to zero which maps to "Unknown".

--- a/tests/fermichopper_merlin.py
+++ b/tests/fermichopper_merlin.py
@@ -39,14 +39,14 @@ class MerlinFermiChopperTests(FermichopperBase):
         for temp in self.test_temperature_values:
             self._lewis.backdoor_set_on_device("electronics_temp", temp)
             self.ca.assert_that_pv_is_number("TEMP:ELECTRONICS", temp, tolerance=0.2)
-            self.ca.assert_pv_alarm_is("TEMP:ELECTRONICS", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("TEMP:ELECTRONICS", self.ca.Alarms.NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_WHEN_the_motor_temperature_is_set_via_backdoor_THEN_pv_updates(self):
         for temp in self.test_temperature_values:
             self._lewis.backdoor_set_on_device("motor_temp", temp)
             self.ca.assert_that_pv_is_number("TEMP:MOTOR", temp, tolerance=0.2)
-            self.ca.assert_pv_alarm_is("TEMP:MOTOR", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("TEMP:MOTOR", self.ca.Alarms.NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_WHEN_chopper_parameters_are_set_THEN_status_updates(self):
@@ -80,7 +80,7 @@ class MerlinFermiChopperTests(FermichopperBase):
         for voltage in self.test_voltage_values:
             self._lewis.backdoor_set_on_device("voltage", voltage)
             self.ca.assert_that_pv_is_number("VOLTAGE", voltage, tolerance=0.1)
-            self.ca.assert_pv_alarm_is("VOLTAGE", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("VOLTAGE", self.ca.Alarms.NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_WHEN_motor_temperature_is_too_high_THEN_switch_drive_off_is_sent(self):

--- a/tests/fermichopper_merlin.py
+++ b/tests/fermichopper_merlin.py
@@ -39,14 +39,14 @@ class MerlinFermiChopperTests(FermichopperBase):
         for temp in self.test_temperature_values:
             self._lewis.backdoor_set_on_device("electronics_temp", temp)
             self.ca.assert_that_pv_is_number("TEMP:ELECTRONICS", temp, tolerance=0.2)
-            self.ca.assert_pv_alarm_is("TEMP:ELECTRONICS", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("TEMP:ELECTRONICS", self.ca.Alarms.NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_WHEN_the_motor_temperature_is_set_via_backdoor_THEN_pv_updates(self):
         for temp in self.test_temperature_values:
             self._lewis.backdoor_set_on_device("motor_temp", temp)
             self.ca.assert_that_pv_is_number("TEMP:MOTOR", temp, tolerance=0.2)
-            self.ca.assert_pv_alarm_is("TEMP:MOTOR", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("TEMP:MOTOR", self.ca.Alarms.NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_WHEN_chopper_parameters_are_set_THEN_status_updates(self):
@@ -80,7 +80,7 @@ class MerlinFermiChopperTests(FermichopperBase):
         for voltage in self.test_voltage_values:
             self._lewis.backdoor_set_on_device("voltage", voltage)
             self.ca.assert_that_pv_is_number("VOLTAGE", voltage, tolerance=0.1)
-            self.ca.assert_pv_alarm_is("VOLTAGE", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("VOLTAGE", self.ca.Alarms.NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_WHEN_motor_temperature_is_too_high_THEN_switch_drive_off_is_sent(self):

--- a/tests/fzj_dd_fermi_chopper.py
+++ b/tests/fzj_dd_fermi_chopper.py
@@ -128,7 +128,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self._set_simulated_value("frequency_setpoint", expected_value)
 
         self.ca.assert_that_pv_is("FREQ:SP:RBV", expected_value)
-        self.ca.assert_pv_alarm_is("FREQ:SP:RBV", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("FREQ:SP:RBV", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_phase_setpoint_WHEN_read_all_status_THEN_value_is_as_expected(self):
@@ -136,7 +136,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self._set_simulated_value("phase_setpoint", expected_value)
 
         self.ca.assert_that_pv_is("PHAS:SP:RBV", expected_value)
-        self.ca.assert_pv_alarm_is("PHAS:SP:RBV", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("PHAS:SP:RBV", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_phase_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -144,7 +144,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("phase_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("PHAS:STAT", expected_value)
-            self.ca.assert_pv_alarm_is("PHAS:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("PHAS:STAT", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_magnetic_bearing_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -152,7 +152,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("magnetic_bearing_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("MB:STAT", expected_value)
-            self.ca.assert_pv_alarm_is("MB:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("MB:STAT", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_magnetic_bearing_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -160,7 +160,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("magnetic_bearing_is_on", boolean_value)
 
             self.ca.assert_that_pv_is("MB", expected_value)
-            self.ca.assert_pv_alarm_is("MB", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("MB", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -168,7 +168,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("drive_is_on", boolean_value)
 
             self.ca.assert_that_pv_is("DRIVE", expected_value)
-            self.ca.assert_pv_alarm_is("DRIVE", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("DRIVE", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_mode_WHEN_read_all_status_THEN_value_is_as_expected(self):
@@ -176,7 +176,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("drive_mode_is_start", boolean_value)
 
             self.ca.assert_that_pv_is("DRIVE:MODE", expected_value)
-            self.ca.assert_pv_alarm_is("DRIVE:MODE", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("DRIVE:MODE", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_l1_current_WHEN_read_all_status_THEN_value_is_as_expected(self):
@@ -184,7 +184,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self._set_simulated_value("drive_l1_current", expected_value)
 
         self.ca.assert_that_pv_is("DRIVE:L1:CURR", expected_value)
-        self.ca.assert_pv_alarm_is("DRIVE:L1:CURR", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("DRIVE:L1:CURR", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_l2_current_WHEN_read_all_status_THEN_value_is_as_expected(self):
@@ -192,7 +192,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self._set_simulated_value("drive_l2_current", expected_value)
 
         self.ca.assert_that_pv_is("DRIVE:L2:CURR", expected_value)
-        self.ca.assert_pv_alarm_is("DRIVE:L2:CURR", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("DRIVE:L2:CURR", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_l3_current_WHEN_read_all_status_THEN_value_is_as_expected(self):
@@ -200,7 +200,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self._set_simulated_value("drive_l3_current", expected_value)
 
         self.ca.assert_that_pv_is("DRIVE:L3:CURR", expected_value)
-        self.ca.assert_pv_alarm_is("DRIVE:L3:CURR", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("DRIVE:L3:CURR", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_direction_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -208,7 +208,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("drive_direction_is_cw", boolean_value)
 
             self.ca.assert_that_pv_is("DRIVE:DIR", expected_value)
-            self.ca.assert_pv_alarm_is("DRIVE:DIR", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("DRIVE:DIR", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_temperature_WHEN_read_all_status_THEN_value_is_as_expected(self):
@@ -216,7 +216,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self._set_simulated_value("drive_temperature", expected_value)
 
         self.ca.assert_that_pv_is("DRIVE:TEMP", expected_value)
-        self.ca.assert_pv_alarm_is("DRIVE:TEMP", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("DRIVE:TEMP", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_phase_outage_WHEN_read_all_status_THEN_value_is_as_expected(self):
@@ -224,7 +224,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self._set_simulated_value("phase_outage", expected_value)
 
         self.ca.assert_that_pv_is("PHAS:OUTAGE", expected_value)
-        self.ca.assert_pv_alarm_is("PHAS:OUTAGE", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("PHAS:OUTAGE", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_logging_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -232,7 +232,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("logging_is_on", boolean_value)
 
             self.ca.assert_that_pv_is("LOGGING", expected_value)
-            self.ca.assert_pv_alarm_is("LOGGING", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("LOGGING", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_dsp_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -240,7 +240,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("dsp_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("DSP:STAT", expected_value)
-            self.ca.assert_pv_alarm_is("DSP:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("DSP:STAT", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_er_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -248,7 +248,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("interlock_er_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("INTERLOCK:ER:STAT", expected_value)
-            self.ca.assert_pv_alarm_is("INTERLOCK:ER:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("INTERLOCK:ER:STAT", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_vacuum_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -256,7 +256,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("interlock_vacuum_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("INTERLOCK:VAC:STAT", expected_value)
-            self.ca.assert_pv_alarm_is("INTERLOCK:VAC:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("INTERLOCK:VAC:STAT", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_frequency_monitoring_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -264,7 +264,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("interlock_frequency_monitoring_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("INTERLOCK:FREQMON:STAT", expected_value)
-            self.ca.assert_pv_alarm_is("INTERLOCK:FREQMON:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("INTERLOCK:FREQMON:STAT", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_magnetic_bearing_amplifier_temperature_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -272,7 +272,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("interlock_magnetic_bearing_amplifier_temperature_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("INTERLOCK:MB:AMP:TEMP:STAT", expected_value)
-            self.ca.assert_pv_alarm_is("INTERLOCK:MB:AMP:TEMP:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("INTERLOCK:MB:AMP:TEMP:STAT", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_magnetic_bearing_amplifier_current_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -280,7 +280,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("interlock_magnetic_bearing_amplifier_current_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("INTERLOCK:MB:AMP:CURR:STAT", expected_value)
-            self.ca.assert_pv_alarm_is("INTERLOCK:MB:AMP:CURR:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("INTERLOCK:MB:AMP:CURR:STAT", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_drive_amplifier_temperature_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -288,7 +288,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("interlock_drive_amplifier_temperature_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("INTERLOCK:DRIVE:AMP:TEMP:STAT", expected_value)
-            self.ca.assert_pv_alarm_is("INTERLOCK:DRIVE:AMP:TEMP:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("INTERLOCK:DRIVE:AMP:TEMP:STAT", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_drive_amplifier_current_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -296,7 +296,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("interlock_drive_amplifier_current_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("INTERLOCK:DRIVE:AMP:CURR:STAT", expected_value)
-            self.ca.assert_pv_alarm_is("INTERLOCK:DRIVE:AMP:CURR:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("INTERLOCK:DRIVE:AMP:CURR:STAT", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_ups_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -304,7 +304,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("interlock_ups_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("INTERLOCK:UPS:STAT", expected_value)
-            self.ca.assert_pv_alarm_is("INTERLOCK:UPS:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("INTERLOCK:UPS:STAT", ChannelAccess.ALARM_NONE)
 
     # ***** Test set commands *****
 
@@ -319,7 +319,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("FREQ:SP", str(frequency))
 
         self.ca.assert_that_pv_is_number("FREQ", frequency, timeout=30)
-        self.ca.assert_pv_alarm_is("FREQ", self.ca.Alarms.NONE)
+        self.ca.assert_that_pv_alarm_is("FREQ", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses mbbo record - incompatible with RECSIM")
     def test_GIVEN_drive_mode_is_stop_WHEN_frequency_setpoint_is_set_THEN_frequency_is_zero(self):
@@ -330,7 +330,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("FREQ:SP", str(frequency))
 
         self.ca.assert_that_pv_is_number("FREQ", 0, timeout=30)
-        self.ca.assert_pv_alarm_is("FREQ", self.ca.Alarms.NONE)
+        self.ca.assert_that_pv_alarm_is("FREQ", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses mbbo record - incompatible with RECSIM")
     def test_GIVEN_frequency_setpoint_is_set_WHEN_drive_mode_is_start_THEN_frequency_reaches_setpoint(self):
@@ -341,7 +341,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("DRIVE:MODE:SP", START_STOP[True])
 
         self.ca.assert_that_pv_is_number("FREQ", frequency, timeout=30)
-        self.ca.assert_pv_alarm_is("FREQ", self.ca.Alarms.NONE)
+        self.ca.assert_that_pv_alarm_is("FREQ", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses mbbo record - incompatible with RECSIM")
     def test_GIVEN_frequency_setpoint_is_set_WHEN_drive_mode_is_stop_THEN_frequency_is_zero(self):
@@ -352,7 +352,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("DRIVE:MODE:SP", START_STOP[False])
 
         self.ca.assert_that_pv_is_number("FREQ", 0, timeout=30)
-        self.ca.assert_pv_alarm_is("FREQ", self.ca.Alarms.NONE)
+        self.ca.assert_that_pv_alarm_is("FREQ", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses mbbo record - incompatible with RECSIM")
     def test_WHEN_frequency_setpoint_is_set_THEN_readback_updates(self):
@@ -361,9 +361,9 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("FREQ:SP", frequency_as_string)
 
         self.ca.assert_that_pv_is("FREQ:SP", frequency_as_string)
-        self.ca.assert_pv_alarm_is("FREQ:SP", self.ca.Alarms.NONE)
+        self.ca.assert_that_pv_alarm_is("FREQ:SP", self.ca.Alarms.NONE)
         self.ca.assert_that_pv_is("FREQ:SP:RBV", frequency)
-        self.ca.assert_pv_alarm_is("FREQ:SP:RBV", self.ca.Alarms.NONE)
+        self.ca.assert_that_pv_alarm_is("FREQ:SP:RBV", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set error")
     def test_GIVEN_error_WHEN_set_frequency_THEN_error_is_handled(self):
@@ -373,7 +373,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self._lewis.backdoor_set_on_device("error_on_set_frequency", expected_error)
         self.ca.set_pv_value("FREQ:SP", frequency_as_string)
 
-        self.ca.assert_pv_alarm_is("FREQ:SP", self.ca.Alarms.INVALID)
+        self.ca.assert_that_pv_alarm_is("FREQ:SP", self.ca.Alarms.INVALID)
         self.ca.assert_that_pv_is("FREQ:SP:ERROR", expected_error)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set error")
@@ -383,7 +383,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         expected_error = "07;C01NOK;RATIO_SPEED_OUT_OF_RANGE"
         self._lewis.backdoor_set_on_device("error_on_set_frequency", expected_error)
         self.ca.set_pv_value("FREQ:SP", frequency_as_string)
-        self.ca.assert_pv_alarm_is("FREQ:SP", self.ca.Alarms.INVALID)
+        self.ca.assert_that_pv_alarm_is("FREQ:SP", self.ca.Alarms.INVALID)
         self.ca.assert_that_pv_is("FREQ:SP:ERROR", expected_error)
         self._lewis.backdoor_set_on_device("error_on_set_frequency", None)
 
@@ -402,7 +402,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("PHAS:SP", phase)
 
         self.ca.assert_that_pv_is_number("PHAS", phase, timeout=30)
-        self.ca.assert_pv_alarm_is("PHAS", self.ca.Alarms.NONE)
+        self.ca.assert_that_pv_alarm_is("PHAS", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS to implement state machine.  Depends on current state.")
     def test_GIVEN_drive_mode_is_stop_WHEN_phase_setpoint_is_set_THEN_phase_is_zero(self):
@@ -413,7 +413,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("PHAS:SP", phase)
 
         self.ca.assert_that_pv_is_number("PHAS", 0, timeout=30)
-        self.ca.assert_pv_alarm_is("PHAS", self.ca.Alarms.NONE)
+        self.ca.assert_that_pv_alarm_is("PHAS", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS to implement state machine.  Depends on current state.")
     def test_GIVEN_phase_setpoint_is_set_WHEN_drive_mode_is_start_THEN_phase_reaches_setpoint(self):
@@ -424,7 +424,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("DRIVE:MODE:SP", START_STOP[True])
 
         self.ca.assert_that_pv_is_number("PHAS", phase, timeout=30)
-        self.ca.assert_pv_alarm_is("PHAS", self.ca.Alarms.NONE)
+        self.ca.assert_that_pv_alarm_is("PHAS", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS to implement state machine.  Depends on current state.")
     def test_GIVEN_phase_setpoint_is_set_WHEN_drive_mode_is_stop_THEN_phase_is_zero(self):
@@ -435,7 +435,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("DRIVE:MODE:SP", START_STOP[False])
 
         self.ca.assert_that_pv_is_number("PHAS", 0, timeout=30)
-        self.ca.assert_pv_alarm_is("PHAS", self.ca.Alarms.NONE)
+        self.ca.assert_that_pv_alarm_is("PHAS", self.ca.Alarms.NONE)
 
     @skip_if_recsim("PHAS:SP:RBV pushed from protocol")
     def test_WHEN_phase_setpoint_is_set_THEN_readback_updates(self):
@@ -443,9 +443,9 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("PHAS:SP", phase)
 
         self.ca.assert_that_pv_is("PHAS:SP", phase)
-        self.ca.assert_pv_alarm_is("PHAS:SP", self.ca.Alarms.NONE)
+        self.ca.assert_that_pv_alarm_is("PHAS:SP", self.ca.Alarms.NONE)
         self.ca.assert_that_pv_is("PHAS:SP:RBV", phase)
-        self.ca.assert_pv_alarm_is("PHAS:SP:RBV", self.ca.Alarms.NONE)
+        self.ca.assert_that_pv_alarm_is("PHAS:SP:RBV", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set error")
     def test_GIVEN_error_WHEN_set_phase_THEN_error_is_handled(self):
@@ -454,7 +454,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self._lewis.backdoor_set_on_device("error_on_set_phase", expected_error)
         self.ca.set_pv_value("PHAS:SP", phase)
 
-        self.ca.assert_pv_alarm_is("PHAS:SP", self.ca.Alarms.INVALID)
+        self.ca.assert_that_pv_alarm_is("PHAS:SP", self.ca.Alarms.INVALID)
         self.ca.assert_that_pv_is("PHAS:SP:ERROR", expected_error)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set error")
@@ -463,7 +463,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         expected_error = "09;CxxNOK;SETPOINT_PHASE_OUT_OF_RANGE"
         self._lewis.backdoor_set_on_device("error_on_set_phase", expected_error)
         self.ca.set_pv_value("PHAS:SP", phase)
-        self.ca.assert_pv_alarm_is("PHAS:SP", self.ca.Alarms.INVALID)
+        self.ca.assert_that_pv_alarm_is("PHAS:SP", self.ca.Alarms.INVALID)
         self.ca.assert_that_pv_is("PHAS:SP:ERROR", expected_error)
         self._lewis.backdoor_set_on_device("error_on_set_phase", None)
 
@@ -479,9 +479,9 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.set_pv_value("MB:SP", magnetic_bearing)
 
             self.ca.assert_that_pv_is("MB:SP", magnetic_bearing)
-            self.ca.assert_pv_alarm_is("MB:SP", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("MB:SP", self.ca.Alarms.NONE)
             self.ca.assert_that_pv_is("MB", magnetic_bearing)
-            self.ca.assert_pv_alarm_is("MB", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("MB", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set error")
     def test_GIVEN_error_WHEN_set_magnetic_bearing_is_on_THEN_error_is_handled(self):
@@ -490,7 +490,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._lewis.backdoor_set_on_device("error_on_set_magnetic_bearing", expected_error)
             self.ca.set_pv_value("MB:SP", magnetic_bearing)
 
-            self.ca.assert_pv_alarm_is("MB:SP", self.ca.Alarms.INVALID)
+            self.ca.assert_that_pv_alarm_is("MB:SP", self.ca.Alarms.INVALID)
             self.ca.assert_that_pv_is("MB:SP:ERROR", expected_error)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set error")
@@ -499,7 +499,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             expected_error = "10;CxxNOK;MAGNETIC_BEARING_NOT_OK"
             self._lewis.backdoor_set_on_device("error_on_set_magnetic_bearing", expected_error)
             self.ca.set_pv_value("MB:SP", magnetic_bearing)
-            self.ca.assert_pv_alarm_is("MB:SP", self.ca.Alarms.INVALID)
+            self.ca.assert_that_pv_alarm_is("MB:SP", self.ca.Alarms.INVALID)
             self.ca.assert_that_pv_is("MB:SP:ERROR", expected_error)
             self._lewis.backdoor_set_on_device("error_on_set_magnetic_bearing", None)
 
@@ -515,9 +515,9 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.set_pv_value("DRIVE:MODE:SP", drive_mode)
 
             self.ca.assert_that_pv_is("DRIVE:MODE:SP", drive_mode)
-            self.ca.assert_pv_alarm_is("DRIVE:MODE:SP", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("DRIVE:MODE:SP", self.ca.Alarms.NONE)
             self.ca.assert_that_pv_is("DRIVE:MODE", drive_mode)
-            self.ca.assert_pv_alarm_is("DRIVE:MODE", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("DRIVE:MODE", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set error")
     def test_GIVEN_error_WHEN_set_drive_mode_is_start_THEN_error_is_handled(self):
@@ -526,7 +526,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._lewis.backdoor_set_on_device("error_on_set_drive_mode", expected_error)
             self.ca.set_pv_value("DRIVE:MODE:SP", drive_mode)
 
-            self.ca.assert_pv_alarm_is("DRIVE:MODE:SP", self.ca.Alarms.INVALID)
+            self.ca.assert_that_pv_alarm_is("DRIVE:MODE:SP", self.ca.Alarms.INVALID)
             self.ca.assert_that_pv_is("DRIVE:MODE:SP:ERROR", expected_error)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set error")
@@ -535,7 +535,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             expected_error = "10;CxxNOK;MAGNETIC_BEARING_NOT_OK"
             self._lewis.backdoor_set_on_device("error_on_set_drive_mode", expected_error)
             self.ca.set_pv_value("DRIVE:MODE:SP", drive_mode)
-            self.ca.assert_pv_alarm_is("DRIVE:MODE:SP", self.ca.Alarms.INVALID)
+            self.ca.assert_that_pv_alarm_is("DRIVE:MODE:SP", self.ca.Alarms.INVALID)
             self.ca.assert_that_pv_is("DRIVE:MODE:SP:ERROR", expected_error)
             self._lewis.backdoor_set_on_device("error_on_set_drive_mode", None)
 
@@ -573,4 +573,4 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
                    "INTERLOCK:DRIVE:AMP:CURR:STAT",
                    "INTERLOCK:UPS:STAT"]:
 
-            self.ca.assert_pv_alarm_is(pv, ChannelAccess.ALARM_INVALID)
+            self.ca.assert_that_pv_alarm_is(pv, ChannelAccess.ALARM_INVALID)

--- a/tests/fzj_dd_fermi_chopper.py
+++ b/tests/fzj_dd_fermi_chopper.py
@@ -128,7 +128,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self._set_simulated_value("frequency_setpoint", expected_value)
 
         self.ca.assert_that_pv_is("FREQ:SP:RBV", expected_value)
-        self.ca.assert_that_pv_alarm_is("FREQ:SP:RBV", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("FREQ:SP:RBV", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_phase_setpoint_WHEN_read_all_status_THEN_value_is_as_expected(self):
@@ -136,7 +136,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self._set_simulated_value("phase_setpoint", expected_value)
 
         self.ca.assert_that_pv_is("PHAS:SP:RBV", expected_value)
-        self.ca.assert_that_pv_alarm_is("PHAS:SP:RBV", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("PHAS:SP:RBV", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_phase_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -144,7 +144,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("phase_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("PHAS:STAT", expected_value)
-            self.ca.assert_that_pv_alarm_is("PHAS:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("PHAS:STAT", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_magnetic_bearing_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -152,7 +152,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("magnetic_bearing_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("MB:STAT", expected_value)
-            self.ca.assert_that_pv_alarm_is("MB:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("MB:STAT", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_magnetic_bearing_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -160,7 +160,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("magnetic_bearing_is_on", boolean_value)
 
             self.ca.assert_that_pv_is("MB", expected_value)
-            self.ca.assert_that_pv_alarm_is("MB", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("MB", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -168,7 +168,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("drive_is_on", boolean_value)
 
             self.ca.assert_that_pv_is("DRIVE", expected_value)
-            self.ca.assert_that_pv_alarm_is("DRIVE", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("DRIVE", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_mode_WHEN_read_all_status_THEN_value_is_as_expected(self):
@@ -176,7 +176,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("drive_mode_is_start", boolean_value)
 
             self.ca.assert_that_pv_is("DRIVE:MODE", expected_value)
-            self.ca.assert_that_pv_alarm_is("DRIVE:MODE", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("DRIVE:MODE", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_l1_current_WHEN_read_all_status_THEN_value_is_as_expected(self):
@@ -184,7 +184,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self._set_simulated_value("drive_l1_current", expected_value)
 
         self.ca.assert_that_pv_is("DRIVE:L1:CURR", expected_value)
-        self.ca.assert_that_pv_alarm_is("DRIVE:L1:CURR", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("DRIVE:L1:CURR", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_l2_current_WHEN_read_all_status_THEN_value_is_as_expected(self):
@@ -192,7 +192,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self._set_simulated_value("drive_l2_current", expected_value)
 
         self.ca.assert_that_pv_is("DRIVE:L2:CURR", expected_value)
-        self.ca.assert_that_pv_alarm_is("DRIVE:L2:CURR", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("DRIVE:L2:CURR", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_l3_current_WHEN_read_all_status_THEN_value_is_as_expected(self):
@@ -200,7 +200,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self._set_simulated_value("drive_l3_current", expected_value)
 
         self.ca.assert_that_pv_is("DRIVE:L3:CURR", expected_value)
-        self.ca.assert_that_pv_alarm_is("DRIVE:L3:CURR", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("DRIVE:L3:CURR", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_direction_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -208,7 +208,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("drive_direction_is_cw", boolean_value)
 
             self.ca.assert_that_pv_is("DRIVE:DIR", expected_value)
-            self.ca.assert_that_pv_alarm_is("DRIVE:DIR", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("DRIVE:DIR", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_temperature_WHEN_read_all_status_THEN_value_is_as_expected(self):
@@ -216,7 +216,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self._set_simulated_value("drive_temperature", expected_value)
 
         self.ca.assert_that_pv_is("DRIVE:TEMP", expected_value)
-        self.ca.assert_that_pv_alarm_is("DRIVE:TEMP", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("DRIVE:TEMP", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_phase_outage_WHEN_read_all_status_THEN_value_is_as_expected(self):
@@ -224,7 +224,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self._set_simulated_value("phase_outage", expected_value)
 
         self.ca.assert_that_pv_is("PHAS:OUTAGE", expected_value)
-        self.ca.assert_that_pv_alarm_is("PHAS:OUTAGE", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("PHAS:OUTAGE", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_logging_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -232,7 +232,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("logging_is_on", boolean_value)
 
             self.ca.assert_that_pv_is("LOGGING", expected_value)
-            self.ca.assert_that_pv_alarm_is("LOGGING", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("LOGGING", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_dsp_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -240,7 +240,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("dsp_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("DSP:STAT", expected_value)
-            self.ca.assert_that_pv_alarm_is("DSP:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("DSP:STAT", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_er_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -248,7 +248,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("interlock_er_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("INTERLOCK:ER:STAT", expected_value)
-            self.ca.assert_that_pv_alarm_is("INTERLOCK:ER:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("INTERLOCK:ER:STAT", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_vacuum_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -256,7 +256,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("interlock_vacuum_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("INTERLOCK:VAC:STAT", expected_value)
-            self.ca.assert_that_pv_alarm_is("INTERLOCK:VAC:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("INTERLOCK:VAC:STAT", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_frequency_monitoring_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -264,7 +264,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("interlock_frequency_monitoring_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("INTERLOCK:FREQMON:STAT", expected_value)
-            self.ca.assert_that_pv_alarm_is("INTERLOCK:FREQMON:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("INTERLOCK:FREQMON:STAT", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_magnetic_bearing_amplifier_temperature_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -272,7 +272,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("interlock_magnetic_bearing_amplifier_temperature_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("INTERLOCK:MB:AMP:TEMP:STAT", expected_value)
-            self.ca.assert_that_pv_alarm_is("INTERLOCK:MB:AMP:TEMP:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("INTERLOCK:MB:AMP:TEMP:STAT", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_magnetic_bearing_amplifier_current_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -280,7 +280,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("interlock_magnetic_bearing_amplifier_current_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("INTERLOCK:MB:AMP:CURR:STAT", expected_value)
-            self.ca.assert_that_pv_alarm_is("INTERLOCK:MB:AMP:CURR:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("INTERLOCK:MB:AMP:CURR:STAT", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_drive_amplifier_temperature_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -288,7 +288,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("interlock_drive_amplifier_temperature_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("INTERLOCK:DRIVE:AMP:TEMP:STAT", expected_value)
-            self.ca.assert_that_pv_alarm_is("INTERLOCK:DRIVE:AMP:TEMP:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("INTERLOCK:DRIVE:AMP:TEMP:STAT", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_drive_amplifier_current_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -296,7 +296,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("interlock_drive_amplifier_current_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("INTERLOCK:DRIVE:AMP:CURR:STAT", expected_value)
-            self.ca.assert_that_pv_alarm_is("INTERLOCK:DRIVE:AMP:CURR:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("INTERLOCK:DRIVE:AMP:CURR:STAT", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_ups_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
@@ -304,7 +304,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._set_simulated_value("interlock_ups_status_is_ok", boolean_value)
 
             self.ca.assert_that_pv_is("INTERLOCK:UPS:STAT", expected_value)
-            self.ca.assert_that_pv_alarm_is("INTERLOCK:UPS:STAT", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("INTERLOCK:UPS:STAT", self.ca.Alarms.NONE)
 
     # ***** Test set commands *****
 
@@ -573,4 +573,4 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
                    "INTERLOCK:DRIVE:AMP:CURR:STAT",
                    "INTERLOCK:UPS:STAT"]:
 
-            self.ca.assert_that_pv_alarm_is(pv, ChannelAccess.ALARM_INVALID)
+            self.ca.assert_that_pv_alarm_is(pv, self.ca.Alarms.INVALID)

--- a/tests/fzj_dd_fermi_chopper.py
+++ b/tests/fzj_dd_fermi_chopper.py
@@ -319,7 +319,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("FREQ:SP", str(frequency))
 
         self.ca.assert_that_pv_is_number("FREQ", frequency, timeout=30)
-        self.ca.assert_pv_alarm_is("FREQ", self.ca.ALARM_NONE)
+        self.ca.assert_pv_alarm_is("FREQ", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses mbbo record - incompatible with RECSIM")
     def test_GIVEN_drive_mode_is_stop_WHEN_frequency_setpoint_is_set_THEN_frequency_is_zero(self):
@@ -330,7 +330,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("FREQ:SP", str(frequency))
 
         self.ca.assert_that_pv_is_number("FREQ", 0, timeout=30)
-        self.ca.assert_pv_alarm_is("FREQ", self.ca.ALARM_NONE)
+        self.ca.assert_pv_alarm_is("FREQ", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses mbbo record - incompatible with RECSIM")
     def test_GIVEN_frequency_setpoint_is_set_WHEN_drive_mode_is_start_THEN_frequency_reaches_setpoint(self):
@@ -341,7 +341,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("DRIVE:MODE:SP", START_STOP[True])
 
         self.ca.assert_that_pv_is_number("FREQ", frequency, timeout=30)
-        self.ca.assert_pv_alarm_is("FREQ", self.ca.ALARM_NONE)
+        self.ca.assert_pv_alarm_is("FREQ", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses mbbo record - incompatible with RECSIM")
     def test_GIVEN_frequency_setpoint_is_set_WHEN_drive_mode_is_stop_THEN_frequency_is_zero(self):
@@ -352,7 +352,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("DRIVE:MODE:SP", START_STOP[False])
 
         self.ca.assert_that_pv_is_number("FREQ", 0, timeout=30)
-        self.ca.assert_pv_alarm_is("FREQ", self.ca.ALARM_NONE)
+        self.ca.assert_pv_alarm_is("FREQ", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses mbbo record - incompatible with RECSIM")
     def test_WHEN_frequency_setpoint_is_set_THEN_readback_updates(self):
@@ -361,9 +361,9 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("FREQ:SP", frequency_as_string)
 
         self.ca.assert_that_pv_is("FREQ:SP", frequency_as_string)
-        self.ca.assert_pv_alarm_is("FREQ:SP", self.ca.ALARM_NONE)
+        self.ca.assert_pv_alarm_is("FREQ:SP", self.ca.Alarms.NONE)
         self.ca.assert_that_pv_is("FREQ:SP:RBV", frequency)
-        self.ca.assert_pv_alarm_is("FREQ:SP:RBV", self.ca.ALARM_NONE)
+        self.ca.assert_pv_alarm_is("FREQ:SP:RBV", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set error")
     def test_GIVEN_error_WHEN_set_frequency_THEN_error_is_handled(self):
@@ -373,7 +373,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self._lewis.backdoor_set_on_device("error_on_set_frequency", expected_error)
         self.ca.set_pv_value("FREQ:SP", frequency_as_string)
 
-        self.ca.assert_pv_alarm_is("FREQ:SP", self.ca.ALARM_INVALID)
+        self.ca.assert_pv_alarm_is("FREQ:SP", self.ca.Alarms.INVALID)
         self.ca.assert_that_pv_is("FREQ:SP:ERROR", expected_error)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set error")
@@ -383,7 +383,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         expected_error = "07;C01NOK;RATIO_SPEED_OUT_OF_RANGE"
         self._lewis.backdoor_set_on_device("error_on_set_frequency", expected_error)
         self.ca.set_pv_value("FREQ:SP", frequency_as_string)
-        self.ca.assert_pv_alarm_is("FREQ:SP", self.ca.ALARM_INVALID)
+        self.ca.assert_pv_alarm_is("FREQ:SP", self.ca.Alarms.INVALID)
         self.ca.assert_that_pv_is("FREQ:SP:ERROR", expected_error)
         self._lewis.backdoor_set_on_device("error_on_set_frequency", None)
 
@@ -402,7 +402,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("PHAS:SP", phase)
 
         self.ca.assert_that_pv_is_number("PHAS", phase, timeout=30)
-        self.ca.assert_pv_alarm_is("PHAS", self.ca.ALARM_NONE)
+        self.ca.assert_pv_alarm_is("PHAS", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS to implement state machine.  Depends on current state.")
     def test_GIVEN_drive_mode_is_stop_WHEN_phase_setpoint_is_set_THEN_phase_is_zero(self):
@@ -413,7 +413,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("PHAS:SP", phase)
 
         self.ca.assert_that_pv_is_number("PHAS", 0, timeout=30)
-        self.ca.assert_pv_alarm_is("PHAS", self.ca.ALARM_NONE)
+        self.ca.assert_pv_alarm_is("PHAS", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS to implement state machine.  Depends on current state.")
     def test_GIVEN_phase_setpoint_is_set_WHEN_drive_mode_is_start_THEN_phase_reaches_setpoint(self):
@@ -424,7 +424,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("DRIVE:MODE:SP", START_STOP[True])
 
         self.ca.assert_that_pv_is_number("PHAS", phase, timeout=30)
-        self.ca.assert_pv_alarm_is("PHAS", self.ca.ALARM_NONE)
+        self.ca.assert_pv_alarm_is("PHAS", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS to implement state machine.  Depends on current state.")
     def test_GIVEN_phase_setpoint_is_set_WHEN_drive_mode_is_stop_THEN_phase_is_zero(self):
@@ -435,7 +435,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("DRIVE:MODE:SP", START_STOP[False])
 
         self.ca.assert_that_pv_is_number("PHAS", 0, timeout=30)
-        self.ca.assert_pv_alarm_is("PHAS", self.ca.ALARM_NONE)
+        self.ca.assert_pv_alarm_is("PHAS", self.ca.Alarms.NONE)
 
     @skip_if_recsim("PHAS:SP:RBV pushed from protocol")
     def test_WHEN_phase_setpoint_is_set_THEN_readback_updates(self):
@@ -443,9 +443,9 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.set_pv_value("PHAS:SP", phase)
 
         self.ca.assert_that_pv_is("PHAS:SP", phase)
-        self.ca.assert_pv_alarm_is("PHAS:SP", self.ca.ALARM_NONE)
+        self.ca.assert_pv_alarm_is("PHAS:SP", self.ca.Alarms.NONE)
         self.ca.assert_that_pv_is("PHAS:SP:RBV", phase)
-        self.ca.assert_pv_alarm_is("PHAS:SP:RBV", self.ca.ALARM_NONE)
+        self.ca.assert_pv_alarm_is("PHAS:SP:RBV", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set error")
     def test_GIVEN_error_WHEN_set_phase_THEN_error_is_handled(self):
@@ -454,7 +454,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self._lewis.backdoor_set_on_device("error_on_set_phase", expected_error)
         self.ca.set_pv_value("PHAS:SP", phase)
 
-        self.ca.assert_pv_alarm_is("PHAS:SP", self.ca.ALARM_INVALID)
+        self.ca.assert_pv_alarm_is("PHAS:SP", self.ca.Alarms.INVALID)
         self.ca.assert_that_pv_is("PHAS:SP:ERROR", expected_error)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set error")
@@ -463,7 +463,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         expected_error = "09;CxxNOK;SETPOINT_PHASE_OUT_OF_RANGE"
         self._lewis.backdoor_set_on_device("error_on_set_phase", expected_error)
         self.ca.set_pv_value("PHAS:SP", phase)
-        self.ca.assert_pv_alarm_is("PHAS:SP", self.ca.ALARM_INVALID)
+        self.ca.assert_pv_alarm_is("PHAS:SP", self.ca.Alarms.INVALID)
         self.ca.assert_that_pv_is("PHAS:SP:ERROR", expected_error)
         self._lewis.backdoor_set_on_device("error_on_set_phase", None)
 
@@ -479,9 +479,9 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.set_pv_value("MB:SP", magnetic_bearing)
 
             self.ca.assert_that_pv_is("MB:SP", magnetic_bearing)
-            self.ca.assert_pv_alarm_is("MB:SP", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("MB:SP", self.ca.Alarms.NONE)
             self.ca.assert_that_pv_is("MB", magnetic_bearing)
-            self.ca.assert_pv_alarm_is("MB", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("MB", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set error")
     def test_GIVEN_error_WHEN_set_magnetic_bearing_is_on_THEN_error_is_handled(self):
@@ -490,7 +490,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._lewis.backdoor_set_on_device("error_on_set_magnetic_bearing", expected_error)
             self.ca.set_pv_value("MB:SP", magnetic_bearing)
 
-            self.ca.assert_pv_alarm_is("MB:SP", self.ca.ALARM_INVALID)
+            self.ca.assert_pv_alarm_is("MB:SP", self.ca.Alarms.INVALID)
             self.ca.assert_that_pv_is("MB:SP:ERROR", expected_error)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set error")
@@ -499,7 +499,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             expected_error = "10;CxxNOK;MAGNETIC_BEARING_NOT_OK"
             self._lewis.backdoor_set_on_device("error_on_set_magnetic_bearing", expected_error)
             self.ca.set_pv_value("MB:SP", magnetic_bearing)
-            self.ca.assert_pv_alarm_is("MB:SP", self.ca.ALARM_INVALID)
+            self.ca.assert_pv_alarm_is("MB:SP", self.ca.Alarms.INVALID)
             self.ca.assert_that_pv_is("MB:SP:ERROR", expected_error)
             self._lewis.backdoor_set_on_device("error_on_set_magnetic_bearing", None)
 
@@ -515,9 +515,9 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.set_pv_value("DRIVE:MODE:SP", drive_mode)
 
             self.ca.assert_that_pv_is("DRIVE:MODE:SP", drive_mode)
-            self.ca.assert_pv_alarm_is("DRIVE:MODE:SP", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("DRIVE:MODE:SP", self.ca.Alarms.NONE)
             self.ca.assert_that_pv_is("DRIVE:MODE", drive_mode)
-            self.ca.assert_pv_alarm_is("DRIVE:MODE", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("DRIVE:MODE", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set error")
     def test_GIVEN_error_WHEN_set_drive_mode_is_start_THEN_error_is_handled(self):
@@ -526,7 +526,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._lewis.backdoor_set_on_device("error_on_set_drive_mode", expected_error)
             self.ca.set_pv_value("DRIVE:MODE:SP", drive_mode)
 
-            self.ca.assert_pv_alarm_is("DRIVE:MODE:SP", self.ca.ALARM_INVALID)
+            self.ca.assert_pv_alarm_is("DRIVE:MODE:SP", self.ca.Alarms.INVALID)
             self.ca.assert_that_pv_is("DRIVE:MODE:SP:ERROR", expected_error)
 
     @skip_if_recsim("Uses LeWIS backdoor command to set error")
@@ -535,7 +535,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             expected_error = "10;CxxNOK;MAGNETIC_BEARING_NOT_OK"
             self._lewis.backdoor_set_on_device("error_on_set_drive_mode", expected_error)
             self.ca.set_pv_value("DRIVE:MODE:SP", drive_mode)
-            self.ca.assert_pv_alarm_is("DRIVE:MODE:SP", self.ca.ALARM_INVALID)
+            self.ca.assert_pv_alarm_is("DRIVE:MODE:SP", self.ca.Alarms.INVALID)
             self.ca.assert_that_pv_is("DRIVE:MODE:SP:ERROR", expected_error)
             self._lewis.backdoor_set_on_device("error_on_set_drive_mode", None)
 

--- a/tests/gem_jaws.py
+++ b/tests/gem_jaws.py
@@ -84,7 +84,7 @@ class GemJawsTests(unittest.TestCase):
         self._ioc = IOCRegister.get_running("gem_jaws")
         self.ca = ChannelAccess(default_timeout=30)
 
-        [self.ca.wait_for(mot) for mot in all_motors]
+        [self.ca.assert_that_pv_exists(mot) for mot in all_motors]
 
     def _test_readback(self, underlying_motor, calibrated_axis, to_read_func, x):
         self.ca.set_pv_value(underlying_motor, x)

--- a/tests/gemorc.py
+++ b/tests/gemorc.py
@@ -70,7 +70,7 @@ class GemorcTests(unittest.TestCase):
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("gemorc", DEVICE_PREFIX)
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX, default_timeout=DEFAULT_TIMEOUT)
-        self.ca.wait_for("ID", timeout=30)
+        self.ca.assert_that_pv_exists("ID", timeout=30)
         self.reset_ioc()
         if not IOCRegister.uses_rec_sim:
             self.reset_emulator()
@@ -215,7 +215,7 @@ class GemorcTests(unittest.TestCase):
     @skip_if_recsim("Device reset requires Lewis backdoor")
     def test_GIVEN_initialised_WHEN_oscillation_requested_THEN_complete_cycles_increases(self):
         self.start_oscillating()
-        self.ca.assert_pv_value_is_increasing("CYCLES", DEFAULT_TIMEOUT)
+        self.ca.assert_that_pv_value_is_increasing("CYCLES", DEFAULT_TIMEOUT)
 
     @skip_if_recsim("Device reset requires Lewis backdoor")
     def test_GIVEN_oscillating_WHEN_oscillation_stopped_THEN_reports_not_oscillating(self):
@@ -227,7 +227,7 @@ class GemorcTests(unittest.TestCase):
     def test_GIVEN_initialised_WHEN_oscillation_requested_THEN_complete_cycles_does_not_change(self):
         self.start_oscillating()
         self.ca.set_pv_value("STOP", 1)
-        self.ca.assert_pv_value_is_unchanged("CYCLES", DEFAULT_TIMEOUT)
+        self.ca.assert_that_pv_value_is_unchanged("CYCLES", DEFAULT_TIMEOUT)
 
     @skip_if_recsim("Device reset requires Lewis backdoor")
     def test_GIVEN_oscillating_WHEN_initialisation_requested_THEN_initialises(self):

--- a/tests/hifimag.py
+++ b/tests/hifimag.py
@@ -28,7 +28,7 @@ class HifimagTests(unittest.TestCase):
         self._ioc = IOCRegister.get_running(DEVICE_PREFIX)
 
         self.ca = ChannelAccess(20, DEVICE_PREFIX)
-        self.ca.wait_for("DISABLE", timeout=30)
+        self.ca.assert_that_pv_exists("DISABLE", timeout=30)
         
     def test_WHEN_ioc_is_started_THEN_ioc_is_not_disabled(self):
         self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")

--- a/tests/hlg.py
+++ b/tests/hlg.py
@@ -52,38 +52,38 @@ class HlgTests(unittest.TestCase):
         self._set_level(expected_level)
 
         self.ca.assert_that_pv_is("LEVEL", expected_level)
-        self.ca.assert_that_pv_alarm_is("LEVEL", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("LEVEL", self.ca.Alarms.NONE)
 
     def test_GIVEN_high_level_set_WHEN_read_THEN_minor_alarm(self):
         level = hi_level + 1
         self._set_level(level)
 
-        self.ca.assert_that_pv_alarm_is("LEVEL", ChannelAccess.ALARM_MINOR)
+        self.ca.assert_that_pv_alarm_is("LEVEL", self.ca.Alarms.MINOR)
 
     def test_GIVEN_low_level_set_WHEN_read_THEN_minor_alarm(self):
         level = low_level - 1
         self._set_level(level)
 
-        self.ca.assert_that_pv_alarm_is("LEVEL", ChannelAccess.ALARM_MINOR)
+        self.ca.assert_that_pv_alarm_is("LEVEL", self.ca.Alarms.MINOR)
 
     def test_GIVEN_hihi_level_set_WHEN_read_THEN_major_alarm(self):
         level = hihi_level + 1
         self._set_level(level)
 
-        self.ca.assert_that_pv_alarm_is("LEVEL", ChannelAccess.ALARM_MAJOR)
+        self.ca.assert_that_pv_alarm_is("LEVEL", self.ca.Alarms.MAJOR)
 
     def test_GIVEN_lolo_level_set_WHEN_read_THEN_major_alarm(self):
         level = lolo_level - 1
         self._set_level(level)
 
-        self.ca.assert_that_pv_alarm_is("LEVEL", ChannelAccess.ALARM_MAJOR)
+        self.ca.assert_that_pv_alarm_is("LEVEL", self.ca.Alarms.MAJOR)
 
     @skip_if_recsim("Can not disconnect in recsim")
     def test_GIVEN_not_connected_WHEN_read_THEN_alarm_error(self):
 
         self._set_level(None)
 
-        self.ca.assert_that_pv_alarm_is("LEVEL", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("LEVEL", self.ca.Alarms.INVALID)
 
     @skip_if_recsim("Can not set prefix in recsim")
     def test_GIVEN_prefix_set_incorrectly_WHEN_read_THEN_prefix_is_set_to_none_and_level_is_read(self):
@@ -92,7 +92,7 @@ class HlgTests(unittest.TestCase):
         self._set_level(expected_level)
 
         self.ca.assert_that_pv_is("LEVEL", expected_level)
-        self.ca.assert_that_pv_alarm_is("LEVEL", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("LEVEL", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Can not set verbosity in recsim")
     def test_GIVEN_verbosity_set_incorrectly_WHEN_read_THEN_verbosity_is_set_to_1_and_level_is_read(self):
@@ -101,4 +101,4 @@ class HlgTests(unittest.TestCase):
         self._set_level(expected_level)
 
         self.ca.assert_that_pv_is("LEVEL", expected_level)
-        self.ca.assert_that_pv_alarm_is("LEVEL", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("LEVEL", self.ca.Alarms.NONE)

--- a/tests/hlg.py
+++ b/tests/hlg.py
@@ -52,38 +52,38 @@ class HlgTests(unittest.TestCase):
         self._set_level(expected_level)
 
         self.ca.assert_that_pv_is("LEVEL", expected_level)
-        self.ca.assert_pv_alarm_is("LEVEL", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("LEVEL", ChannelAccess.ALARM_NONE)
 
     def test_GIVEN_high_level_set_WHEN_read_THEN_minor_alarm(self):
         level = hi_level + 1
         self._set_level(level)
 
-        self.ca.assert_pv_alarm_is("LEVEL", ChannelAccess.ALARM_MINOR)
+        self.ca.assert_that_pv_alarm_is("LEVEL", ChannelAccess.ALARM_MINOR)
 
     def test_GIVEN_low_level_set_WHEN_read_THEN_minor_alarm(self):
         level = low_level - 1
         self._set_level(level)
 
-        self.ca.assert_pv_alarm_is("LEVEL", ChannelAccess.ALARM_MINOR)
+        self.ca.assert_that_pv_alarm_is("LEVEL", ChannelAccess.ALARM_MINOR)
 
     def test_GIVEN_hihi_level_set_WHEN_read_THEN_major_alarm(self):
         level = hihi_level + 1
         self._set_level(level)
 
-        self.ca.assert_pv_alarm_is("LEVEL", ChannelAccess.ALARM_MAJOR)
+        self.ca.assert_that_pv_alarm_is("LEVEL", ChannelAccess.ALARM_MAJOR)
 
     def test_GIVEN_lolo_level_set_WHEN_read_THEN_major_alarm(self):
         level = lolo_level - 1
         self._set_level(level)
 
-        self.ca.assert_pv_alarm_is("LEVEL", ChannelAccess.ALARM_MAJOR)
+        self.ca.assert_that_pv_alarm_is("LEVEL", ChannelAccess.ALARM_MAJOR)
 
     @skip_if_recsim("Can not disconnect in recsim")
     def test_GIVEN_not_connected_WHEN_read_THEN_alarm_error(self):
 
         self._set_level(None)
 
-        self.ca.assert_pv_alarm_is("LEVEL", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("LEVEL", ChannelAccess.ALARM_INVALID)
 
     @skip_if_recsim("Can not set prefix in recsim")
     def test_GIVEN_prefix_set_incorrectly_WHEN_read_THEN_prefix_is_set_to_none_and_level_is_read(self):
@@ -92,7 +92,7 @@ class HlgTests(unittest.TestCase):
         self._set_level(expected_level)
 
         self.ca.assert_that_pv_is("LEVEL", expected_level)
-        self.ca.assert_pv_alarm_is("LEVEL", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("LEVEL", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Can not set verbosity in recsim")
     def test_GIVEN_verbosity_set_incorrectly_WHEN_read_THEN_verbosity_is_set_to_1_and_level_is_read(self):
@@ -101,4 +101,4 @@ class HlgTests(unittest.TestCase):
         self._set_level(expected_level)
 
         self.ca.assert_that_pv_is("LEVEL", expected_level)
-        self.ca.assert_pv_alarm_is("LEVEL", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("LEVEL", ChannelAccess.ALARM_NONE)

--- a/tests/ieg.py
+++ b/tests/ieg.py
@@ -67,7 +67,7 @@ class IegTests(unittest.TestCase):
         self._lewis, self._ioc = get_running_lewis_and_ioc("ieg", DEVICE_PREFIX)
 
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX, default_timeout=20)
-        self.ca.wait_for("DISABLE", timeout=30)
+        self.ca.assert_that_pv_exists("DISABLE", timeout=30)
 
     def test_WHEN_ioc_is_started_THEN_ioc_is_not_disabled(self):
         self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")
@@ -89,7 +89,7 @@ class IegTests(unittest.TestCase):
         for val in self.test_device_ids:
             self._lewis.backdoor_set_on_device("unique_id", val)
             self.ca.assert_that_pv_is("ID", val, timeout=30)
-            self.ca.assert_pv_alarm_is("ID", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("ID", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses lewis backdoor command")
     def test_WHEN_valve_states_are_changed_on_device_THEN_valve_state_pv_updates(self):
@@ -102,21 +102,21 @@ class IegTests(unittest.TestCase):
                     self.ca.assert_that_pv_is_number("VALVESTATE.B0", 1 if pump_valve_open else 0)
                     self.ca.assert_that_pv_is_number("VALVESTATE.B1", 1 if buffer_valve_open else 0)
                     self.ca.assert_that_pv_is_number("VALVESTATE.B2", 1 if gas_valve_open else 0)
-                    self.ca.assert_pv_alarm_is("VALVESTATE", self.ca.Alarms.NONE)
+                    self.ca.assert_that_pv_alarm_is("VALVESTATE", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses lewis backdoor command")
     def test_WHEN_valve_states_are_changed_on_device_THEN_valve_state_pv_updates(self):
         for error_num, error in self.error_codes:
             self._lewis.backdoor_set_on_device("error", error_num)
             self.ca.assert_that_pv_is("ERROR", error)
-            self.ca.assert_pv_alarm_is("ERROR", self.ca.Alarms.MAJOR if error_num else self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("ERROR", self.ca.Alarms.MAJOR if error_num else self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses lewis backdoor command")
     def test_WHEN_pressure_is_changed_on_device_THEN_raw_pressure_pv_updates(self):
         for pressure in self.test_pressures:
             self._lewis.backdoor_set_on_device("sample_pressure", pressure)
             self.ca.assert_that_pv_is("PRESSURE:RAW", pressure)
-            self.ca.assert_pv_alarm_is("PRESSURE:RAW", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("PRESSURE:RAW", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses lewis backdoor command")
     def test_WHEN_pressure_and_upper_limit_are_changed_on_device_THEN_pressure_high_pv_updates(self):
@@ -126,8 +126,8 @@ class IegTests(unittest.TestCase):
                 self._lewis.backdoor_set_on_device("sample_pressure_high_limit", upper_limit)
                 self.ca.assert_that_pv_is("PRESSURE:HIGH",
                                           "Out of range" if pressure > upper_limit else "In range")
-                self.ca.assert_pv_alarm_is("PRESSURE:HIGH",
-                                           self.ca.Alarms.MINOR if pressure > upper_limit else self.ca.Alarms.NONE)
+                self.ca.assert_that_pv_alarm_is("PRESSURE:HIGH",
+                                                self.ca.Alarms.MINOR if pressure > upper_limit else self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses lewis backdoor command")
     def test_WHEN_pressure_and_lower_limit_are_changed_on_device_THEN_pressure_low_pv_updates(self):
@@ -137,8 +137,8 @@ class IegTests(unittest.TestCase):
                 self._lewis.backdoor_set_on_device("sample_pressure_low_limit", lower_limit)
                 self.ca.assert_that_pv_is("PRESSURE:LOW",
                                           "Out of range" if pressure < lower_limit else "In range")
-                self.ca.assert_pv_alarm_is("PRESSURE:LOW",
-                                           self.ca.Alarms.MINOR if pressure < lower_limit else self.ca.Alarms.NONE)
+                self.ca.assert_that_pv_alarm_is("PRESSURE:LOW",
+                                                self.ca.Alarms.MINOR if pressure < lower_limit else self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses lewis backdoor command")
     def test_WHEN_buffer_pressure_high_is_changed_on_device_THEN_buffer_pressure_high_pv_updates(self):
@@ -149,20 +149,20 @@ class IegTests(unittest.TestCase):
             # says that 0 means 'above high threshold' and 1 is 'below high threshold'
             self.ca.assert_that_pv_is("PRESSURE:BUFFER:HIGH",
                                       "Out of range" if value else "In range")
-            self.ca.assert_pv_alarm_is("PRESSURE:BUFFER:HIGH",
-                                       self.ca.Alarms.MINOR if value else self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("PRESSURE:BUFFER:HIGH",
+                                            self.ca.Alarms.MINOR if value else self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses lewis backdoor command")
     def test_WHEN_pressure_is_over_350_THEN_displayed_as_greater_than_350_mBar(self):
         self._lewis.backdoor_set_on_device("sample_pressure", self._get_raw_from_actual(400))
         self.ca.assert_that_pv_is("PRESSURE:GUI.OSV", ">350 mbar")
-        self.ca.assert_pv_alarm_is("PRESSURE:GUI", self.ca.Alarms.MAJOR)
+        self.ca.assert_that_pv_alarm_is("PRESSURE:GUI", self.ca.Alarms.MAJOR)
 
     @skip_if_recsim("Uses lewis backdoor command")
     def test_WHEN_pressure_is_less_than_0_THEN_displayed_as_less_than_0_mBar(self):
         self._lewis.backdoor_set_on_device("sample_pressure", self._get_raw_from_actual(-10))
         self.ca.assert_that_pv_is("PRESSURE:GUI.OSV", "<0 mbar")
-        self.ca.assert_pv_alarm_is("PRESSURE:GUI", self.ca.Alarms.MAJOR)
+        self.ca.assert_that_pv_alarm_is("PRESSURE:GUI", self.ca.Alarms.MAJOR)
 
     @skip_if_recsim("Uses lewis backdoor command")
     def test_WHEN_pressure_is_set_THEN_it_is_converted_correctly_using_the_calibration(self):
@@ -172,4 +172,4 @@ class IegTests(unittest.TestCase):
             self._lewis.backdoor_set_on_device("sample_pressure", raw_pressure)
             # PRESSURE is restricted to use [0-350]. PRESSURE:CALC is unrestricted
             self.ca.assert_that_pv_is_number("PRESSURE:CALC", actual_pressure, tolerance=0.05)
-            self.ca.assert_pv_alarm_is("PRESSURE", self.ca.Alarms.NONE if .0 < actual_pressure < 350 else self.ca.Alarms.MAJOR)
+            self.ca.assert_that_pv_alarm_is("PRESSURE", self.ca.Alarms.NONE if .0 < actual_pressure < 350 else self.ca.Alarms.MAJOR)

--- a/tests/ieg.py
+++ b/tests/ieg.py
@@ -89,7 +89,7 @@ class IegTests(unittest.TestCase):
         for val in self.test_device_ids:
             self._lewis.backdoor_set_on_device("unique_id", val)
             self.ca.assert_that_pv_is("ID", val, timeout=30)
-            self.ca.assert_pv_alarm_is("ID", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("ID", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses lewis backdoor command")
     def test_WHEN_valve_states_are_changed_on_device_THEN_valve_state_pv_updates(self):
@@ -102,21 +102,21 @@ class IegTests(unittest.TestCase):
                     self.ca.assert_that_pv_is_number("VALVESTATE.B0", 1 if pump_valve_open else 0)
                     self.ca.assert_that_pv_is_number("VALVESTATE.B1", 1 if buffer_valve_open else 0)
                     self.ca.assert_that_pv_is_number("VALVESTATE.B2", 1 if gas_valve_open else 0)
-                    self.ca.assert_pv_alarm_is("VALVESTATE", self.ca.ALARM_NONE)
+                    self.ca.assert_pv_alarm_is("VALVESTATE", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses lewis backdoor command")
     def test_WHEN_valve_states_are_changed_on_device_THEN_valve_state_pv_updates(self):
         for error_num, error in self.error_codes:
             self._lewis.backdoor_set_on_device("error", error_num)
             self.ca.assert_that_pv_is("ERROR", error)
-            self.ca.assert_pv_alarm_is("ERROR", self.ca.ALARM_MAJOR if error_num else self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("ERROR", self.ca.Alarms.MAJOR if error_num else self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses lewis backdoor command")
     def test_WHEN_pressure_is_changed_on_device_THEN_raw_pressure_pv_updates(self):
         for pressure in self.test_pressures:
             self._lewis.backdoor_set_on_device("sample_pressure", pressure)
             self.ca.assert_that_pv_is("PRESSURE:RAW", pressure)
-            self.ca.assert_pv_alarm_is("PRESSURE:RAW", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("PRESSURE:RAW", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses lewis backdoor command")
     def test_WHEN_pressure_and_upper_limit_are_changed_on_device_THEN_pressure_high_pv_updates(self):
@@ -127,7 +127,7 @@ class IegTests(unittest.TestCase):
                 self.ca.assert_that_pv_is("PRESSURE:HIGH",
                                           "Out of range" if pressure > upper_limit else "In range")
                 self.ca.assert_pv_alarm_is("PRESSURE:HIGH",
-                                           self.ca.ALARM_MINOR if pressure > upper_limit else self.ca.ALARM_NONE)
+                                           self.ca.Alarms.MINOR if pressure > upper_limit else self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses lewis backdoor command")
     def test_WHEN_pressure_and_lower_limit_are_changed_on_device_THEN_pressure_low_pv_updates(self):
@@ -138,7 +138,7 @@ class IegTests(unittest.TestCase):
                 self.ca.assert_that_pv_is("PRESSURE:LOW",
                                           "Out of range" if pressure < lower_limit else "In range")
                 self.ca.assert_pv_alarm_is("PRESSURE:LOW",
-                                           self.ca.ALARM_MINOR if pressure < lower_limit else self.ca.ALARM_NONE)
+                                           self.ca.Alarms.MINOR if pressure < lower_limit else self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses lewis backdoor command")
     def test_WHEN_buffer_pressure_high_is_changed_on_device_THEN_buffer_pressure_high_pv_updates(self):
@@ -150,19 +150,19 @@ class IegTests(unittest.TestCase):
             self.ca.assert_that_pv_is("PRESSURE:BUFFER:HIGH",
                                       "Out of range" if value else "In range")
             self.ca.assert_pv_alarm_is("PRESSURE:BUFFER:HIGH",
-                                       self.ca.ALARM_MINOR if value else self.ca.ALARM_NONE)
+                                       self.ca.Alarms.MINOR if value else self.ca.Alarms.NONE)
 
     @skip_if_recsim("Uses lewis backdoor command")
     def test_WHEN_pressure_is_over_350_THEN_displayed_as_greater_than_350_mBar(self):
         self._lewis.backdoor_set_on_device("sample_pressure", self._get_raw_from_actual(400))
         self.ca.assert_that_pv_is("PRESSURE:GUI.OSV", ">350 mbar")
-        self.ca.assert_pv_alarm_is("PRESSURE:GUI", self.ca.ALARM_MAJOR)
+        self.ca.assert_pv_alarm_is("PRESSURE:GUI", self.ca.Alarms.MAJOR)
 
     @skip_if_recsim("Uses lewis backdoor command")
     def test_WHEN_pressure_is_less_than_0_THEN_displayed_as_less_than_0_mBar(self):
         self._lewis.backdoor_set_on_device("sample_pressure", self._get_raw_from_actual(-10))
         self.ca.assert_that_pv_is("PRESSURE:GUI.OSV", "<0 mbar")
-        self.ca.assert_pv_alarm_is("PRESSURE:GUI", self.ca.ALARM_MAJOR)
+        self.ca.assert_pv_alarm_is("PRESSURE:GUI", self.ca.Alarms.MAJOR)
 
     @skip_if_recsim("Uses lewis backdoor command")
     def test_WHEN_pressure_is_set_THEN_it_is_converted_correctly_using_the_calibration(self):
@@ -172,4 +172,4 @@ class IegTests(unittest.TestCase):
             self._lewis.backdoor_set_on_device("sample_pressure", raw_pressure)
             # PRESSURE is restricted to use [0-350]. PRESSURE:CALC is unrestricted
             self.ca.assert_that_pv_is_number("PRESSURE:CALC", actual_pressure, tolerance=0.05)
-            self.ca.assert_pv_alarm_is("PRESSURE", self.ca.ALARM_NONE if .0 < actual_pressure < 350 else self.ca.ALARM_MAJOR)
+            self.ca.assert_pv_alarm_is("PRESSURE", self.ca.Alarms.NONE if .0 < actual_pressure < 350 else self.ca.Alarms.MAJOR)

--- a/tests/ilm200.py
+++ b/tests/ilm200.py
@@ -139,7 +139,7 @@ class Ilm200Tests(unittest.TestCase):
         for i in self.channel_range():
             level = self.FILL/2
             self.set_level_via_backdoor(i, level)
-            self.ca.assert_pv_alarm_is(self.ch_pv(i, "LOW"), self.ca.ALARM_MINOR)
+            self.ca.assert_pv_alarm_is(self.ch_pv(i, "LOW"), self.ca.Alarms.MINOR)
 
     @skip_if_recsim("Cannot do back door in recsim")
     def test_GIVEN_helium_channel_WHEN_helium_current_set_on_THEN_ioc_reports_current(self):

--- a/tests/ilm200.py
+++ b/tests/ilm200.py
@@ -73,16 +73,16 @@ class Ilm200Tests(unittest.TestCase):
 
     def test_GIVEN_ilm200_THEN_has_version(self):
         self.ca.assert_that_pv_is_not("VERSION", "")
-        self.ca.assert_that_pv_alarm_is("VERSION", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("VERSION", self.ca.Alarms.NONE)
 
     def test_GIVEN_ilm200_THEN_each_channel_has_type(self):
         for i in self.channel_range():
             self.ca.assert_that_pv_is_not(self.ch_pv(i, self.TYPE), "Not in use")
-            self.ca.assert_that_pv_alarm_is(self.ch_pv(i, self.TYPE), ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is(self.ch_pv(i, self.TYPE), self.ca.Alarms.NONE)
 
     def test_GIVEN_ilm_200_THEN_can_read_level(self):
         for i in self.channel_range():
-            self.ca.assert_that_pv_alarm_is(self.ch_pv(i, self.LEVEL), ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is(self.ch_pv(i, self.LEVEL), self.ca.Alarms.NONE)
 
     @skip_if_recsim("Cannot do back door of dynamic behaviour in recsim")
     def test_GIVEN_ilm_200_WHEN_level_set_on_device_THEN_reported_level_matches_set_level(self):

--- a/tests/ilm200.py
+++ b/tests/ilm200.py
@@ -57,7 +57,7 @@ class Ilm200Tests(unittest.TestCase):
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("ilm200", DEVICE_PREFIX)
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
-        self.ca.wait_for("VERSION", timeout=30)
+        self.ca.assert_that_pv_exists("VERSION", timeout=30)
         self._lewis.backdoor_set_on_device("cycle", False)
 
     def set_level_via_backdoor(self, channel, level):
@@ -73,16 +73,16 @@ class Ilm200Tests(unittest.TestCase):
 
     def test_GIVEN_ilm200_THEN_has_version(self):
         self.ca.assert_that_pv_is_not("VERSION", "")
-        self.ca.assert_pv_alarm_is("VERSION", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("VERSION", ChannelAccess.ALARM_NONE)
 
     def test_GIVEN_ilm200_THEN_each_channel_has_type(self):
         for i in self.channel_range():
             self.ca.assert_that_pv_is_not(self.ch_pv(i, self.TYPE), "Not in use")
-            self.ca.assert_pv_alarm_is(self.ch_pv(i, self.TYPE), ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is(self.ch_pv(i, self.TYPE), ChannelAccess.ALARM_NONE)
 
     def test_GIVEN_ilm_200_THEN_can_read_level(self):
         for i in self.channel_range():
-            self.ca.assert_pv_alarm_is(self.ch_pv(i, self.LEVEL), ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is(self.ch_pv(i, self.LEVEL), ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Cannot do back door of dynamic behaviour in recsim")
     def test_GIVEN_ilm_200_WHEN_level_set_on_device_THEN_reported_level_matches_set_level(self):
@@ -98,7 +98,7 @@ class Ilm200Tests(unittest.TestCase):
             def not_equal(a, b):
                 tolerance = self.LEVEL_TOLERANCE
                 return abs(a-b)/(a+b+tolerance) > tolerance
-            self.ca.assert_pv_value_over_time(self.ch_pv(i, self.LEVEL), 2*Ilm200Tests.DEFAULT_SCAN_RATE, not_equal)
+            self.ca.assert_that_pv_value_over_time_satisfies_comparator(self.ch_pv(i, self.LEVEL), 2 * Ilm200Tests.DEFAULT_SCAN_RATE, not_equal)
 
     def test_GIVEN_ilm200_channel_WHEN_rate_change_requested_THEN_rate_changed(self):
         for i in self.channel_range():
@@ -139,7 +139,7 @@ class Ilm200Tests(unittest.TestCase):
         for i in self.channel_range():
             level = self.FILL/2
             self.set_level_via_backdoor(i, level)
-            self.ca.assert_pv_alarm_is(self.ch_pv(i, "LOW"), self.ca.Alarms.MINOR)
+            self.ca.assert_that_pv_alarm_is(self.ch_pv(i, "LOW"), self.ca.Alarms.MINOR)
 
     @skip_if_recsim("Cannot do back door in recsim")
     def test_GIVEN_helium_channel_WHEN_helium_current_set_on_THEN_ioc_reports_current(self):

--- a/tests/instron_stress_rig.py
+++ b/tests/instron_stress_rig.py
@@ -106,14 +106,14 @@ class InstronStressRigTests(unittest.TestCase):
         self._lewis.backdoor_set_on_device("status", 7680)
 
         self.ca.assert_that_pv_is("STAT:DISP", "System OK")
-        self.ca.assert_that_pv_alarm_is("STAT:DISP", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("STAT:DISP", ChannelAccess.Alarms.NONE)
 
     @skip_if_recsim("In rec sim we can not set the code easily")
     def test_WHEN_the_rig_has_other_no_error_THEN_the_status_is_ok(self):
         self._lewis.backdoor_set_on_device("status", 0)
 
         self.ca.assert_that_pv_is("STAT:DISP", "System OK")
-        self.ca.assert_that_pv_alarm_is("STAT:DISP", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("STAT:DISP", ChannelAccess.Alarms.NONE)
 
     @skip_if_recsim("In rec sim we can not set the code easily")
     def test_WHEN_the_rig_has_error_THEN_the_status_is_emergency_stop_pushed(self):
@@ -144,7 +144,7 @@ class InstronStressRigTests(unittest.TestCase):
             self._lewis.backdoor_set_on_device("status", code_val)
 
             self.ca.assert_that_pv_is("STAT:DISP", error, msg="code set {0} = {code_val}".format(code, code_val=code_val))
-            self.ca.assert_that_pv_alarm_is("STAT:DISP", ChannelAccess.ALARM_MAJOR)
+            self.ca.assert_that_pv_alarm_is("STAT:DISP", ChannelAccess.Alarms.MAJOR)
 
     def test_WHEN_the_rig_is_initialized_THEN_it_is_not_going(self):
         self.ca.assert_that_pv_is("GOING", "NO")
@@ -305,7 +305,7 @@ class InstronStressRigTests(unittest.TestCase):
         def _set_and_check(chan, value):
             self.ca.set_pv_value(chan + ":SP", value)
             self.ca.set_pv_value(chan + ":TOLERANCE", 9999)
-            self.ca.assert_that_pv_alarm_is(chan + ":SP:RBV", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is(chan + ":SP:RBV", ChannelAccess.Alarms.NONE)
 
         for chan in POS_STRESS_STRAIN:
             for i in [0.123, 567]:
@@ -317,7 +317,7 @@ class InstronStressRigTests(unittest.TestCase):
         def _set_and_check(chan, value):
             self.ca.set_pv_value(chan + ":SP", value)
             self.ca.set_pv_value(chan + ":TOLERANCE", -1)
-            self.ca.assert_that_pv_alarm_is(chan + ":SP:RBV", ChannelAccess.ALARM_MINOR)
+            self.ca.assert_that_pv_alarm_is(chan + ":SP:RBV", ChannelAccess.Alarms.MINOR)
 
         for chan in POS_STRESS_STRAIN:
             for i in [0.234, 789]:
@@ -379,7 +379,7 @@ class InstronStressRigTests(unittest.TestCase):
         def _set_and_check(value):
             self.ca.set_pv_value("STRESS:AREA:SP", value)
             self.ca.assert_that_pv_is_number("STRESS:AREA", value, tolerance=0.01)
-            self.ca.assert_that_pv_alarm_is("STRESS:AREA", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("STRESS:AREA", ChannelAccess.Alarms.NONE)
 
         for val in [0.234, 789]:
             _set_and_check(val)
@@ -388,7 +388,7 @@ class InstronStressRigTests(unittest.TestCase):
         def _set_and_check(value):
             self.ca.set_pv_value("STRESS:AREA:SP", value)
             self.ca.assert_that_pv_is_number("STRESS:DIAMETER", (2*math.sqrt(value/math.pi)), tolerance=0.01)
-            self.ca.assert_that_pv_alarm_is("STRESS:DIAMETER", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("STRESS:DIAMETER", ChannelAccess.Alarms.NONE)
 
         for val in [0.234, 789]:
             _set_and_check(val)
@@ -397,7 +397,7 @@ class InstronStressRigTests(unittest.TestCase):
         def _set_and_check(value):
             self.ca.set_pv_value("STRESS:DIAMETER:SP", value)
             self.ca.assert_that_pv_is_number("STRESS:DIAMETER", value, tolerance=0.0005)
-            self.ca.assert_that_pv_alarm_is("STRESS:DIAMETER", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("STRESS:DIAMETER", ChannelAccess.Alarms.NONE)
 
         for val in [0.234, 789]:
             _set_and_check(val)
@@ -406,7 +406,7 @@ class InstronStressRigTests(unittest.TestCase):
         def _set_and_check(value):
             self.ca.set_pv_value("STRESS:DIAMETER:SP", value)
             self.ca.assert_that_pv_is_number("STRESS:AREA", ((value/2.0)**2 * math.pi), tolerance=0.0005)
-            self.ca.assert_that_pv_alarm_is("STRESS:AREA", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("STRESS:AREA", ChannelAccess.Alarms.NONE)
 
         for val in [0.234, 789]:
             _set_and_check(val)
@@ -420,7 +420,7 @@ class InstronStressRigTests(unittest.TestCase):
             for val in [1.23, 123.45]:
                 self.ca.set_pv_value("POS:SP", val)
                 self.ca.assert_that_pv_is_number("POS:RAW:SP", val * (1.0/1000.0) * (1/scale), tolerance=0.0000000001)
-                self.ca.assert_that_pv_alarm_is("POS:RAW:SP", ChannelAccess.ALARM_NONE)
+                self.ca.assert_that_pv_alarm_is("POS:RAW:SP", ChannelAccess.Alarms.NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_WHEN_a_stress_setpoint_is_set_THEN_it_is_converted_correctly(self):
@@ -437,7 +437,7 @@ class InstronStressRigTests(unittest.TestCase):
                     self.ca.set_pv_value("STRESS:SP", val)
                     self.ca.assert_that_pv_is_number("STRESS:RAW:SP", val * (1 / chan_scale) * area,
                                                      tolerance=0.0000000001)
-                    self.ca.assert_that_pv_alarm_is("STRESS:RAW:SP", ChannelAccess.ALARM_NONE)
+                    self.ca.assert_that_pv_alarm_is("STRESS:RAW:SP", ChannelAccess.Alarms.NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_WHEN_a_strain_setpoint_is_set_THEN_it_is_converted_correctly(self):
@@ -454,7 +454,7 @@ class InstronStressRigTests(unittest.TestCase):
                     self.ca.set_pv_value("STRAIN:SP", val)
                     self.ca.assert_that_pv_is_number("STRAIN:RAW:SP", val * (1 / chan_scale) * length * (1.0/100000.0),
                                                      tolerance=0.0000000001)
-                    self.ca.assert_that_pv_alarm_is("STRAIN:RAW:SP", ChannelAccess.ALARM_NONE)
+                    self.ca.assert_that_pv_alarm_is("STRAIN:RAW:SP", ChannelAccess.Alarms.NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_WHEN_the_channel_type_updates_on_the_device_THEN_the_pv_updates(self):
@@ -476,7 +476,7 @@ class InstronStressRigTests(unittest.TestCase):
             self.ca.set_pv_value("AXES:RAMP:WFTYP:SP", set_value)
             for chan in POS_STRESS_STRAIN:
                 self.ca.assert_that_pv_is("{0}:RAMP:WFTYP".format(chan), return_value)
-                self.ca.assert_that_pv_alarm_is("{0}:RAMP:WFTYP".format(chan), ChannelAccess.ALARM_NONE)
+                self.ca.assert_that_pv_alarm_is("{0}:RAMP:WFTYP".format(chan), ChannelAccess.Alarms.NONE)
 
         for set_value, return_value in enumerate(RAMP_WAVEFORM_TYPES):
             _set_and_check(set_value, return_value)
@@ -494,7 +494,7 @@ class InstronStressRigTests(unittest.TestCase):
 
             self.ca.set_pv_value("CHANNEL:SP", index)
 
-            self.ca.assert_that_pv_alarm_is("CHANNEL:SP", ChannelAccess.ALARM_INVALID)
+            self.ca.assert_that_pv_alarm_is("CHANNEL:SP", ChannelAccess.Alarms.INVALID)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_WHEN_channel_succeeds_check_THEN_channel_mbbi_record_is_invalid_and_has_tag_disabled(self):
@@ -506,16 +506,16 @@ class InstronStressRigTests(unittest.TestCase):
             self.ca.assert_that_pv_is(""+chan_name+":TYPE:CHECK", "PASS", timeout=30)
 
             self.ca.assert_that_pv_is("CHANNEL:SP.{}ST".format(index_as_name), channel_as_name)
-            self.ca.assert_that_pv_is("CHANNEL:SP.{}SV".format(index_as_name), ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_is("CHANNEL:SP.{}SV".format(index_as_name), ChannelAccess.Alarms.NONE)
 
             self.ca.set_pv_value("CHANNEL:SP", index)
-            self.ca.assert_that_pv_alarm_is("CHANNEL:SP", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("CHANNEL:SP", ChannelAccess.Alarms.NONE)
 
     @skip_if_recsim("In rec sim we can not disconnect the device from the IOC")
     def test_WHEN_the_rig_is_not_connected_THEN_the_status_has_alarm(self):
         self._lewis.backdoor_set_on_device("status", None)
 
-        self.ca.assert_that_pv_alarm_is("STAT:DISP", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("STAT:DISP", ChannelAccess.Alarms.INVALID)
 
     # Waveform tests
 

--- a/tests/instron_stress_rig.py
+++ b/tests/instron_stress_rig.py
@@ -57,9 +57,9 @@ class InstronStressRigTests(unittest.TestCase):
         # Setpoint is zero-indexed
         self.ca.set_pv_value("CHANNEL:SP", CHANNELS[name] - 1)
         self.ca.assert_that_pv_is("CHANNEL.RVAL", CHANNELS[name])
-        self.ca.assert_pv_alarm_is("CHANNEL", self.ca.ALARM_NONE)
+        self.ca.assert_pv_alarm_is("CHANNEL", self.ca.Alarms.NONE)
         self.ca.assert_that_pv_is("CHANNEL:GUI", name)
-        self.ca.assert_pv_alarm_is("CHANNEL:GUI", self.ca.ALARM_NONE)
+        self.ca.assert_pv_alarm_is("CHANNEL:GUI", self.ca.Alarms.NONE)
 
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("instron_stress_rig", DEVICE_PREFIX)
@@ -218,12 +218,12 @@ class InstronStressRigTests(unittest.TestCase):
             # Put the record into a non-alarm state. This is needed so that we can wait until the record is in alarm
             # later, when we do a command which (expectedly) puts the record into a timeout alarm.
             self.ca.set_pv_value("ARBITRARY:SP", "Q4,1")
-            self.ca.assert_pv_alarm_is("ARBITRARY", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("ARBITRARY", self.ca.Alarms.NONE)
 
             self.ca.set_pv_value("ARBITRARY:SP", "C4,1," + str(value))
             self.ca.assert_that_pv_is("ARBITRARY:SP", "C4,1," + str(value))
             # No response from arbitrary command causes record to be TIMEOUT INVALID - this is expected.
-            self.ca.assert_pv_alarm_is("ARBITRARY", self.ca.ALARM_INVALID)
+            self.ca.assert_pv_alarm_is("ARBITRARY", self.ca.Alarms.INVALID)
 
             self.ca.set_pv_value("ARBITRARY:SP", "Q4,1")
             self.ca.assert_that_pv_is_number("ARBITRARY", value, tolerance=0.001, timeout=60)

--- a/tests/instron_stress_rig.py
+++ b/tests/instron_stress_rig.py
@@ -57,15 +57,15 @@ class InstronStressRigTests(unittest.TestCase):
         # Setpoint is zero-indexed
         self.ca.set_pv_value("CHANNEL:SP", CHANNELS[name] - 1)
         self.ca.assert_that_pv_is("CHANNEL.RVAL", CHANNELS[name])
-        self.ca.assert_pv_alarm_is("CHANNEL", self.ca.Alarms.NONE)
+        self.ca.assert_that_pv_alarm_is("CHANNEL", self.ca.Alarms.NONE)
         self.ca.assert_that_pv_is("CHANNEL:GUI", name)
-        self.ca.assert_pv_alarm_is("CHANNEL:GUI", self.ca.Alarms.NONE)
+        self.ca.assert_that_pv_alarm_is("CHANNEL:GUI", self.ca.Alarms.NONE)
 
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("instron_stress_rig", DEVICE_PREFIX)
 
         self.ca = ChannelAccess(15, device_prefix=DEVICE_PREFIX)
-        self.ca.wait_for("CHANNEL", timeout=30)
+        self.ca.assert_that_pv_exists("CHANNEL", timeout=30)
 
         # Can't use lewis backdoor commands in recsim
         # All of the below commands apply to devsim only.
@@ -106,14 +106,14 @@ class InstronStressRigTests(unittest.TestCase):
         self._lewis.backdoor_set_on_device("status", 7680)
 
         self.ca.assert_that_pv_is("STAT:DISP", "System OK")
-        self.ca.assert_pv_alarm_is("STAT:DISP", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("STAT:DISP", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("In rec sim we can not set the code easily")
     def test_WHEN_the_rig_has_other_no_error_THEN_the_status_is_ok(self):
         self._lewis.backdoor_set_on_device("status", 0)
 
         self.ca.assert_that_pv_is("STAT:DISP", "System OK")
-        self.ca.assert_pv_alarm_is("STAT:DISP", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("STAT:DISP", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("In rec sim we can not set the code easily")
     def test_WHEN_the_rig_has_error_THEN_the_status_is_emergency_stop_pushed(self):
@@ -144,7 +144,7 @@ class InstronStressRigTests(unittest.TestCase):
             self._lewis.backdoor_set_on_device("status", code_val)
 
             self.ca.assert_that_pv_is("STAT:DISP", error, msg="code set {0} = {code_val}".format(code, code_val=code_val))
-            self.ca.assert_pv_alarm_is("STAT:DISP", ChannelAccess.ALARM_MAJOR)
+            self.ca.assert_that_pv_alarm_is("STAT:DISP", ChannelAccess.ALARM_MAJOR)
 
     def test_WHEN_the_rig_is_initialized_THEN_it_is_not_going(self):
         self.ca.assert_that_pv_is("GOING", "NO")
@@ -218,12 +218,12 @@ class InstronStressRigTests(unittest.TestCase):
             # Put the record into a non-alarm state. This is needed so that we can wait until the record is in alarm
             # later, when we do a command which (expectedly) puts the record into a timeout alarm.
             self.ca.set_pv_value("ARBITRARY:SP", "Q4,1")
-            self.ca.assert_pv_alarm_is("ARBITRARY", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("ARBITRARY", self.ca.Alarms.NONE)
 
             self.ca.set_pv_value("ARBITRARY:SP", "C4,1," + str(value))
             self.ca.assert_that_pv_is("ARBITRARY:SP", "C4,1," + str(value))
             # No response from arbitrary command causes record to be TIMEOUT INVALID - this is expected.
-            self.ca.assert_pv_alarm_is("ARBITRARY", self.ca.Alarms.INVALID)
+            self.ca.assert_that_pv_alarm_is("ARBITRARY", self.ca.Alarms.INVALID)
 
             self.ca.set_pv_value("ARBITRARY:SP", "Q4,1")
             self.ca.assert_that_pv_is_number("ARBITRARY", value, tolerance=0.001, timeout=60)
@@ -305,7 +305,7 @@ class InstronStressRigTests(unittest.TestCase):
         def _set_and_check(chan, value):
             self.ca.set_pv_value(chan + ":SP", value)
             self.ca.set_pv_value(chan + ":TOLERANCE", 9999)
-            self.ca.assert_pv_alarm_is(chan + ":SP:RBV", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is(chan + ":SP:RBV", ChannelAccess.ALARM_NONE)
 
         for chan in POS_STRESS_STRAIN:
             for i in [0.123, 567]:
@@ -317,7 +317,7 @@ class InstronStressRigTests(unittest.TestCase):
         def _set_and_check(chan, value):
             self.ca.set_pv_value(chan + ":SP", value)
             self.ca.set_pv_value(chan + ":TOLERANCE", -1)
-            self.ca.assert_pv_alarm_is(chan + ":SP:RBV", ChannelAccess.ALARM_MINOR)
+            self.ca.assert_that_pv_alarm_is(chan + ":SP:RBV", ChannelAccess.ALARM_MINOR)
 
         for chan in POS_STRESS_STRAIN:
             for i in [0.234, 789]:
@@ -379,7 +379,7 @@ class InstronStressRigTests(unittest.TestCase):
         def _set_and_check(value):
             self.ca.set_pv_value("STRESS:AREA:SP", value)
             self.ca.assert_that_pv_is_number("STRESS:AREA", value, tolerance=0.01)
-            self.ca.assert_pv_alarm_is("STRESS:AREA", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("STRESS:AREA", ChannelAccess.ALARM_NONE)
 
         for val in [0.234, 789]:
             _set_and_check(val)
@@ -388,7 +388,7 @@ class InstronStressRigTests(unittest.TestCase):
         def _set_and_check(value):
             self.ca.set_pv_value("STRESS:AREA:SP", value)
             self.ca.assert_that_pv_is_number("STRESS:DIAMETER", (2*math.sqrt(value/math.pi)), tolerance=0.01)
-            self.ca.assert_pv_alarm_is("STRESS:DIAMETER", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("STRESS:DIAMETER", ChannelAccess.ALARM_NONE)
 
         for val in [0.234, 789]:
             _set_and_check(val)
@@ -397,7 +397,7 @@ class InstronStressRigTests(unittest.TestCase):
         def _set_and_check(value):
             self.ca.set_pv_value("STRESS:DIAMETER:SP", value)
             self.ca.assert_that_pv_is_number("STRESS:DIAMETER", value, tolerance=0.0005)
-            self.ca.assert_pv_alarm_is("STRESS:DIAMETER", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("STRESS:DIAMETER", ChannelAccess.ALARM_NONE)
 
         for val in [0.234, 789]:
             _set_and_check(val)
@@ -406,7 +406,7 @@ class InstronStressRigTests(unittest.TestCase):
         def _set_and_check(value):
             self.ca.set_pv_value("STRESS:DIAMETER:SP", value)
             self.ca.assert_that_pv_is_number("STRESS:AREA", ((value/2.0)**2 * math.pi), tolerance=0.0005)
-            self.ca.assert_pv_alarm_is("STRESS:AREA", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("STRESS:AREA", ChannelAccess.ALARM_NONE)
 
         for val in [0.234, 789]:
             _set_and_check(val)
@@ -420,7 +420,7 @@ class InstronStressRigTests(unittest.TestCase):
             for val in [1.23, 123.45]:
                 self.ca.set_pv_value("POS:SP", val)
                 self.ca.assert_that_pv_is_number("POS:RAW:SP", val * (1.0/1000.0) * (1/scale), tolerance=0.0000000001)
-                self.ca.assert_pv_alarm_is("POS:RAW:SP", ChannelAccess.ALARM_NONE)
+                self.ca.assert_that_pv_alarm_is("POS:RAW:SP", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_WHEN_a_stress_setpoint_is_set_THEN_it_is_converted_correctly(self):
@@ -437,7 +437,7 @@ class InstronStressRigTests(unittest.TestCase):
                     self.ca.set_pv_value("STRESS:SP", val)
                     self.ca.assert_that_pv_is_number("STRESS:RAW:SP", val * (1 / chan_scale) * area,
                                                      tolerance=0.0000000001)
-                    self.ca.assert_pv_alarm_is("STRESS:RAW:SP", ChannelAccess.ALARM_NONE)
+                    self.ca.assert_that_pv_alarm_is("STRESS:RAW:SP", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_WHEN_a_strain_setpoint_is_set_THEN_it_is_converted_correctly(self):
@@ -454,7 +454,7 @@ class InstronStressRigTests(unittest.TestCase):
                     self.ca.set_pv_value("STRAIN:SP", val)
                     self.ca.assert_that_pv_is_number("STRAIN:RAW:SP", val * (1 / chan_scale) * length * (1.0/100000.0),
                                                      tolerance=0.0000000001)
-                    self.ca.assert_pv_alarm_is("STRAIN:RAW:SP", ChannelAccess.ALARM_NONE)
+                    self.ca.assert_that_pv_alarm_is("STRAIN:RAW:SP", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_WHEN_the_channel_type_updates_on_the_device_THEN_the_pv_updates(self):
@@ -476,7 +476,7 @@ class InstronStressRigTests(unittest.TestCase):
             self.ca.set_pv_value("AXES:RAMP:WFTYP:SP", set_value)
             for chan in POS_STRESS_STRAIN:
                 self.ca.assert_that_pv_is("{0}:RAMP:WFTYP".format(chan), return_value)
-                self.ca.assert_pv_alarm_is("{0}:RAMP:WFTYP".format(chan), ChannelAccess.ALARM_NONE)
+                self.ca.assert_that_pv_alarm_is("{0}:RAMP:WFTYP".format(chan), ChannelAccess.ALARM_NONE)
 
         for set_value, return_value in enumerate(RAMP_WAVEFORM_TYPES):
             _set_and_check(set_value, return_value)
@@ -494,7 +494,7 @@ class InstronStressRigTests(unittest.TestCase):
 
             self.ca.set_pv_value("CHANNEL:SP", index)
 
-            self.ca.assert_pv_alarm_is("CHANNEL:SP", ChannelAccess.ALARM_INVALID)
+            self.ca.assert_that_pv_alarm_is("CHANNEL:SP", ChannelAccess.ALARM_INVALID)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_WHEN_channel_succeeds_check_THEN_channel_mbbi_record_is_invalid_and_has_tag_disabled(self):
@@ -509,13 +509,13 @@ class InstronStressRigTests(unittest.TestCase):
             self.ca.assert_that_pv_is("CHANNEL:SP.{}SV".format(index_as_name), ChannelAccess.ALARM_NONE)
 
             self.ca.set_pv_value("CHANNEL:SP", index)
-            self.ca.assert_pv_alarm_is("CHANNEL:SP", ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is("CHANNEL:SP", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("In rec sim we can not disconnect the device from the IOC")
     def test_WHEN_the_rig_is_not_connected_THEN_the_status_has_alarm(self):
         self._lewis.backdoor_set_on_device("status", None)
 
-        self.ca.assert_pv_alarm_is("STAT:DISP", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("STAT:DISP", ChannelAccess.ALARM_INVALID)
 
     # Waveform tests
 
@@ -647,7 +647,7 @@ class InstronStressRigTests(unittest.TestCase):
     @skip_if_recsim("Counting part of dynamic device behaviour")
     def test_WHEN_the_waveform_generator_is_started_THEN_the_quarter_counter_starts_counting_and_keeps_increasing(self):
         self.ca.set_pv_value(wave_prefixed("START"), 1)
-        self.ca.assert_pv_value_is_increasing("QUART", 5)
+        self.ca.assert_that_pv_value_is_increasing("QUART", 5)
 
     @skip_if_recsim("Status more complicated than RECSIM can handle")
     def test_WHEN_the_quarter_counter_is_armed_THEN_the_number_of_quarts_never_exceeds_the_requested_maximum(self):

--- a/tests/ips.py
+++ b/tests/ips.py
@@ -162,7 +162,7 @@ class IpsTests(unittest.TestCase):
             # quenched.
             self._lewis.backdoor_run_function_on_device("unquench")
             # Wait for IOC to notice quench state has gone away
-            self.ca.assert_pv_alarm_is("STS:SYSTEM:FAULT", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("STS:SYSTEM:FAULT", self.ca.Alarms.NONE)
 
     def test_GIVEN_magnet_quenches_while_at_field_THEN_ioc_displays_this_quench_in_statuses(self):
 
@@ -174,9 +174,9 @@ class IpsTests(unittest.TestCase):
 
             with self._backdoor_magnet_quench():
                 self.ca.assert_that_pv_is("STS:SYSTEM:FAULT", "Quenched")
-                self.ca.assert_pv_alarm_is("STS:SYSTEM:FAULT", self.ca.ALARM_MAJOR)
+                self.ca.assert_pv_alarm_is("STS:SYSTEM:FAULT", self.ca.Alarms.MAJOR)
                 self.ca.assert_that_pv_is("CONTROL", "Auto-Run-Down")
-                self.ca.assert_pv_alarm_is("CONTROL", self.ca.ALARM_MAJOR)
+                self.ca.assert_pv_alarm_is("CONTROL", self.ca.Alarms.MAJOR)
 
                 # The trip field should be the field at the point when the magnet quenched.
                 self.ca.assert_that_pv_is_number("FIELD:TRIP", field, tolerance=TOLERANCE)
@@ -200,4 +200,4 @@ class IpsTests(unittest.TestCase):
             self.ca.set_pv_value("FIELD:RATE:SP", val)
             self.ca.assert_that_pv_is_number("FIELD:RATE:SP", val, tolerance=TOLERANCE)
             self.ca.assert_that_pv_is_number("FIELD:RATE", val, tolerance=TOLERANCE)
-            self.ca.assert_pv_alarm_is("FIELD:RATE", self.ca.ALARM_NONE)
+            self.ca.assert_pv_alarm_is("FIELD:RATE", self.ca.Alarms.NONE)

--- a/tests/ips.py
+++ b/tests/ips.py
@@ -47,7 +47,7 @@ class IpsTests(unittest.TestCase):
 
         # Wait for some critical pvs to be connected.
         for pv in ["MAGNET:FIELD:PERSISTENT", "FIELD", "FIELD:SP:RBV", "HEATER:STATUS"]:
-            self.ca.wait_for(pv)
+            self.ca.assert_that_pv_exists(pv)
 
         # Ensure in the correct mode
         self.ca.set_pv_value("CONTROL:SP", "Remote & Unlocked")
@@ -76,7 +76,7 @@ class IpsTests(unittest.TestCase):
     def _assert_field_is(self, field, check_stable=False):
         self.ca.assert_that_pv_is_number("FIELD", field, tolerance=TOLERANCE)
         if check_stable:
-            self.ca.assert_pv_value_is_unchanged("FIELD", wait=30)
+            self.ca.assert_that_pv_value_is_unchanged("FIELD", wait=30)
             self.ca.assert_that_pv_is_number("FIELD", field, tolerance=TOLERANCE)
 
     def _assert_heater_is(self, heater_state):
@@ -162,7 +162,7 @@ class IpsTests(unittest.TestCase):
             # quenched.
             self._lewis.backdoor_run_function_on_device("unquench")
             # Wait for IOC to notice quench state has gone away
-            self.ca.assert_pv_alarm_is("STS:SYSTEM:FAULT", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("STS:SYSTEM:FAULT", self.ca.Alarms.NONE)
 
     def test_GIVEN_magnet_quenches_while_at_field_THEN_ioc_displays_this_quench_in_statuses(self):
 
@@ -174,9 +174,9 @@ class IpsTests(unittest.TestCase):
 
             with self._backdoor_magnet_quench():
                 self.ca.assert_that_pv_is("STS:SYSTEM:FAULT", "Quenched")
-                self.ca.assert_pv_alarm_is("STS:SYSTEM:FAULT", self.ca.Alarms.MAJOR)
+                self.ca.assert_that_pv_alarm_is("STS:SYSTEM:FAULT", self.ca.Alarms.MAJOR)
                 self.ca.assert_that_pv_is("CONTROL", "Auto-Run-Down")
-                self.ca.assert_pv_alarm_is("CONTROL", self.ca.Alarms.MAJOR)
+                self.ca.assert_that_pv_alarm_is("CONTROL", self.ca.Alarms.MAJOR)
 
                 # The trip field should be the field at the point when the magnet quenched.
                 self.ca.assert_that_pv_is_number("FIELD:TRIP", field, tolerance=TOLERANCE)
@@ -200,4 +200,4 @@ class IpsTests(unittest.TestCase):
             self.ca.set_pv_value("FIELD:RATE:SP", val)
             self.ca.assert_that_pv_is_number("FIELD:RATE:SP", val, tolerance=TOLERANCE)
             self.ca.assert_that_pv_is_number("FIELD:RATE", val, tolerance=TOLERANCE)
-            self.ca.assert_pv_alarm_is("FIELD:RATE", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is("FIELD:RATE", self.ca.Alarms.NONE)

--- a/tests/itc503.py
+++ b/tests/itc503.py
@@ -42,7 +42,7 @@ class Itc503Tests(unittest.TestCase):
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("itc503", DEVICE_PREFIX)
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX, default_timeout=20)
-        self.ca.wait_for("DISABLE")
+        self.ca.assert_that_pv_exists("DISABLE")
         self._make_device_scan_faster()
 
     def _make_device_scan_faster(self):
@@ -50,8 +50,8 @@ class Itc503Tests(unittest.TestCase):
         Purely so that the tests run faster, the real IOC scans excruciatingly slowly.
         """
         # Skip setting the PVs if the scan rate is already fast
-        self.ca.wait_for("FAN1")
-        self.ca.wait_for("FAN2")
+        self.ca.assert_that_pv_exists("FAN1")
+        self.ca.assert_that_pv_exists("FAN2")
         if self.ca.get_pv_value("FAN1.SCAN") != ".1 second":
             for i in range(1, 8+1):
                 # Ensure all DLY links are 0 in both FAN records

--- a/tests/julabo.py
+++ b/tests/julabo.py
@@ -36,7 +36,7 @@ class JulaboTests(unittest.TestCase):
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("julabo", "JULABO_01")
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
-        self.ca.wait_for("TEMP", timeout=30)
+        self.ca.assert_that_pv_exists("TEMP", timeout=30)
         # Turn off circulate
         self.ca.set_pv_value("MODE:SP", 0)
 

--- a/tests/keithley_2700.py
+++ b/tests/keithley_2700.py
@@ -34,7 +34,7 @@ class Keithley_2700Tests(unittest.TestCase):
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("keithley_2700", DEVICE_PREFIX)
         self.ca = ChannelAccess(default_timeout=30, device_prefix=DEVICE_PREFIX)
-        self.ca.wait_for("IDN")
+        self.ca.assert_that_pv_exists("IDN")
 
     def test_WHEN_scan_state_set_THEN_scan_state_matches_the_set_state(self):
         sample_data = {0: "INT", 1: "NONE"}

--- a/tests/kepco.py
+++ b/tests/kepco.py
@@ -45,7 +45,7 @@ class KepcoTests(unittest.TestCase):
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("kepco", DEVICE_PREFIX)
         self.ca = ChannelAccess(default_timeout=30, device_prefix=DEVICE_PREFIX)
-        self.ca.wait_for("VOLTAGE", timeout=30)
+        self.ca.assert_that_pv_exists("VOLTAGE", timeout=30)
 
     def _write_voltage(self, expected_voltage):
         self._lewis.backdoor_set_on_device("voltage", expected_voltage)

--- a/tests/lakeshore460.py
+++ b/tests/lakeshore460.py
@@ -60,7 +60,7 @@ class Lakeshore460Tests(unittest.TestCase):
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("lakeshore460", DEVICE_PREFIX)
         self.ca = ChannelAccess(device_prefix="LKSH460_01", default_timeout=30)
-        self.ca.wait_for("IDN")
+        self.ca.assert_that_pv_exists("IDN")
 
     def test_GIVEN_unit_set_gauss_WHEN_read_THEN_unit_is_gauss(self):
         self.ca.set_pv_value("CHANNEL", "X")

--- a/tests/lksh218.py
+++ b/tests/lksh218.py
@@ -83,19 +83,19 @@ class Lksh218Tests(unittest.TestCase):
         self._lewis.backdoor_set_on_device("connected", False)
 
         for i in range(1, 9):
-            self.ca.assert_that_pv_alarm_is("TEMP{}".format(i), ChannelAccess.ALARM_INVALID)
-            self.ca.assert_that_pv_alarm_is("SENSOR{}".format(i), ChannelAccess.ALARM_INVALID)
+            self.ca.assert_that_pv_alarm_is("TEMP{}".format(i), ChannelAccess.Alarms.INVALID)
+            self.ca.assert_that_pv_alarm_is("SENSOR{}".format(i), ChannelAccess.Alarms.INVALID)
 
     @skip_if_recsim("Recsim is unable to simulate a disconnected device.")
     def test_that_WHEN_the_emulator_is_disconnected_THEN_an_alarm_is_raised_on_SENSORALL(self):
         self._lewis.backdoor_set_on_device("connected", False)
 
         self.ca.process_pv("SENSORALL")
-        self.ca.assert_that_pv_alarm_is("SENSORALL", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("SENSORALL", ChannelAccess.Alarms.INVALID)
 
     @skip_if_recsim("Recsim is unable to simulate a disconnected device.")
     def test_that_WHEN_the_emulator_is_disconnected_THEN_an_alarm_is_raised_on_TEMPALL(self):
         self._lewis.backdoor_set_on_device("connected", False)
 
         self.ca.process_pv("TEMPALL")
-        self.ca.assert_that_pv_alarm_is("TEMPALL", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("TEMPALL", ChannelAccess.Alarms.INVALID)

--- a/tests/lksh218.py
+++ b/tests/lksh218.py
@@ -83,19 +83,19 @@ class Lksh218Tests(unittest.TestCase):
         self._lewis.backdoor_set_on_device("connected", False)
 
         for i in range(1, 9):
-            self.ca.assert_pv_alarm_is("TEMP{}".format(i), ChannelAccess.ALARM_INVALID)
-            self.ca.assert_pv_alarm_is("SENSOR{}".format(i), ChannelAccess.ALARM_INVALID)
+            self.ca.assert_that_pv_alarm_is("TEMP{}".format(i), ChannelAccess.ALARM_INVALID)
+            self.ca.assert_that_pv_alarm_is("SENSOR{}".format(i), ChannelAccess.ALARM_INVALID)
 
     @skip_if_recsim("Recsim is unable to simulate a disconnected device.")
     def test_that_WHEN_the_emulator_is_disconnected_THEN_an_alarm_is_raised_on_SENSORALL(self):
         self._lewis.backdoor_set_on_device("connected", False)
 
         self.ca.process_pv("SENSORALL")
-        self.ca.assert_pv_alarm_is("SENSORALL", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("SENSORALL", ChannelAccess.ALARM_INVALID)
 
     @skip_if_recsim("Recsim is unable to simulate a disconnected device.")
     def test_that_WHEN_the_emulator_is_disconnected_THEN_an_alarm_is_raised_on_TEMPALL(self):
         self._lewis.backdoor_set_on_device("connected", False)
 
         self.ca.process_pv("TEMPALL")
-        self.ca.assert_pv_alarm_is("TEMPALL", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("TEMPALL", ChannelAccess.ALARM_INVALID)

--- a/tests/mk3chopper.py
+++ b/tests/mk3chopper.py
@@ -40,11 +40,11 @@ class Mk3chopperTests(unittest.TestCase):
             # Bug in CA channel. Reports invalid alarm severity if you set enum directly
             self.ca.set_pv_value("SIM:{}.VAL".format(self.COMP_MODE_PV), 1)
         self.ca.assert_that_pv_is(self.COMP_MODE_PV, self.REMOTE)
-        self.ca.assert_that_pv_alarm_is(self.COMP_MODE_PV, ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is(self.COMP_MODE_PV, ChannelAccess.Alarms.NONE)
 
     @skip_if_devsim("Can't switch to local mode in DEVSIM")
     def test_WHEN_ioc_is_in_local_mode_THEN_it_has_a_major_alarm(self):
         # Bug in CA channel. Reports invalid alarm severity if you set enum directly
         self.ca.set_pv_value("SIM:{}.VAL".format(self.COMP_MODE_PV), 0)
         self.ca.assert_that_pv_is(self.COMP_MODE_PV, self.LOCAL)
-        self.ca.assert_that_pv_alarm_is(self.COMP_MODE_PV, ChannelAccess.ALARM_MAJOR)
+        self.ca.assert_that_pv_alarm_is(self.COMP_MODE_PV, ChannelAccess.Alarms.MAJOR)

--- a/tests/mk3chopper.py
+++ b/tests/mk3chopper.py
@@ -32,7 +32,7 @@ class Mk3chopperTests(unittest.TestCase):
         self._ioc = IOCRegister.get_running(DEVICE_PREFIX)
         # Comp mode is on a slow 10s read. Needs a longer timeout than default
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX, default_timeout=30)
-        self.ca.wait_for(self.COMP_MODE_PV)
+        self.ca.assert_that_pv_exists(self.COMP_MODE_PV)
 
     def test_WHEN_ioc_is_in_remote_mode_THEN_it_has_no_alarm(self):
         # In RECSIM, switch to remote explicitly. DEVSIM can only have remote mode so no switch needed
@@ -40,11 +40,11 @@ class Mk3chopperTests(unittest.TestCase):
             # Bug in CA channel. Reports invalid alarm severity if you set enum directly
             self.ca.set_pv_value("SIM:{}.VAL".format(self.COMP_MODE_PV), 1)
         self.ca.assert_that_pv_is(self.COMP_MODE_PV, self.REMOTE)
-        self.ca.assert_pv_alarm_is(self.COMP_MODE_PV, ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is(self.COMP_MODE_PV, ChannelAccess.ALARM_NONE)
 
     @skip_if_devsim("Can't switch to local mode in DEVSIM")
     def test_WHEN_ioc_is_in_local_mode_THEN_it_has_a_major_alarm(self):
         # Bug in CA channel. Reports invalid alarm severity if you set enum directly
         self.ca.set_pv_value("SIM:{}.VAL".format(self.COMP_MODE_PV), 0)
         self.ca.assert_that_pv_is(self.COMP_MODE_PV, self.LOCAL)
-        self.ca.assert_pv_alarm_is(self.COMP_MODE_PV, ChannelAccess.ALARM_MAJOR)
+        self.ca.assert_that_pv_alarm_is(self.COMP_MODE_PV, ChannelAccess.ALARM_MAJOR)

--- a/tests/motion_setpoints.py
+++ b/tests/motion_setpoints.py
@@ -64,7 +64,7 @@ class MotionSetpointsTests(unittest.TestCase):
         self.caDN = ChannelAccess(device_prefix=DEVICE_PREFIX_DN)
         self.caDP = ChannelAccess(device_prefix=DEVICE_PREFIX_DP)
         self.motor_ca = ChannelAccess(device_prefix=MOTOR_PREFIX)
-        self.ca1D.wait_for("COORD1:NAME", timeout=30)
+        self.ca1D.assert_that_pv_exists("COORD1:NAME", timeout=30)
         self.ca1D.set_pv_value("COORD1:OFFSET:SP", 0)
         self.ca1D.assert_that_pv_is("STATIONARY", 1)
 
@@ -87,7 +87,7 @@ class MotionSetpointsTests(unittest.TestCase):
             self.ca1D.set_pv_value("POSN:SP", expected_position)
 
             self.ca1D.assert_that_pv_is("POSN", expected_position)
-            self.ca1D.assert_pv_alarm_is("POSN", ChannelAccess.ALARM_NONE)
+            self.ca1D.assert_that_pv_alarm_is("POSN", ChannelAccess.ALARM_NONE)
             self.ca1D.assert_that_pv_is("POSN:SP:RBV", expected_position)
             self.ca1D.assert_that_pv_is("POSN:SP:RBV", expected_position)
             self.ca1D.assert_that_pv_is("IPOSN", index)
@@ -151,7 +151,7 @@ class MotionSetpointsTests(unittest.TestCase):
             self.ca2D.set_pv_value("POSN:SP", expected_position)
 
             self.ca2D.assert_that_pv_is("POSN", expected_position)
-            self.ca2D.assert_pv_alarm_is("POSN", ChannelAccess.ALARM_NONE)
+            self.ca2D.assert_that_pv_alarm_is("POSN", ChannelAccess.ALARM_NONE)
             self.ca2D.assert_that_pv_is("POSN:SP:RBV", expected_position)
             self.ca2D.assert_that_pv_is("POSN:SP:RBV", expected_position)
             self.ca2D.assert_that_pv_is("IPOSN", index)
@@ -212,7 +212,7 @@ class MotionSetpointsTests(unittest.TestCase):
             self.ca1DAxis.set_pv_value("POSN:SP", expected_position)
 
             self.ca1DAxis.assert_that_pv_is("POSN", expected_position)
-            self.ca1DAxis.assert_pv_alarm_is("POSN", ChannelAccess.ALARM_NONE)
+            self.ca1DAxis.assert_that_pv_alarm_is("POSN", ChannelAccess.ALARM_NONE)
             self.ca1DAxis.assert_that_pv_is("POSN:SP:RBV", expected_position)
             self.ca1DAxis.assert_that_pv_is("POSN:SP:RBV", expected_position)
             self.ca1DAxis.assert_that_pv_is("IPOSN", index)
@@ -226,7 +226,7 @@ class MotionSetpointsTests(unittest.TestCase):
             self.ca2DAxis.set_pv_value("POSN:SP", expected_position)
 
             self.ca2DAxis.assert_that_pv_is("POSN", expected_position)
-            self.ca2DAxis.assert_pv_alarm_is("POSN", ChannelAccess.ALARM_NONE)
+            self.ca2DAxis.assert_that_pv_alarm_is("POSN", ChannelAccess.ALARM_NONE)
             self.ca2DAxis.assert_that_pv_is("POSN:SP:RBV", expected_position)
             self.ca2DAxis.assert_that_pv_is("POSN:SP:RBV", expected_position)
             self.ca2DAxis.assert_that_pv_is("IPOSN", index)
@@ -245,7 +245,7 @@ class MotionSetpointsTests(unittest.TestCase):
 
     def test_GIVEN_2D_WHEN_invalid_position_specified_THEN_alarm(self):
         self.ca2DAxis.set_pv_value("POSN:SP", "an_invalid_position")
-        self.ca2DAxis.assert_pv_alarm_is("POSN:SP", ChannelAccess.ALARM_INVALID)
+        self.ca2DAxis.assert_that_pv_alarm_is("POSN:SP", ChannelAccess.ALARM_INVALID)
         
     def test_GIVEN_2D_WHEN_move_motor_THEN_tolerance_checked(self):
         self.ca2DAxis.set_pv_value("TOLERENCE", 10)

--- a/tests/motion_setpoints.py
+++ b/tests/motion_setpoints.py
@@ -87,7 +87,7 @@ class MotionSetpointsTests(unittest.TestCase):
             self.ca1D.set_pv_value("POSN:SP", expected_position)
 
             self.ca1D.assert_that_pv_is("POSN", expected_position)
-            self.ca1D.assert_that_pv_alarm_is("POSN", ChannelAccess.ALARM_NONE)
+            self.ca1D.assert_that_pv_alarm_is("POSN", ChannelAccess.Alarms.NONE)
             self.ca1D.assert_that_pv_is("POSN:SP:RBV", expected_position)
             self.ca1D.assert_that_pv_is("POSN:SP:RBV", expected_position)
             self.ca1D.assert_that_pv_is("IPOSN", index)
@@ -151,7 +151,7 @@ class MotionSetpointsTests(unittest.TestCase):
             self.ca2D.set_pv_value("POSN:SP", expected_position)
 
             self.ca2D.assert_that_pv_is("POSN", expected_position)
-            self.ca2D.assert_that_pv_alarm_is("POSN", ChannelAccess.ALARM_NONE)
+            self.ca2D.assert_that_pv_alarm_is("POSN", ChannelAccess.Alarms.NONE)
             self.ca2D.assert_that_pv_is("POSN:SP:RBV", expected_position)
             self.ca2D.assert_that_pv_is("POSN:SP:RBV", expected_position)
             self.ca2D.assert_that_pv_is("IPOSN", index)
@@ -212,7 +212,7 @@ class MotionSetpointsTests(unittest.TestCase):
             self.ca1DAxis.set_pv_value("POSN:SP", expected_position)
 
             self.ca1DAxis.assert_that_pv_is("POSN", expected_position)
-            self.ca1DAxis.assert_that_pv_alarm_is("POSN", ChannelAccess.ALARM_NONE)
+            self.ca1DAxis.assert_that_pv_alarm_is("POSN", ChannelAccess.Alarms.NONE)
             self.ca1DAxis.assert_that_pv_is("POSN:SP:RBV", expected_position)
             self.ca1DAxis.assert_that_pv_is("POSN:SP:RBV", expected_position)
             self.ca1DAxis.assert_that_pv_is("IPOSN", index)
@@ -226,7 +226,7 @@ class MotionSetpointsTests(unittest.TestCase):
             self.ca2DAxis.set_pv_value("POSN:SP", expected_position)
 
             self.ca2DAxis.assert_that_pv_is("POSN", expected_position)
-            self.ca2DAxis.assert_that_pv_alarm_is("POSN", ChannelAccess.ALARM_NONE)
+            self.ca2DAxis.assert_that_pv_alarm_is("POSN", ChannelAccess.Alarms.NONE)
             self.ca2DAxis.assert_that_pv_is("POSN:SP:RBV", expected_position)
             self.ca2DAxis.assert_that_pv_is("POSN:SP:RBV", expected_position)
             self.ca2DAxis.assert_that_pv_is("IPOSN", index)
@@ -245,7 +245,7 @@ class MotionSetpointsTests(unittest.TestCase):
 
     def test_GIVEN_2D_WHEN_invalid_position_specified_THEN_alarm(self):
         self.ca2DAxis.set_pv_value("POSN:SP", "an_invalid_position")
-        self.ca2DAxis.assert_that_pv_alarm_is("POSN:SP", ChannelAccess.ALARM_INVALID)
+        self.ca2DAxis.assert_that_pv_alarm_is("POSN:SP", ChannelAccess.Alarms.INVALID)
         
     def test_GIVEN_2D_WHEN_move_motor_THEN_tolerance_checked(self):
         self.ca2DAxis.set_pv_value("TOLERENCE", 10)

--- a/tests/oscillating_collimator.py
+++ b/tests/oscillating_collimator.py
@@ -44,9 +44,9 @@ class OscillatingCollimatorTests(unittest.TestCase):
     """
     def setUp(self):
         self._ioc = IOCRegister.get_running("GALIL_01")
-        ChannelAccess().wait_for("MOT:MTR0101", timeout=30)
+        ChannelAccess().assert_that_pv_exists("MOT:MTR0101", timeout=30)
         self.ca = ChannelAccess(device_prefix=PREFIX)
-        self.ca.wait_for("VEL:SP", timeout=30)
+        self.ca.assert_that_pv_exists("VEL:SP", timeout=30)
 
     def test_GIVEN_angle_frequency_and_radius_WHEN_set_THEN_distance_and_velocity_match_LabView_generated_values(self):
 

--- a/tests/readascii.py
+++ b/tests/readascii.py
@@ -110,7 +110,7 @@ class ReadasciiTests(unittest.TestCase):
     def setUp(self):
         self.ca = ChannelAccess(default_timeout=30, device_prefix=DEVICE_PREFIX)
         self._ioc = IOCRegister.get_running(DEVICE_PREFIX)
-        self.ca.wait_for("DIRBASE")
+        self.ca.assert_that_pv_exists("DIRBASE")
         self._set_ramp_status(False)
 
     def test_GIVEN_the_test_file_has_entries_for_a_setpoint_WHEN_that_exact_setpoint_is_set_THEN_it_updates_the_pid_pvs_with_the_values_from_the_file(self):

--- a/tests/rknps.py
+++ b/tests/rknps.py
@@ -44,7 +44,7 @@ class RknpsTests(unittest.TestCase):
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("rknps", PREFIX)
         self.ca = ChannelAccess()
-        self.ca.wait_for("{0}:{1}:ADDRESS".format(PREFIX, ID1), timeout=30)
+        self.ca.assert_that_pv_exists("{0}:{1}:ADDRESS".format(PREFIX, ID1), timeout=30)
 
     def _activate_interlocks(self):
         """

--- a/tests/rotsc.py
+++ b/tests/rotsc.py
@@ -28,7 +28,7 @@ class RotscTests(unittest.TestCase):
     def setUp(self):
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
         self._ioc = IOCRegister.get_running(DEVICE_PREFIX)
-        self.ca.wait_for("POSN")
+        self.ca.assert_that_pv_exists("POSN")
 
     def test_WHEN_position_set_to_value_THEN_readback_set_to_value(self):
         for val in [1, 16]:

--- a/tests/sampos.py
+++ b/tests/sampos.py
@@ -32,7 +32,7 @@ class SamposTests(unittest.TestCase):
         self._ioc = IOCRegister.get_running("SAMPOS")
 
         self.ca = ChannelAccess(20, device_prefix=DEVICE_PREFIX)
-        self.ca.wait_for("DISABLE", timeout=30)
+        self.ca.assert_that_pv_exists("DISABLE", timeout=30)
 
     def test_WHEN_ioc_is_started_THEN_ioc_is_not_disabled(self):
         self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")

--- a/tests/skf_mb350_chopper.py
+++ b/tests/skf_mb350_chopper.py
@@ -60,7 +60,7 @@ class SkfMB350ChopperTests(unittest.TestCase):
         self._lewis, self._ioc = get_running_lewis_and_ioc("skf_mb350_chopper", DEVICE_PREFIX)
         self.ca = ChannelAccess(20, device_prefix=DEVICE_PREFIX)
 
-        self.ca.wait_for("FREQ", timeout=30)
+        self.ca.assert_that_pv_exists("FREQ", timeout=30)
 
         # Wait for emulator to be connected, signified by "STAT:OK"
         self.ca.assert_that_pv_is("STAT:OK", "OK")

--- a/tests/sm300.py
+++ b/tests/sm300.py
@@ -73,7 +73,7 @@ class Sm300Tests(unittest.TestCase):
         self._lewis, self._ioc = get_running_lewis_and_ioc("sm300", SM300_DEVICE_PREFIX)
         self.ca = ChannelAccess(device_prefix="MOT")
         self.ioc_ca = ChannelAccess(device_prefix=SM300_DEVICE_PREFIX)
-        self.ioc_ca.wait_for("RESET_AND_HOME", timeout=30)
+        self.ioc_ca.assert_that_pv_exists("RESET_AND_HOME", timeout=30)
         self._lewis.backdoor_run_function_on_device("reset")
 
     def set_starting_position(self, starting_pos, axis="x"):
@@ -114,14 +114,14 @@ class Sm300Tests(unittest.TestCase):
         self._lewis.backdoor_set_on_device("x_axis_rbv_error", "B10")
 
         # It doesn't appear that the motor can be made to go into an invlaid state so major alarm will have to do
-        self.ca.assert_pv_alarm_is("MTR0101", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("MTR0101", ChannelAccess.ALARM_INVALID)
 
     @skip_if_recsim("Needs to set error")
     def test_GIVEN_malformed_motor_position_WHEN_get_axis_x_THEN_error_returned(self):
         self._lewis.backdoor_set_on_device("x_axis_rbv_error", "Xrubbish")
 
         # It doesn't appear that the motor can be made to go into an invlaid state so major alarm will have to do
-        self.ca.assert_pv_alarm_is("MTR0101", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("MTR0101", ChannelAccess.ALARM_INVALID)
 
     @skip_if_recsim("Needs to set moving on motor")
     def test_GIVEN_a_motor_is_moving_WHEN_get_moving_THEN_both_axis_are_moving(self):
@@ -144,8 +144,8 @@ class Sm300Tests(unittest.TestCase):
     def test_GIVEN_a_motor_is_in_error_WHEN_get_moving_THEN_both_axis_are_in_error(self):
         self._lewis.backdoor_set_on_device("is_moving_error", True)
 
-        self.ca.assert_pv_alarm_is("MTR0101", ChannelAccess.ALARM_MAJOR)
-        self.ca.assert_pv_alarm_is("MTR0102", ChannelAccess.ALARM_MAJOR)
+        self.ca.assert_that_pv_alarm_is("MTR0101", ChannelAccess.ALARM_MAJOR)
+        self.ca.assert_that_pv_alarm_is("MTR0102", ChannelAccess.ALARM_MAJOR)
 
     def test_GIVEN_motor_at_position_WHEN_set_postion_THEN_motor_moves_to_the_position(self):
         expected_value = 10
@@ -172,7 +172,7 @@ class Sm300Tests(unittest.TestCase):
 
     @skip_if_recsim("Needs to get reset values set from lewis")
     def test_GIVEN_a_motor_WHEN_reset_pressed_THEN_initial_values_sent(self):
-        self.ioc_ca.wait_for("RESET", 30)
+        self.ioc_ca.assert_that_pv_exists("RESET", 30)
         self.ioc_ca.set_pv_value("RESET", 1)
 
         reset_codes = self._lewis.backdoor_get_from_device("reset_codes")
@@ -209,7 +209,7 @@ class Sm300Tests(unittest.TestCase):
 
     @skip_if_recsim("Needs to get reset code from lewis")
     def test_GIVEN_a_motor_WHEN_disconnect_THEN_M77_is_sent(self):
-        self.ioc_ca.wait_for("DISCONNECT", 30)
+        self.ioc_ca.assert_that_pv_exists("DISCONNECT", 30)
         self.ioc_ca.set_pv_value("DISCONNECT", 1)
 
         reset_codes = self._lewis.backdoor_get_from_device("disconnect")
@@ -221,28 +221,28 @@ class Sm300Tests(unittest.TestCase):
         self._lewis.backdoor_set_on_device("error_code", 1)
 
         self.ioc_ca.assert_that_pv_is("ERROR", "Servo error")
-        self.ioc_ca.assert_pv_alarm_is("ERROR", ChannelAccess.ALARM_MAJOR)
+        self.ioc_ca.assert_that_pv_alarm_is("ERROR", ChannelAccess.ALARM_MAJOR)
 
     @skip_if_recsim("Needs to set error code in lewis")
     def test_GIVEN_no_error_WHEN_query_THEN_error_is_blank(self):
         self._lewis.backdoor_set_on_device("error_code", 0)
 
         self.ioc_ca.assert_that_pv_is("ERROR", "")
-        self.ioc_ca.assert_pv_alarm_is("ERROR", ChannelAccess.ALARM_NONE)
+        self.ioc_ca.assert_that_pv_alarm_is("ERROR", ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("Needs to set error code in lewis")
     def test_GIVEN_command_send_error_WHEN_query_THEN_error_is_set(self):
         self._lewis.backdoor_set_on_device("error_code", 0x10)
 
         self.ioc_ca.assert_that_pv_is("ERROR", "Cmd error code")
-        self.ioc_ca.assert_pv_alarm_is("ERROR", ChannelAccess.ALARM_MAJOR)
+        self.ioc_ca.assert_that_pv_alarm_is("ERROR", ChannelAccess.ALARM_MAJOR)
 
     @skip_if_recsim("Needs to set error code in lewis")
     def test_GIVEN_cnc_command_send_CNC_error_WHEN_query_THEN_error_is_set(self):
         self._lewis.backdoor_set_on_device("error_code", 0x20)
 
         self.ioc_ca.assert_that_pv_is("ERROR", "CNC cmd error code")
-        self.ioc_ca.assert_pv_alarm_is("ERROR", ChannelAccess.ALARM_MAJOR)
+        self.ioc_ca.assert_that_pv_alarm_is("ERROR", ChannelAccess.ALARM_MAJOR)
 
     @skip_if_recsim("Needs to set error code in lewis")
     def test_GIVEN_a_motor_WHEN_reset_and_homed_THEN_motor_moves_to_home_and_resets(self):
@@ -263,4 +263,4 @@ class Sm300Tests(unittest.TestCase):
     def test_GIVEN_motor_is_disconnected_WHEN_get_axis_x_ioc_position_THEN_alarm_is_disconnected(self):
         self._lewis.backdoor_set_on_device("is_disconnected", True)
 
-        self.ca.assert_pv_alarm_is("MTR0101", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("MTR0101", ChannelAccess.ALARM_INVALID)

--- a/tests/sm300.py
+++ b/tests/sm300.py
@@ -114,14 +114,14 @@ class Sm300Tests(unittest.TestCase):
         self._lewis.backdoor_set_on_device("x_axis_rbv_error", "B10")
 
         # It doesn't appear that the motor can be made to go into an invlaid state so major alarm will have to do
-        self.ca.assert_that_pv_alarm_is("MTR0101", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("MTR0101", self.ca.Alarms.INVALID)
 
     @skip_if_recsim("Needs to set error")
     def test_GIVEN_malformed_motor_position_WHEN_get_axis_x_THEN_error_returned(self):
         self._lewis.backdoor_set_on_device("x_axis_rbv_error", "Xrubbish")
 
         # It doesn't appear that the motor can be made to go into an invlaid state so major alarm will have to do
-        self.ca.assert_that_pv_alarm_is("MTR0101", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("MTR0101", self.ca.Alarms.INVALID)
 
     @skip_if_recsim("Needs to set moving on motor")
     def test_GIVEN_a_motor_is_moving_WHEN_get_moving_THEN_both_axis_are_moving(self):
@@ -144,8 +144,8 @@ class Sm300Tests(unittest.TestCase):
     def test_GIVEN_a_motor_is_in_error_WHEN_get_moving_THEN_both_axis_are_in_error(self):
         self._lewis.backdoor_set_on_device("is_moving_error", True)
 
-        self.ca.assert_that_pv_alarm_is("MTR0101", ChannelAccess.ALARM_MAJOR)
-        self.ca.assert_that_pv_alarm_is("MTR0102", ChannelAccess.ALARM_MAJOR)
+        self.ca.assert_that_pv_alarm_is("MTR0101", self.ca.Alarms.MAJOR)
+        self.ca.assert_that_pv_alarm_is("MTR0102", self.ca.Alarms.MAJOR)
 
     def test_GIVEN_motor_at_position_WHEN_set_postion_THEN_motor_moves_to_the_position(self):
         expected_value = 10
@@ -221,28 +221,28 @@ class Sm300Tests(unittest.TestCase):
         self._lewis.backdoor_set_on_device("error_code", 1)
 
         self.ioc_ca.assert_that_pv_is("ERROR", "Servo error")
-        self.ioc_ca.assert_that_pv_alarm_is("ERROR", ChannelAccess.ALARM_MAJOR)
+        self.ioc_ca.assert_that_pv_alarm_is("ERROR", self.ca.Alarms.MAJOR)
 
     @skip_if_recsim("Needs to set error code in lewis")
     def test_GIVEN_no_error_WHEN_query_THEN_error_is_blank(self):
         self._lewis.backdoor_set_on_device("error_code", 0)
 
         self.ioc_ca.assert_that_pv_is("ERROR", "")
-        self.ioc_ca.assert_that_pv_alarm_is("ERROR", ChannelAccess.ALARM_NONE)
+        self.ioc_ca.assert_that_pv_alarm_is("ERROR", self.ca.Alarms.NONE)
 
     @skip_if_recsim("Needs to set error code in lewis")
     def test_GIVEN_command_send_error_WHEN_query_THEN_error_is_set(self):
         self._lewis.backdoor_set_on_device("error_code", 0x10)
 
         self.ioc_ca.assert_that_pv_is("ERROR", "Cmd error code")
-        self.ioc_ca.assert_that_pv_alarm_is("ERROR", ChannelAccess.ALARM_MAJOR)
+        self.ioc_ca.assert_that_pv_alarm_is("ERROR", self.ca.Alarms.MAJOR)
 
     @skip_if_recsim("Needs to set error code in lewis")
     def test_GIVEN_cnc_command_send_CNC_error_WHEN_query_THEN_error_is_set(self):
         self._lewis.backdoor_set_on_device("error_code", 0x20)
 
         self.ioc_ca.assert_that_pv_is("ERROR", "CNC cmd error code")
-        self.ioc_ca.assert_that_pv_alarm_is("ERROR", ChannelAccess.ALARM_MAJOR)
+        self.ioc_ca.assert_that_pv_alarm_is("ERROR", self.ca.Alarms.MAJOR)
 
     @skip_if_recsim("Needs to set error code in lewis")
     def test_GIVEN_a_motor_WHEN_reset_and_homed_THEN_motor_moves_to_home_and_resets(self):
@@ -263,4 +263,4 @@ class Sm300Tests(unittest.TestCase):
     def test_GIVEN_motor_is_disconnected_WHEN_get_axis_x_ioc_position_THEN_alarm_is_disconnected(self):
         self._lewis.backdoor_set_on_device("is_disconnected", True)
 
-        self.ca.assert_that_pv_alarm_is("MTR0101", ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is("MTR0101", self.ca.Alarms.INVALID)

--- a/tests/superlogics.py
+++ b/tests/superlogics.py
@@ -32,7 +32,7 @@ class SuperlogicsTests(unittest.TestCase):
         self._lewis, self._ioc = get_running_lewis_and_ioc("superlogics", PREFIX)
 
         self.ca = ChannelAccess(device_prefix=PREFIX)
-        self.ca.wait_for("{}:1:VALUE".format("01"))
+        self.ca.assert_that_pv_exists("{}:1:VALUE".format("01"))
         self._set_disconnected(False)
 
     def _set_channel_values(self, values, address):
@@ -73,7 +73,7 @@ class SuperlogicsTests(unittest.TestCase):
 
         pv_name = "{}:{}:VALUE".format(address, channel)
         self.ca.assert_that_pv_is(pv_name, expected_value)
-        self.ca.assert_pv_alarm_is(pv_name, ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is(pv_name, ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_GIVEN_address_01_all_channels_value_set_WHEN_read_THEN_error_state(self):
@@ -82,7 +82,7 @@ class SuperlogicsTests(unittest.TestCase):
         self._set_channel_values(expected_values, address)
 
         pv_name = "{}:{}:VALUE".format(address, 1)
-        self.ca.assert_pv_alarm_is(pv_name, ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is(pv_name, ChannelAccess.ALARM_INVALID)
 
     def test_GIVEN_address_01_version_set_WHEN_read_THEN_value_is_as_expected(self):
         address = "01"
@@ -91,7 +91,7 @@ class SuperlogicsTests(unittest.TestCase):
         pv_name = "{}:VERSION".format(address)
 
         self.ca.assert_that_pv_is(pv_name, expected_version)
-        self.ca.assert_pv_alarm_is(pv_name, ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is(pv_name, ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_GIVEN_address_02_one_value_set_WHEN_read_THEN_error_state(self):
@@ -101,7 +101,7 @@ class SuperlogicsTests(unittest.TestCase):
         self._set_channel_values([expected_value], address)
 
         pv_name = "{}:{}:VALUE".format(address, channel)
-        self.ca.assert_pv_alarm_is(pv_name, ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is(pv_name, ChannelAccess.ALARM_INVALID)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_GIVEN_address_02_two_values_set_WHEN_read_THEN_error_state(self):
@@ -111,7 +111,7 @@ class SuperlogicsTests(unittest.TestCase):
         self._set_channel_values([0., expected_value], address)
 
         pv_name = "{}:{}:VALUE".format(address, channel)
-        self.ca.assert_pv_alarm_is(pv_name, ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is(pv_name, ChannelAccess.ALARM_INVALID)
 
     def test_GIVEN_address_02_all_channels_value_set_WHEN_read_THEN_values_are_as_expected(self):
         address = "02"
@@ -121,7 +121,7 @@ class SuperlogicsTests(unittest.TestCase):
         for channel, expected_value in enumerate(expected_values):
             pv_name = "{}:{}:VALUE".format(address, channel+1)
             self.ca.assert_that_pv_is(pv_name, expected_value)
-            self.ca.assert_pv_alarm_is(pv_name, ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is(pv_name, ChannelAccess.ALARM_NONE)
 
     def test_GIVEN_address_02_version_set_WHEN_read_THEN_value_is_as_expected(self):
         address = "02"
@@ -130,7 +130,7 @@ class SuperlogicsTests(unittest.TestCase):
         pv_name = "{}:VERSION".format(address)
 
         self.ca.assert_that_pv_is(pv_name, expected_version)
-        self.ca.assert_pv_alarm_is(pv_name, ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is(pv_name, ChannelAccess.ALARM_NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_GIVEN_address_02_disconnected_WHEN_read_values_THEN_error_state(self):
@@ -141,4 +141,4 @@ class SuperlogicsTests(unittest.TestCase):
 
         for channel, expected_value in enumerate(expected_values):
             pv_name = "{}:{}:VALUE".format(address, channel+1)
-            self.ca.assert_pv_alarm_is(pv_name, ChannelAccess.ALARM_INVALID)
+            self.ca.assert_that_pv_alarm_is(pv_name, ChannelAccess.ALARM_INVALID)

--- a/tests/superlogics.py
+++ b/tests/superlogics.py
@@ -73,7 +73,7 @@ class SuperlogicsTests(unittest.TestCase):
 
         pv_name = "{}:{}:VALUE".format(address, channel)
         self.ca.assert_that_pv_is(pv_name, expected_value)
-        self.ca.assert_that_pv_alarm_is(pv_name, ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is(pv_name, self.ca.Alarms.NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_GIVEN_address_01_all_channels_value_set_WHEN_read_THEN_error_state(self):
@@ -82,7 +82,7 @@ class SuperlogicsTests(unittest.TestCase):
         self._set_channel_values(expected_values, address)
 
         pv_name = "{}:{}:VALUE".format(address, 1)
-        self.ca.assert_that_pv_alarm_is(pv_name, ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is(pv_name, self.ca.Alarms.INVALID)
 
     def test_GIVEN_address_01_version_set_WHEN_read_THEN_value_is_as_expected(self):
         address = "01"
@@ -91,7 +91,7 @@ class SuperlogicsTests(unittest.TestCase):
         pv_name = "{}:VERSION".format(address)
 
         self.ca.assert_that_pv_is(pv_name, expected_version)
-        self.ca.assert_that_pv_alarm_is(pv_name, ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is(pv_name, self.ca.Alarms.NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_GIVEN_address_02_one_value_set_WHEN_read_THEN_error_state(self):
@@ -101,7 +101,7 @@ class SuperlogicsTests(unittest.TestCase):
         self._set_channel_values([expected_value], address)
 
         pv_name = "{}:{}:VALUE".format(address, channel)
-        self.ca.assert_that_pv_alarm_is(pv_name, ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is(pv_name, self.ca.Alarms.INVALID)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_GIVEN_address_02_two_values_set_WHEN_read_THEN_error_state(self):
@@ -111,7 +111,7 @@ class SuperlogicsTests(unittest.TestCase):
         self._set_channel_values([0., expected_value], address)
 
         pv_name = "{}:{}:VALUE".format(address, channel)
-        self.ca.assert_that_pv_alarm_is(pv_name, ChannelAccess.ALARM_INVALID)
+        self.ca.assert_that_pv_alarm_is(pv_name, self.ca.Alarms.INVALID)
 
     def test_GIVEN_address_02_all_channels_value_set_WHEN_read_THEN_values_are_as_expected(self):
         address = "02"
@@ -121,7 +121,7 @@ class SuperlogicsTests(unittest.TestCase):
         for channel, expected_value in enumerate(expected_values):
             pv_name = "{}:{}:VALUE".format(address, channel+1)
             self.ca.assert_that_pv_is(pv_name, expected_value)
-            self.ca.assert_that_pv_alarm_is(pv_name, ChannelAccess.ALARM_NONE)
+            self.ca.assert_that_pv_alarm_is(pv_name, self.ca.Alarms.NONE)
 
     def test_GIVEN_address_02_version_set_WHEN_read_THEN_value_is_as_expected(self):
         address = "02"
@@ -130,7 +130,7 @@ class SuperlogicsTests(unittest.TestCase):
         pv_name = "{}:VERSION".format(address)
 
         self.ca.assert_that_pv_is(pv_name, expected_version)
-        self.ca.assert_that_pv_alarm_is(pv_name, ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is(pv_name, self.ca.Alarms.NONE)
 
     @skip_if_recsim("In rec sim this test fails")
     def test_GIVEN_address_02_disconnected_WHEN_read_values_THEN_error_state(self):
@@ -141,4 +141,4 @@ class SuperlogicsTests(unittest.TestCase):
 
         for channel, expected_value in enumerate(expected_values):
             pv_name = "{}:{}:VALUE".format(address, channel+1)
-            self.ca.assert_that_pv_alarm_is(pv_name, ChannelAccess.ALARM_INVALID)
+            self.ca.assert_that_pv_alarm_is(pv_name, self.ca.Alarms.INVALID)

--- a/tests/tdk_lambda_genesys.py
+++ b/tests/tdk_lambda_genesys.py
@@ -33,7 +33,7 @@ class TdkLambdaGenesysTests(unittest.TestCase):
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("tdk_lambda_genesys", "GENESYS_01")
         self.ca = ChannelAccess(default_timeout=10, device_prefix="GENESYS_01")
-        self.ca.wait_for("1:VOLT", timeout=20)
+        self.ca.assert_that_pv_exists("1:VOLT", timeout=20)
 
     def _write_voltage(self, expected_voltage):
         self._lewis.backdoor_set_on_device("voltage", expected_voltage)

--- a/tests/tpg26x.py
+++ b/tests/tpg26x.py
@@ -67,7 +67,7 @@ class Tpg26xTests(unittest.TestCase):
         self._lewis, self._ioc = get_running_lewis_and_ioc("tpg26x", DEVICE_PREFIX)
 
         self.ca = ChannelAccess(20, device_prefix=DEVICE_PREFIX)
-        self.ca.wait_for("1:PRESSURE")
+        self.ca.assert_that_pv_exists("1:PRESSURE")
         # Reset and error flags and alarms
         self._set_error(ErrorFlags.NO_ERROR, self.CHANNEL_ONE)
         self._set_error(ErrorFlags.NO_ERROR, self.CHANNEL_TWO)
@@ -93,7 +93,7 @@ class Tpg26xTests(unittest.TestCase):
         self._set_pressure(expected_pressure, self.CHANNEL_ONE)
 
         self.ca.assert_that_pv_is("1:PRESSURE", expected_pressure)
-        self.ca.assert_pv_alarm_is("1:PRESSURE", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("1:PRESSURE", ChannelAccess.ALARM_NONE)
         self.ca.assert_that_pv_is("1:ERROR", "No Error")
 
     def test_GIVEN_negative_pressure1_set_WHEN_read_THEN_pressure1_is_as_expected(self):
@@ -115,7 +115,7 @@ class Tpg26xTests(unittest.TestCase):
         self._set_error(expected_error, self.CHANNEL_ONE)
 
         self.ca.assert_that_pv_is("1:ERROR", expected_error_str)
-        self.ca.assert_pv_alarm_is("1:ERROR", expected_alarm)
+        self.ca.assert_that_pv_alarm_is("1:ERROR", expected_alarm)
 
     def test_GIVEN_pressure1_over_range_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.OVER_RANGE
@@ -124,7 +124,7 @@ class Tpg26xTests(unittest.TestCase):
         self._set_error(expected_error, self.CHANNEL_ONE)
 
         self.ca.assert_that_pv_is("1:ERROR", expected_error_str)
-        self.ca.assert_pv_alarm_is("1:ERROR", expected_alarm)
+        self.ca.assert_that_pv_alarm_is("1:ERROR", expected_alarm)
 
     def test_GIVEN_pressure1_sensor_error_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.SENSOR_ERROR
@@ -133,7 +133,7 @@ class Tpg26xTests(unittest.TestCase):
         self._set_error(expected_error, self.CHANNEL_ONE)
 
         self.ca.assert_that_pv_is("1:ERROR", expected_error_str)
-        self.ca.assert_pv_alarm_is("1:ERROR", expected_alarm)
+        self.ca.assert_that_pv_alarm_is("1:ERROR", expected_alarm)
 
     def test_GIVEN_pressure1_sensor_off_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.SENSOR_OFF
@@ -142,7 +142,7 @@ class Tpg26xTests(unittest.TestCase):
         self._set_error(expected_error, self.CHANNEL_ONE)
 
         self.ca.assert_that_pv_is("1:ERROR", expected_error_str)
-        self.ca.assert_pv_alarm_is("1:ERROR", expected_alarm)
+        self.ca.assert_that_pv_alarm_is("1:ERROR", expected_alarm)
 
     def test_GIVEN_pressure1_no_sensor_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.NO_SENSOR
@@ -151,7 +151,7 @@ class Tpg26xTests(unittest.TestCase):
         self._set_error(expected_error, self.CHANNEL_ONE)
 
         self.ca.assert_that_pv_is("1:ERROR", expected_error_str)
-        self.ca.assert_pv_alarm_is("1:ERROR", expected_alarm)
+        self.ca.assert_that_pv_alarm_is("1:ERROR", expected_alarm)
 
     def test_GIVEN_pressure1_identification_error_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.IDENTIFICATION_ERROR
@@ -160,14 +160,14 @@ class Tpg26xTests(unittest.TestCase):
         self._set_error(expected_error, self.CHANNEL_ONE)
 
         self.ca.assert_that_pv_is("1:ERROR", expected_error_str)
-        self.ca.assert_pv_alarm_is("1:ERROR", expected_alarm)
+        self.ca.assert_that_pv_alarm_is("1:ERROR", expected_alarm)
 
     def test_GIVEN_pressure2_set_WHEN_read_THEN_pressure_is_as_expected(self):
         expected_pressure = 1.23
         self._set_pressure(expected_pressure, self.CHANNEL_TWO)
 
         self.ca.assert_that_pv_is("2:PRESSURE", expected_pressure)
-        self.ca.assert_pv_alarm_is("2:PRESSURE", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("2:PRESSURE", ChannelAccess.ALARM_NONE)
         self.ca.assert_that_pv_is("2:ERROR", "No Error")
 
     def test_GIVEN_negative_pressure2_set_WHEN_read_THEN_pressure2_is_as_expected(self):
@@ -189,7 +189,7 @@ class Tpg26xTests(unittest.TestCase):
         self._set_error(expected_error, self.CHANNEL_TWO)
 
         self.ca.assert_that_pv_is("2:ERROR", expected_error_str)
-        self.ca.assert_pv_alarm_is("2:ERROR", expected_alarm)
+        self.ca.assert_that_pv_alarm_is("2:ERROR", expected_alarm)
 
     def test_GIVEN_pressure2_over_range_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.OVER_RANGE
@@ -198,7 +198,7 @@ class Tpg26xTests(unittest.TestCase):
         self._set_error(expected_error, self.CHANNEL_TWO)
 
         self.ca.assert_that_pv_is("2:ERROR", expected_error_str)
-        self.ca.assert_pv_alarm_is("2:ERROR", expected_alarm)
+        self.ca.assert_that_pv_alarm_is("2:ERROR", expected_alarm)
 
     def test_GIVEN_pressure2_sensor_error_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.SENSOR_ERROR
@@ -207,7 +207,7 @@ class Tpg26xTests(unittest.TestCase):
         self._set_error(expected_error, self.CHANNEL_TWO)
 
         self.ca.assert_that_pv_is("2:ERROR", expected_error_str)
-        self.ca.assert_pv_alarm_is("2:ERROR", expected_alarm)
+        self.ca.assert_that_pv_alarm_is("2:ERROR", expected_alarm)
 
     def test_GIVEN_pressure2_sensor_off_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.SENSOR_OFF
@@ -216,7 +216,7 @@ class Tpg26xTests(unittest.TestCase):
         self._set_error(expected_error, self.CHANNEL_TWO)
 
         self.ca.assert_that_pv_is("2:ERROR", expected_error_str)
-        self.ca.assert_pv_alarm_is("2:ERROR", expected_alarm)
+        self.ca.assert_that_pv_alarm_is("2:ERROR", expected_alarm)
 
     def test_GIVEN_pressure2_no_sensor_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.NO_SENSOR
@@ -225,7 +225,7 @@ class Tpg26xTests(unittest.TestCase):
         self._set_error(expected_error, self.CHANNEL_TWO)
 
         self.ca.assert_that_pv_is("2:ERROR", expected_error_str)
-        self.ca.assert_pv_alarm_is("2:ERROR", expected_alarm)
+        self.ca.assert_that_pv_alarm_is("2:ERROR", expected_alarm)
 
     def test_GIVEN_pressure2_identification_error_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.IDENTIFICATION_ERROR
@@ -234,7 +234,7 @@ class Tpg26xTests(unittest.TestCase):
         self._set_error(expected_error, self.CHANNEL_TWO)
 
         self.ca.assert_that_pv_is("2:ERROR", expected_error_str)
-        self.ca.assert_pv_alarm_is("2:ERROR", expected_alarm)
+        self.ca.assert_that_pv_alarm_is("2:ERROR", expected_alarm)
 
     def test_GIVEN_units_set_WHEN_read_THEN_units_are_as_expected(self):
         expected_units = UnitFlags.PA

--- a/tests/tpg26x.py
+++ b/tests/tpg26x.py
@@ -93,7 +93,7 @@ class Tpg26xTests(unittest.TestCase):
         self._set_pressure(expected_pressure, self.CHANNEL_ONE)
 
         self.ca.assert_that_pv_is("1:PRESSURE", expected_pressure)
-        self.ca.assert_that_pv_alarm_is("1:PRESSURE", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("1:PRESSURE", self.ca.Alarms.NONE)
         self.ca.assert_that_pv_is("1:ERROR", "No Error")
 
     def test_GIVEN_negative_pressure1_set_WHEN_read_THEN_pressure1_is_as_expected(self):
@@ -111,7 +111,7 @@ class Tpg26xTests(unittest.TestCase):
     def test_GIVEN_pressure1_under_range_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.UNDER_RANGE
         expected_error_str = ErrorStrings.UNDER_RANGE
-        expected_alarm = ChannelAccess.ALARM_MINOR
+        expected_alarm = self.ca.Alarms.MINOR
         self._set_error(expected_error, self.CHANNEL_ONE)
 
         self.ca.assert_that_pv_is("1:ERROR", expected_error_str)
@@ -120,7 +120,7 @@ class Tpg26xTests(unittest.TestCase):
     def test_GIVEN_pressure1_over_range_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.OVER_RANGE
         expected_error_str = ErrorStrings.OVER_RANGE
-        expected_alarm = ChannelAccess.ALARM_MINOR
+        expected_alarm = self.ca.Alarms.MINOR
         self._set_error(expected_error, self.CHANNEL_ONE)
 
         self.ca.assert_that_pv_is("1:ERROR", expected_error_str)
@@ -129,7 +129,7 @@ class Tpg26xTests(unittest.TestCase):
     def test_GIVEN_pressure1_sensor_error_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.SENSOR_ERROR
         expected_error_str = ErrorStrings.SENSOR_ERROR
-        expected_alarm = ChannelAccess.ALARM_MAJOR
+        expected_alarm = self.ca.Alarms.MAJOR
         self._set_error(expected_error, self.CHANNEL_ONE)
 
         self.ca.assert_that_pv_is("1:ERROR", expected_error_str)
@@ -138,7 +138,7 @@ class Tpg26xTests(unittest.TestCase):
     def test_GIVEN_pressure1_sensor_off_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.SENSOR_OFF
         expected_error_str = ErrorStrings.SENSOR_OFF
-        expected_alarm = ChannelAccess.ALARM_MAJOR
+        expected_alarm = self.ca.Alarms.MAJOR
         self._set_error(expected_error, self.CHANNEL_ONE)
 
         self.ca.assert_that_pv_is("1:ERROR", expected_error_str)
@@ -147,7 +147,7 @@ class Tpg26xTests(unittest.TestCase):
     def test_GIVEN_pressure1_no_sensor_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.NO_SENSOR
         expected_error_str = ErrorStrings.NO_SENSOR
-        expected_alarm = ChannelAccess.ALARM_MAJOR
+        expected_alarm = self.ca.Alarms.MAJOR
         self._set_error(expected_error, self.CHANNEL_ONE)
 
         self.ca.assert_that_pv_is("1:ERROR", expected_error_str)
@@ -156,7 +156,7 @@ class Tpg26xTests(unittest.TestCase):
     def test_GIVEN_pressure1_identification_error_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.IDENTIFICATION_ERROR
         expected_error_str = ErrorStrings.IDENTIFICATION_ERROR
-        expected_alarm = ChannelAccess.ALARM_MAJOR
+        expected_alarm = self.ca.Alarms.MAJOR
         self._set_error(expected_error, self.CHANNEL_ONE)
 
         self.ca.assert_that_pv_is("1:ERROR", expected_error_str)
@@ -167,7 +167,7 @@ class Tpg26xTests(unittest.TestCase):
         self._set_pressure(expected_pressure, self.CHANNEL_TWO)
 
         self.ca.assert_that_pv_is("2:PRESSURE", expected_pressure)
-        self.ca.assert_that_pv_alarm_is("2:PRESSURE", ChannelAccess.ALARM_NONE)
+        self.ca.assert_that_pv_alarm_is("2:PRESSURE", self.ca.Alarms.NONE)
         self.ca.assert_that_pv_is("2:ERROR", "No Error")
 
     def test_GIVEN_negative_pressure2_set_WHEN_read_THEN_pressure2_is_as_expected(self):
@@ -185,7 +185,7 @@ class Tpg26xTests(unittest.TestCase):
     def test_GIVEN_pressure2_under_range_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.UNDER_RANGE
         expected_error_str = ErrorStrings.UNDER_RANGE
-        expected_alarm = ChannelAccess.ALARM_MINOR
+        expected_alarm = self.ca.Alarms.MINOR
         self._set_error(expected_error, self.CHANNEL_TWO)
 
         self.ca.assert_that_pv_is("2:ERROR", expected_error_str)
@@ -194,7 +194,7 @@ class Tpg26xTests(unittest.TestCase):
     def test_GIVEN_pressure2_over_range_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.OVER_RANGE
         expected_error_str = ErrorStrings.OVER_RANGE
-        expected_alarm = ChannelAccess.ALARM_MINOR
+        expected_alarm = self.ca.Alarms.MINOR
         self._set_error(expected_error, self.CHANNEL_TWO)
 
         self.ca.assert_that_pv_is("2:ERROR", expected_error_str)
@@ -203,7 +203,7 @@ class Tpg26xTests(unittest.TestCase):
     def test_GIVEN_pressure2_sensor_error_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.SENSOR_ERROR
         expected_error_str = ErrorStrings.SENSOR_ERROR
-        expected_alarm = ChannelAccess.ALARM_MAJOR
+        expected_alarm = self.ca.Alarms.MAJOR
         self._set_error(expected_error, self.CHANNEL_TWO)
 
         self.ca.assert_that_pv_is("2:ERROR", expected_error_str)
@@ -212,7 +212,7 @@ class Tpg26xTests(unittest.TestCase):
     def test_GIVEN_pressure2_sensor_off_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.SENSOR_OFF
         expected_error_str = ErrorStrings.SENSOR_OFF
-        expected_alarm = ChannelAccess.ALARM_MAJOR
+        expected_alarm = self.ca.Alarms.MAJOR
         self._set_error(expected_error, self.CHANNEL_TWO)
 
         self.ca.assert_that_pv_is("2:ERROR", expected_error_str)
@@ -221,7 +221,7 @@ class Tpg26xTests(unittest.TestCase):
     def test_GIVEN_pressure2_no_sensor_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.NO_SENSOR
         expected_error_str = ErrorStrings.NO_SENSOR
-        expected_alarm = ChannelAccess.ALARM_MAJOR
+        expected_alarm = self.ca.Alarms.MAJOR
         self._set_error(expected_error, self.CHANNEL_TWO)
 
         self.ca.assert_that_pv_is("2:ERROR", expected_error_str)
@@ -230,7 +230,7 @@ class Tpg26xTests(unittest.TestCase):
     def test_GIVEN_pressure2_identification_error_set_WHEN_read_THEN_error(self):
         expected_error = ErrorFlags.IDENTIFICATION_ERROR
         expected_error_str = ErrorStrings.IDENTIFICATION_ERROR
-        expected_alarm = ChannelAccess.ALARM_MAJOR
+        expected_alarm = self.ca.Alarms.MAJOR
         self._set_error(expected_error, self.CHANNEL_TWO)
 
         self.ca.assert_that_pv_is("2:ERROR", expected_error_str)

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -83,5 +83,4 @@ class Tpg300Tests(unittest.TestCase):
 
         for channel in CHANNELS:
             pv = "PRESSURE_{}".format(channel)
-            self.ca.assert_that_pv_alarm_is(pv, ChannelAccess.ALARM_INVALID)
-
+            self.ca.assert_that_pv_alarm_is(pv, self.ca.Alarms.INVALID)

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -83,5 +83,5 @@ class Tpg300Tests(unittest.TestCase):
 
         for channel in CHANNELS:
             pv = "PRESSURE_{}".format(channel)
-            self.ca.assert_pv_alarm_is(pv, ChannelAccess.ALARM_INVALID)
+            self.ca.assert_that_pv_alarm_is(pv, ChannelAccess.ALARM_INVALID)
 

--- a/tests/triton.py
+++ b/tests/triton.py
@@ -115,7 +115,7 @@ class TritonTests(unittest.TestCase):
 
         # Allow truncation for long status, but it should still display as many characters as possible
         self._lewis.backdoor_set_on_device("status", long_status)
-        self.ca.assert_pv_value_causes_func_to_return_true(
+        self.ca.assert_that_pv_value_causes_func_to_return_true(
             "STATUS", lambda val: long_status.startswith(val) and len(val) >= minimum_characters_in_pv)
 
     @skip_if_recsim("Lewis backdoor not available in recsim")
@@ -175,8 +175,8 @@ class TritonTests(unittest.TestCase):
     @skip_if_recsim("Lewis backdoor not available in recsim")
     def test_WHEN_read_mc_id_is_issued_via_arbitrary_command_THEN_response_is_in_format_device_uses(self):
         self.ca.set_pv_value("ARBITRARY:SP", "READ:SYS:DR:CHAN:MC")
-        self.ca.assert_pv_value_causes_func_to_return_true("ARBITRARY",
-                                                           lambda val: val.startswith("STAT:SYS:DR:CHAN:MC:"))
+        self.ca.assert_that_pv_value_causes_func_to_return_true("ARBITRARY",
+                                                                lambda val: val.startswith("STAT:SYS:DR:CHAN:MC:"))
 
     @skip_if_recsim("Lewis backdoor not available in recsim")
     def test_WHEN_channel_temperature_is_set_via_backdoor_THEN_the_pvs_update_with_values_just_written(self):

--- a/tests/xyarmbeamstop.py
+++ b/tests/xyarmbeamstop.py
@@ -78,7 +78,7 @@ class XyarmbeamstopTests(unittest.TestCase):
     def setUp(self):
         self._ioc = IOCRegister.get_running("GALIL_01")
         self.ca = ChannelAccess(default_timeout=30)
-        self.ca.wait_for(MOTOR_X, timeout=60)
+        self.ca.assert_that_pv_exists(MOTOR_X, timeout=60)
         self._set_pv_value(STORE_SP, ACTIVE)
         self._assert_setpoint_and_readback_reached(ACTIVE_X, ACTIVE_Y)
 

--- a/utils/channel_access.py
+++ b/utils/channel_access.py
@@ -35,8 +35,9 @@ class ChannelAccess(object):
         """
         Constructor.
 
-        :param device_prefix: the device prefix which will be added to the start of all pvs
-        :param default_timeout: the default time out to wait for
+        Args:
+            device_prefix: the device prefix which will be added to the start of all pvs
+            default_timeout: the default time out to wait for
         """
         self.ca = CaChannelWrapper()
 
@@ -59,12 +60,13 @@ class ChannelAccess(object):
         """
         Sets the specified PV to the supplied value.
 
-        :param pv: the EPICS PV name
-        :param value: the value to set
+        Args:
+            pv: the EPICS PV name
+            value: the value to set
         """
         # Wait for the PV to exist before writing to it. If this is not here sometimes the tests try to jump the gun
         # and attempt to write to a PV that doesn't exist yet
-        self.wait_for(pv)
+        self.assert_that_pv_exists(pv)
 
         # Don't use wait=True because it will cause an infinite wait if the value never gets set successfully
         # In that case the test should fail (because the correct value is not set)
@@ -77,8 +79,10 @@ class ChannelAccess(object):
         """
         Gets the current value for the specified PV.
 
-        :param pv: the EPICS PV name
-        :return: the current value
+        Args:
+            pv: the EPICS PV name
+        Returns:
+            the current value
         """
         return self.ca.get_pv_value(self._create_pv_with_prefix(pv))
 
@@ -86,8 +90,8 @@ class ChannelAccess(object):
         """
         Makes the pv process once.
 
-        :param pv: the EPICS PV name
-        :return: None
+        Args:
+            pv: the EPICS PV name
         """
         pv_proc = "{}.PROC".format(self._create_pv_with_prefix(pv))
         return self.ca.set_pv_value(pv_proc, 1)
@@ -95,166 +99,14 @@ class ChannelAccess(object):
     def _format_value(self, value):
         return "'{}' (type: '{}')".format(value, value.__class__.__name__)
 
-    def assert_that_pv_is(self, pv, expected_value, timeout=None, msg=None):
-        """
-        Assert that the pv has the expected value or that it becomes the expected value within the timeout.
-
-        :param pv: pv name
-        :param expected_value: expected value
-        :param timeout: if it hasn't changed within this time raise assertion error
-        :param msg: Extra message to print
-        :raises AssertionError: if value does not become requested value
-        :raises UnableToConnectToPVException: if pv does not exist within timeout
-        """
-
-        if msg is None:
-            msg = "Expected PV to have value {}.".format(self._format_value(expected_value))
-
-        return self.assert_pv_value_causes_func_to_return_true(
-            pv, lambda val: val == expected_value, timeout=timeout, message=msg)
-
-    def assert_that_pv_is_not(self, pv, restricted_value, timeout=None, msg=""):
-        """
-        Assert that the pv does not have a particular value and optionally it does not become that value within the
-        timeout.
-
-        :param pv: pv name
-        :param restricted_value: value the PV shouldn't become
-        :param timeout: if it becomes the value within this time, raise an assertion error
-        :param msg: Extra message to print
-        :raises AssertionError: if value has the restricted value
-        :raises UnableToConnectToPVException: if pv does not exist within timeout
-        """
-
-        if msg is None:
-            msg = "Expected PV to not have value {}.".format(self._format_value(restricted_value))
-
-        return self.assert_pv_value_causes_func_to_return_true(
-            pv, lambda val: val != restricted_value, timeout, message=msg)
-
-    def assert_that_pv_is_number(self, pv, expected_value, tolerance=0, timeout=None):
-        """
-        Assert that the pv has the expected value or that it becomes the expected value within the timeout
-        :param pv: pv name
-        :param expected_value: expected value
-        :param tolerance: the allowable deviation from the expected value
-        :param timeout: if it hasn't changed within this time raise assertion error
-        :raises AssertionError: if value does not become requested value
-        :raises UnableToConnectToPVException: if pv does not exist within timeout
-        """
-        def condition(val):
-            try:
-                val = float(val)
-            except (ValueError, TypeError):
-                return False
-            return abs(val - expected_value) <= tolerance
-
-        message = "Expected PV value to be equal to {} (tolerance: {})"\
-            .format(self._format_value(expected_value), self._format_value(tolerance))
-
-        return self.assert_pv_value_causes_func_to_return_true(pv, condition, timeout, message=message)
-
-    def assert_that_pv_is_not_number(self, pv, restricted_value, tolerance=0, timeout=None):
-        """
-        Assert that the pv is at least tolerance from the restricted value within the timeout
-        :param pv: pv name
-        :param restricted_value: the value we don't want the PV to have
-        :param tolerance: the minimal deviation from the expected value
-        :param timeout: if it hasn't changed within this time raise assertion error
-        :raises AssertionError: if value does not enter the desired range
-        :raises UnableToConnectToPVException: if pv does not exist within timeout
-        """
-        def condition(val):
-            try:
-                val = float(val)
-            except (ValueError, TypeError):
-                return False
-            return abs(val - restricted_value) >= tolerance
-
-        message = "Expected PV value to be not equal to {} (tolerance: {})"\
-            .format(self._format_value(restricted_value), self._format_value(tolerance))
-
-        return self.assert_pv_value_causes_func_to_return_true(pv, condition, timeout=timeout, message=message)
-
-    def assert_that_pv_is_one_of(self, pv, expected_values, timeout=None):
-        """
-        Assert that the pv has one of the expected values or that it becomes one of the expected value within the
-        timeout.
-
-        :param pv: pv name
-        :param expected_values: expected values
-        :param timeout: if it hasn't changed within this time raise assertion error
-        :return:
-        :raises AssertionError: if value does not become requested value
-        :raises UnableToConnectToPVException: if pv does not exist within timeout
-        """
-        def condition(val):
-            return val in expected_values
-
-        message = "Expected PV value to be in {}".format(expected_values)
-
-        return self.assert_pv_value_causes_func_to_return_true(pv, condition, timeout, message)
-
-    def assert_that_pv_is_an_integer_between(self, pv, min_value, max_value, timeout=None):
-        """
-        Assert that the pv has one of the expected values or that it becomes one of the expected value within the
-        timeout
-
-        :param pv: pv name
-        :param min_value: minimum value (inclusive)
-        :param max_value: maximum value (inclusive)
-        :param timeout: if it hasn't changed within this time raise assertion error
-        :return:
-        :raises AssertionError: if value does not become requested value
-        :raises UnableToConnectToPVException: if pv does not exist within timeout
-        """
-        def condition(val):
-            try:
-                int_pv_value = int(val)
-            except ValueError:
-                return False
-
-            return min_value <= int_pv_value <= max_value
-
-        message = "Expected PV value to be an integer between {} and {}".format(min_value, max_value)
-
-        return self.assert_pv_value_causes_func_to_return_true(pv, condition, timeout, message)
-
-    def wait_for(self, pv, timeout=None):
-        """
-        Wait for pv to be available or timeout and throw UnableToConnectToPVException.
-
-        :param pv: pv to wait for
-        :param timeout: time to wait for
-        :return:
-        :raises UnableToConnectToPVException: if pv can not be connected to after given time
-        """
-        if timeout is None:
-            timeout = self._default_timeout
-
-        if not self.ca.pv_exists(self._create_pv_with_prefix(pv), timeout=timeout):
-            raise AssertionError("PV {pv} does not exist".format(pv=self._create_pv_with_prefix(pv)))
-
-    def assert_pv_does_not_exist(self, pv, timeout=2):
-        """
-        Asserts that a pv does not exist.
-
-        :param pv: pv to wait for
-        :param timeout: amount of time to wait for
-        :return:
-        :raises AssertionError: if pv exists
-        """
-
-        pv_name = self._create_pv_with_prefix(pv)
-        if self.ca.pv_exists(pv_name, timeout):
-            raise AssertionError("PV {pv} exists".format(pv=self._create_pv_with_prefix(pv)))
-
     def _create_pv_with_prefix(self, pv):
         """
         Create the full pv name with instrument prefix.
 
-        :param pv: pv name without prefix
-        :return: pv name with prefix
+        Args:
+            pv: pv name without prefix
+        Returns:
+            pv name with prefix
         """
         return "{prefix}{pv}".format(prefix=self.prefix, pv=pv)
 
@@ -262,9 +114,11 @@ class ChannelAccess(object):
         """
         Wait for a lambda containing a pv to become None; return value or timeout and return actual value.
 
-        :param wait_for_lambda: lambda we expect to be None
-        :param timeout: time out period
-        :return: final value of lambda
+        Args:
+            wait_for_lambda: lambda we expect to be None
+            timeout: time out period
+        Returns:
+            final value of lambda
         """
         start_time = time.time()
         current_time = start_time
@@ -279,8 +133,6 @@ class ChannelAccess(object):
                     return lambda_value
             except UnableToConnectToPVException:
                 pass  # try again next loop maybe the PV will be up
-            except Exception as e:
-                return "Exception in function while waiting for PV. Error was: {}".format(e)
 
             time.sleep(0.5)
             current_time = time.time()
@@ -288,89 +140,25 @@ class ChannelAccess(object):
         # last try
         return wait_for_lambda()
 
-    def assert_pv_alarm_is(self, pv, alarm, timeout=None):
-        """
-        Assert that a pv is in alarm state given or timeout.
-
-        :param pv: pv name
-        :param alarm: alarm state (see constants ALARM_X)
-        :param timeout: length of time to wait for change
-        :return:
-        :raises AssertionError: if alarm does not become requested value
-        :raises UnableToConnectToPVException: if pv does not exist within timeout
-        """
-        self.assert_that_pv_is("{pv}.SEVR".format(pv=pv), alarm, timeout=timeout)
-
-    def assert_setting_setpoint_sets_readback(self, value, readback_pv, set_point_pv=None, expected_value=None,
-                                              expected_alarm=Alarms.NONE, timeout=None):
-        """
-        Set a pv to a value and check that the readback has the expected value and alarm state.
-        :param value: value to set
-        :param readback_pv: the pv for the read back (e.g. IN:INST:TEMP)
-        :param set_point_pv: the pv to check has the correct value;
-            if None use the readback with SP  (e.g. IN:INST:TEMP:SP)
-        :param expected_value: the expected return value; if None use the value
-        :param expected_alarm: the expected alarm status, None don't check; defaults to ALARM_NONE
-        :param timeout: timeout for the pv and alarm to become the expected values
-        :return:
-        :raises AssertionError: if setback does not become expected value or has incorrect alarm state
-        :raises UnableToConnectToPVException: if a pv does not exist within timeout
-        """
-        if set_point_pv is None:
-            set_point_pv = "{}:SP".format(readback_pv)
-        if expected_value is None:
-            expected_value = value
-
-        self.set_pv_value(set_point_pv, value)
-        self.assert_that_pv_is(readback_pv, expected_value, timeout=timeout)
-        if expected_alarm is not None:
-            self.assert_pv_alarm_is(readback_pv, expected_alarm, timeout=timeout)
-
-    def assert_pv_value_over_time(self, pv, wait, comparator):
-        """
-        Check that a PV satisfies a given function over time. The initial value is compared to the final value after
-        a given time using the comparator.
-        :param pv: the PV to check
-        :param wait: the number of seconds to wait
-        :param comparator: a function taking two arguments; the initial and final values respectively. 
-        The function should return true or false.
-        :return:
-        :raises AssertionError: if the value of the pv has not increased
-        """
-        initial_value = self.get_pv_value(pv)
-        time.sleep(wait)
-
-        message = "Expected value trend to satisfy comparator {}. Initial value was {}."\
-            .format(comparator.__name__, self._format_value(initial_value))
-
-        def condition(val):
-            return comparator(val, initial_value)
-
-        return self.assert_pv_value_causes_func_to_return_true(pv, condition, message=message)
-
-    # Special cases of assert_pv_value_over_time
-    assert_pv_value_is_increasing = partialmethod(assert_pv_value_over_time, comparator=operator.gt)
-    assert_pv_value_is_decreasing = partialmethod(assert_pv_value_over_time, comparator=operator.lt)
-    assert_pv_value_is_unchanged = partialmethod(assert_pv_value_over_time, comparator=operator.eq)
-
-    def assert_pv_value_causes_func_to_return_true(self, pv, func, timeout=None, message=None):
+    def assert_that_pv_value_causes_func_to_return_true(self, pv, func, timeout=None, message=None):
         """
         Check that a PV satisfies a given function within some timeout.
-        :param pv: the PV to check
-        :param func: a function that takes one argument, the PV value, and returns True if the value is valid.
-        :param timeout: time to wait for the PV to satisfy the function
-        :param message: custom message to print on failure
-        :raises: AssertionError: If the function does not evaluate to true within the given timeout
+
+        Args:
+            pv: the PV to check
+            func: a function that takes one argument, the PV value, and returns True if the value is valid.
+            timeout: time to wait for the PV to satisfy the function
+            message: custom message to print on failure
+        Raises:
+            AssertionError: If the function does not evaluate to true within the given timeout
         """
         def wrapper(message):
             value = self.get_pv_value(pv)
-
             try:
                 return_value = func(value)
             except Exception as e:
                 return "Exception was thrown while evaluating function '{}' on pv value {}. Exception was: {} {}"\
                     .format(func.__name__, self._format_value(value), e.__class__.__name__, e.message)
-
             if return_value:
                 return None
             else:
@@ -387,17 +175,262 @@ class ChannelAccess(object):
         if err is not None:
             raise AssertionError(err)
 
+    def assert_that_pv_is(self, pv, expected_value, timeout=None, msg=None):
+        """
+        Assert that the pv has the expected value or that it becomes the expected value within the timeout.
+
+        Args:
+            pv: pv name
+            expected_value: expected value
+            timeout: if it hasn't changed within this time raise assertion error
+            msg: Extra message to print
+        Raises:
+            AssertionError: if value does not become requested value
+            UnableToConnectToPVException: if pv does not exist within timeout
+        """
+
+        if msg is None:
+            msg = "Expected PV to have value {}.".format(self._format_value(expected_value))
+
+        return self.assert_that_pv_value_causes_func_to_return_true(
+            pv, lambda val: val == expected_value, timeout=timeout, message=msg)
+
+    def assert_that_pv_is_not(self, pv, restricted_value, timeout=None, msg=""):
+        """
+        Assert that the pv does not have a particular value and optionally it does not become that value within the
+        timeout.
+
+        Args:
+            pv: pv name
+            restricted_value: value the PV shouldn't become
+            timeout: if it becomes the value within this time, raise an assertion error
+            msg: Extra message to print
+        Raises:
+            AssertionError: if value has the restricted value
+            UnableToConnectToPVException: if pv does not exist within timeout
+        """
+        if msg is None:
+            msg = "Expected PV to not have value {}.".format(self._format_value(restricted_value))
+
+        return self.assert_that_pv_value_causes_func_to_return_true(
+            pv, lambda val: val != restricted_value, timeout, message=msg)
+
+    def assert_that_pv_is_number(self, pv, expected_value, tolerance=0, timeout=None):
+        """
+        Assert that the pv has the expected value or that it becomes the expected value within the timeout
+        
+        Args:
+            pv: pv name
+            expected_value: expected value
+            tolerance: the allowable deviation from the expected value
+            timeout: if it hasn't changed within this time raise assertion error
+        Raises:
+            AssertionError: if value does not become requested value
+            UnableToConnectToPVException: if pv does not exist within timeout
+        """
+        def condition(val):
+            try:
+                val = float(val)
+            except (ValueError, TypeError):
+                return False
+            return abs(val - expected_value) <= tolerance
+
+        message = "Expected PV value to be equal to {} (tolerance: {})"\
+            .format(self._format_value(expected_value), self._format_value(tolerance))
+
+        return self.assert_that_pv_value_causes_func_to_return_true(pv, condition, timeout, message=message)
+
+    def assert_that_pv_is_not_number(self, pv, restricted_value, tolerance=0, timeout=None):
+        """
+        Assert that the pv is at least tolerance from the restricted value within the timeout
+
+        Args:
+             pv: pv name
+             restricted_value: the value we don't want the PV to have
+             tolerance: the minimal deviation from the expected value
+             timeout: if it hasn't changed within this time raise assertion error
+        Raises:
+             AssertionError: if value does not enter the desired range
+             UnableToConnectToPVException: if pv does not exist within timeout
+        """
+        def condition(val):
+            try:
+                val = float(val)
+            except (ValueError, TypeError):
+                return False
+            return abs(val - restricted_value) >= tolerance
+
+        message = "Expected PV value to be not equal to {} (tolerance: {})"\
+            .format(self._format_value(restricted_value), self._format_value(tolerance))
+
+        return self.assert_that_pv_value_causes_func_to_return_true(pv, condition, timeout=timeout, message=message)
+
+    def assert_that_pv_is_one_of(self, pv, expected_values, timeout=None):
+        """
+        Assert that the pv has one of the expected values or that it becomes one of the expected value within the
+        timeout.
+
+        Args:
+             pv: pv name
+             expected_values: expected values
+             timeout: if it hasn't changed within this time raise assertion error
+        Raises:
+             AssertionError: if value does not become requested value
+             UnableToConnectToPVException: if pv does not exist within timeout
+        """
+        def condition(val):
+            return val in expected_values
+
+        message = "Expected PV value to be in {}".format(expected_values)
+
+        return self.assert_that_pv_value_causes_func_to_return_true(pv, condition, timeout, message)
+
+    def assert_that_pv_is_an_integer_between(self, pv, min_value, max_value, timeout=None):
+        """
+        Assert that the pv has one of the expected values or that it becomes one of the expected value within the
+        timeout
+
+        Args:
+             pv: pv name
+             min_value: minimum value (inclusive)
+             max_value: maximum value (inclusive)
+             timeout: if it hasn't changed within this time raise assertion error
+        Raises:
+             AssertionError: if value does not become requested value
+             UnableToConnectToPVException: if pv does not exist within timeout
+        """
+        def condition(val):
+            try:
+                int_pv_value = int(val)
+            except ValueError:
+                return False
+
+            return min_value <= int_pv_value <= max_value
+
+        message = "Expected PV value to be an integer between {} and {}".format(min_value, max_value)
+
+        return self.assert_that_pv_value_causes_func_to_return_true(pv, condition, timeout, message)
+
+    def assert_that_pv_exists(self, pv, timeout=None):
+        """
+        Wait for pv to be available or timeout and throw UnableToConnectToPVException.
+
+        Args:
+             pv: pv to wait for
+             timeout: time to wait for
+        Raises:
+             UnableToConnectToPVException: if pv can not be connected to after given time
+        """
+        if timeout is None:
+            timeout = self._default_timeout
+
+        if not self.ca.pv_exists(self._create_pv_with_prefix(pv), timeout=timeout):
+            raise AssertionError("PV {pv} does not exist".format(pv=self._create_pv_with_prefix(pv)))
+
+    def assert_that_pv_does_not_exist(self, pv, timeout=2):
+        """
+        Asserts that a pv does not exist.
+
+        Args:
+             pv: pv to wait for
+             timeout: amount of time to wait for
+        Raises:
+             AssertionError: if pv exists
+        """
+
+        pv_name = self._create_pv_with_prefix(pv)
+        if self.ca.pv_exists(pv_name, timeout):
+            raise AssertionError("PV {pv} exists".format(pv=self._create_pv_with_prefix(pv)))
+
+    def assert_that_pv_alarm_is(self, pv, alarm, timeout=None):
+        """
+        Assert that a pv is in alarm state given or timeout.
+
+        Args:
+             pv: pv name
+             alarm: alarm state (see constants ALARM_X)
+             timeout: length of time to wait for change
+        Raises:
+             AssertionError: if alarm does not become requested value
+             UnableToConnectToPVException: if pv does not exist within timeout
+        """
+        self.assert_that_pv_is("{pv}.SEVR".format(pv=pv), alarm, timeout=timeout)
+
+    def assert_setting_setpoint_sets_readback(self, value, readback_pv, set_point_pv=None, expected_value=None,
+                                              expected_alarm=Alarms.NONE, timeout=None):
+        """
+        Set a pv to a value and check that the readback has the expected value and alarm state.
+
+        Args:
+             value: value to set
+             readback_pv: the pv for the read back (e.g. IN:INST:TEMP)
+             set_point_pv: the pv to check has the correct value;
+            if None use the readback with SP  (e.g. IN:INST:TEMP:SP)
+             expected_value: the expected return value; if None use the value
+             expected_alarm: the expected alarm status, None don't check; defaults to ALARM_NONE
+             timeout: timeout for the pv and alarm to become the expected values
+        Raises:
+             AssertionError: if setback does not become expected value or has incorrect alarm state
+             UnableToConnectToPVException: if a pv does not exist within timeout
+        """
+        if set_point_pv is None:
+            set_point_pv = "{}:SP".format(readback_pv)
+        if expected_value is None:
+            expected_value = value
+
+        self.set_pv_value(set_point_pv, value)
+        self.assert_that_pv_is(readback_pv, expected_value, timeout=timeout)
+        if expected_alarm is not None:
+            self.assert_that_pv_alarm_is(readback_pv, expected_alarm, timeout=timeout)
+
+    def assert_that_pv_value_over_time_satisfies_comparator(self, pv, wait, comparator):
+        """
+        Check that a PV satisfies a given function over time. The initial value is compared to the final value after
+        a given time using the comparator.
+
+        Args:
+             pv: the PV to check
+             wait: the number of seconds to wait
+             comparator: a function taking two arguments; the initial and final values, which should return a boolean
+        Raises:
+             AssertionError: if the value of the pv has not increased
+        """
+        initial_value = self.get_pv_value(pv)
+        time.sleep(wait)
+
+        message = "Expected value trend to satisfy comparator {}. Initial value was {}."\
+            .format(comparator.__name__, self._format_value(initial_value))
+
+        def condition(val):
+            return comparator(val, initial_value)
+
+        return self.assert_that_pv_value_causes_func_to_return_true(pv, condition, message=message)
+
+    # Special cases of assert_pv_value_over_time
+    assert_that_pv_value_is_increasing = \
+        partialmethod(assert_that_pv_value_over_time_satisfies_comparator, comparator=operator.gt)
+
+    assert_that_pv_value_is_decreasing = \
+        partialmethod(assert_that_pv_value_over_time_satisfies_comparator, comparator=operator.lt)
+
+    assert_that_pv_value_is_unchanged = \
+        partialmethod(assert_that_pv_value_over_time_satisfies_comparator, comparator=operator.eq)
+
     # Using a context manager to put PVs into alarm means they don't accidentally get left in alarm if the test fails
     @contextmanager
     def put_simulated_record_into_alarm(self, pv, alarm):
         """
         Put a simulated record into alarm
-        :param pv: pv to put into alarm
-        :param alarm: type of alarm
+
+        Args:
+             pv: pv to put into alarm
+             alarm: type of alarm
+        Raises:
+            AssertionError if the simulated alarm status could not be set.
         """
         def _set_and_check_simulated_alarm(set_check_pv, set_check_alarm):
             self.set_pv_value("{}.SIMS".format(set_check_pv), set_check_alarm)
-            self.assert_pv_alarm_is("{}".format(set_check_pv), set_check_alarm)
+            self.assert_that_pv_alarm_is("{}".format(set_check_pv), set_check_alarm)
 
         try:
             _set_and_check_simulated_alarm(pv, alarm)

--- a/utils/ioc_launcher.py
+++ b/utils/ioc_launcher.py
@@ -122,7 +122,7 @@ class IocLauncher(object):
         ca = self._get_channel_access()
         try:
             print("Check that IOC is not running")
-            ca.assert_pv_does_not_exist(self.RECORD_THAT_ALWAYS_EXISTS)
+            ca.assert_that_pv_does_not_exist(self.RECORD_THAT_ALWAYS_EXISTS)
         except AssertionError as ex:
             raise AssertionError("IOC '{}' appears to already be running: {}".format(self._device, ex))
 
@@ -168,7 +168,7 @@ class IocLauncher(object):
 
             for _ in range(int(max_wait_for_ioc_to_die/wait_per_loop)):
                 try:
-                    self._get_channel_access().assert_pv_does_not_exist(self.RECORD_THAT_ALWAYS_EXISTS)
+                    self._get_channel_access().assert_that_pv_does_not_exist(self.RECORD_THAT_ALWAYS_EXISTS)
                     break
                 except AssertionError:
                     sleep(wait_per_loop)


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/3281

Refactor the `ChannelAccess` class in the test framework.

The following has been done:
- Consolidate all functions to call a common one, `assert_that_pv_value_causes_func_to_return_true`. This removes a lot of duplicate logic
- Refactor the alarms to be a class within `ChannelAccess` rather than constants with a common prefix
- Convert documentation to new style
- Adjust assertion naming to improve consistency