### PR TITLE
Ticket3363: Running a class of tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,25 +22,39 @@ python run_tests.py
 
 There is a batch file which does this for you, called `run_tests.bat`
 
-### Running specific tests
+### Running tests in modules
 
-Specify the test modules you want to run via the `-tm` argument:
-
-```
-python run_tests.py -tm instron_stress_rig amint2l  # Will run the stress rig tests and then the amint2l tests.
-```
-
-The argument is the name of the module containing the tests. This is the same as the name of the file in the `tests` directory, with the `.py` extension removed.
-
-### Running specific tests by name
-
-Specify the test modules you want to run via the `-tm` argument and the test name you want to run via the `-tn` argument:
+You can run tests in specific modules using the `-t` argument as follows:
 
 ```
-python run_tests.py -tm amint2l -tn test_GIVEN_pressure_over_range_set_WHEN_read_THEN_error  # Will run test_GIVEN_pressure_over_range_set_WHEN_read_THEN_error test in amint2l tests.
+python run_tests.py -t instron_stress_rig amint2l  # Will run the stress rig tests and then the amint2l tests.
 ```
 
-The `-tm` argument is the name of the module containing the tests. This is the same as the name of the file in the `tests` directory, with the `.py` extension removed. The `-tn` argument is the name of the test in the module containing the test with no arguments or parentheses.
+The argument is the name of the module containing the tests. This is the same as the name of the file in the `tests` 
+directory, with the `.py` extension removed.
+
+### Running tests in classes
+
+You can run classes of tests in modules using the `-t` argument as follows:
+
+```
+python run_tests.py -t sp2xx.RunCommandTests # This will run all the tests in the RunCommandTests class in the sp2xx module. 
+```
+
+The argument is the "dotted name" of the class containing the tests. The dotted name takes the form `module.class`.
+You can run the tests in multiple classes in different modules.
+
+### Running tests by name
+
+You can run tests by name using `-t` argument as follows:
+
+```
+python run_tests.py -t sp2xx.RunCommandTests.test_that_GIVEN_an_initialized_pump_THEN_it_is_stopped # This will run the test_that_GIVEN_an_initialized_pump_THEN_it_is_stopped test in the RunCommandTests class in the sp2xx module. 
+```
+
+The argument is the "dotted name" of the test containing the tests. The dotted name takes the form `module.class.test`.
+You can run multiple tests from multiple classes in different modules.
+
 
 ## Troubleshooting 
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ This can be avoided by calling the decorator like ` @skip_if_recsim("In rec sim 
 * Solution is to ensure a consistent startup state in the setUp method of the tests. 
 This will run before each test, and it should “reset” all relevant properties of the device so that each test always starts from a consistent starting state
 * Doing lots in the setup method will make the tests run a bit slower – this is preferable to having inconsistently passing tests!
+* When creating base classes for tests please have your base class inherit from `object` and your subclasses inherit
+from your base class and `unittest.TestCase`. See [Python unit tests with base and sub class](https://stackoverflow.com/questions/1323455/python-unit-test-with-base-and-sub-class)
+for more discussion.
 
 ### Parameterised tests
 You can create tests which check a few values, e.g. boundaries, negative numbers, zero, floats and integers (if applicable to the device):

--- a/common_tests/danfysik.py
+++ b/common_tests/danfysik.py
@@ -1,5 +1,3 @@
-import unittest
-
 from utils.test_modes import TestModes
 from utils.channel_access import ChannelAccess
 from utils.testing import skip_if_recsim, get_running_lewis_and_ioc
@@ -18,7 +16,7 @@ TEST_CURRENTS = [0.4, 47, 10000]
 TEST_VOLTAGES = TEST_CURRENTS
 
 
-class DanfysikBase(unittest.TestCase):
+class DanfysikBase(object):
     """
     Tests for danfysik.
     """

--- a/common_tests/fermichopper.py
+++ b/common_tests/fermichopper.py
@@ -1,4 +1,3 @@
-import unittest
 from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 from time import sleep
@@ -11,7 +10,7 @@ from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
 
 
 @six.add_metaclass(ABCMeta)
-class FermichopperBase(unittest.TestCase):
+class FermichopperBase(object):
     """
     Tests for the Fermi Chopper IOC.
     """

--- a/common_tests/riken_changeover.py
+++ b/common_tests/riken_changeover.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 import itertools
 import six
 from abc import ABCMeta, abstractmethod
@@ -63,7 +62,7 @@ def build_power_supplies_list(riken_setup):
 
 
 @six.add_metaclass(ABCMeta)
-class RikenChangeover(unittest.TestCase):
+class RikenChangeover(object):
     """
     Tests for a riken changeover.
 

--- a/run_utils.py
+++ b/run_utils.py
@@ -4,6 +4,39 @@ import os
 from contextlib import contextmanager
 
 
+def package_contents(package_name):
+    """
+    Finds all the modules in a package.
+
+    :param package_name: the name of the package
+    :return: a set containing all the module names
+    """
+    filename, pathname, description = imp.find_module(package_name)
+    if filename:
+        raise ImportError('Not a package: %r', package_name)
+    # Use a set because some may be both source and compiled.
+    return set([os.path.splitext(module)[0] for module in os.listdir(pathname)
+                if module.endswith('.py') and not module.startswith("__init__")])
+
+
+@contextmanager
+def modified_environment(**kwargs):
+    """
+    Modifies the environment variables as required then returns them to their original state.
+
+    :param kwargs: the settings to apply
+    """
+    # Copying old values
+    old_env = {name: os.environ.get(name, '') for name in kwargs.keys()}
+
+    # Apply new settings and then yield
+    os.environ.update(kwargs)
+    yield
+
+    # Restore old values
+    os.environ.update(old_env)
+
+
 class ModuleTests(object):
     """
     Object which contains information about tests in a module to be run.
@@ -72,34 +105,3 @@ def check_test_modes(module):
     return modes
 
 
-def package_contents(package_name):
-    """
-    Finds all the modules in a package.
-
-    :param package_name: the name of the package
-    :return: a set containing all the module names
-    """
-    filename, pathname, description = imp.find_module(package_name)
-    if filename:
-        raise ImportError('Not a package: %r', package_name)
-    # Use a set because some may be both source and compiled.
-    return set([os.path.splitext(module)[0] for module in os.listdir(pathname)
-                if module.endswith('.py') and not module.startswith("__init__")])
-
-
-@contextmanager
-def modified_environment(**kwargs):
-    """
-    Modifies the environment variables as required then returns them to their original state.
-
-    :param kwargs: the settings to apply
-    """
-    # Copying old values
-    old_env = {name: os.environ.get(name, '') for name in kwargs.keys()}
-
-    # Apply new settings and then yield
-    os.environ.update(kwargs)
-    yield
-
-    # Restore old values
-    os.environ.update(old_env)

--- a/run_utils.py
+++ b/run_utils.py
@@ -1,0 +1,105 @@
+import imp
+import importlib
+import os
+from contextlib import contextmanager
+
+
+class ModuleTests(object):
+    """
+    Object which contains information about tests in a module to be run.
+
+    Attributes:
+        name: Name of the module where the tests are.
+        tests: List of "dotted" test names. E.g. SampleTests.SampleTestCase.test_two runs
+            test_two in SampleTestCase class in the SampleTests module.
+        file: Reference to the module.
+        modes: Modes to run the tests in.
+    """
+
+    def __init__(self, name):
+        self.__name = name
+        self.tests = None
+        self.__file = self.__get_file_reference()
+        self.__modes = self.__get_modes()
+
+    @property
+    def name(self):
+        """ Returns the name of the module."""
+        return self.__name
+
+    @property
+    def modes(self):
+        """ Returns the modes to run the tests in. """
+        return self.__modes
+
+    @property
+    def file(self):
+        """ Returns a reference to the module file. """
+        return self.__file
+
+    def __get_file_reference(self):
+        module = load_module("tests.{}".format(self.__name))
+        return module
+
+    def __get_modes(self):
+        if not self.__file:
+            self.__get_file_reference()
+        return check_test_modes(self.__file)
+
+
+def load_module(name):
+    """
+    Loads a module based on its name.
+
+    :param name: the name of the module
+    :return: a reference to the module
+    """
+    return importlib.import_module(name, )
+
+
+def check_test_modes(module):
+    """
+    Checks for RECSIM and DEVSIM test modes.
+
+    :param module: Modules to check for RECSIM and DEVSIM test modes
+    :return: set: Modes that the tests can be run in.
+    """
+    try:
+        modes = set(module.TEST_MODES)
+    except AttributeError:
+        raise ValueError("Expected test module {} to contain a TEST_MODES attribute".format(module.__name__))
+
+    return modes
+
+
+def package_contents(package_name):
+    """
+    Finds all the modules in a package.
+
+    :param package_name: the name of the package
+    :return: a set containing all the module names
+    """
+    filename, pathname, description = imp.find_module(package_name)
+    if filename:
+        raise ImportError('Not a package: %r', package_name)
+    # Use a set because some may be both source and compiled.
+    return set([os.path.splitext(module)[0] for module in os.listdir(pathname)
+                if module.endswith('.py') and not module.startswith("__init__")])
+
+
+@contextmanager
+def modified_environment(**kwargs):
+    """
+    Modifies the environment variables as required then returns them to their original state.
+
+    :param kwargs: the settings to apply
+    """
+    # Copying old values
+    old_env = {name: os.environ.get(name, '') for name in kwargs.keys()}
+
+    # Apply new settings and then yield
+    os.environ.update(kwargs)
+    yield
+
+    # Restore old values
+    os.environ.update(old_env)

--- a/tests/danfysik8000.py
+++ b/tests/danfysik8000.py
@@ -1,4 +1,4 @@
-from time import sleep
+import unittest
 
 from utils.test_modes import TestModes
 from utils.ioc_launcher import get_default_ioc_dir
@@ -43,7 +43,7 @@ INTERLOCKS = {
 }
 
 
-class Danfysik8000Tests(DanfysikBase):
+class Danfysik8000Tests(DanfysikBase, unittest.TestCase):
     """
     Tests for danfysik model 8000. Tests inherited from DanfysikBase.
     """

--- a/tests/danfysik8800.py
+++ b/tests/danfysik8800.py
@@ -1,4 +1,4 @@
-from time import sleep
+import unittest
 
 from utils.test_modes import TestModes
 from utils.ioc_launcher import get_default_ioc_dir
@@ -47,7 +47,7 @@ INTERLOCKS = {
 }
 
 
-class Danfysik8800Tests(DanfysikBase):
+class Danfysik8800Tests(DanfysikBase, unittest.TestCase):
     """
     Tests for danfysik model 8800. Tests inherited from DanfysikBase.
     """

--- a/tests/fermichopper_maps.py
+++ b/tests/fermichopper_maps.py
@@ -1,3 +1,4 @@
+import unittest
 from utils.test_modes import TestModes
 from utils.ioc_launcher import get_default_ioc_dir
 from common_tests.fermichopper import FermichopperBase
@@ -23,7 +24,7 @@ IOCS = [
 TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
 
 
-class MapsFermiChopperTests(FermichopperBase):
+class MapsFermiChopperTests(FermichopperBase, unittest.TestCase):
     """
     All tests inherited from FermiChopperBase
     """

--- a/tests/fermichopper_merlin.py
+++ b/tests/fermichopper_merlin.py
@@ -1,3 +1,4 @@
+import unittest
 from utils.test_modes import TestModes
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.testing import skip_if_recsim
@@ -24,7 +25,7 @@ IOCS = [
 TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
 
 
-class MerlinFermiChopperTests(FermichopperBase):
+class MerlinFermiChopperTests(FermichopperBase, unittest.TestCase):
     """
     Most tests inherited from FermiChopperBase
 

--- a/tests/rikenportchangeover.py
+++ b/tests/rikenportchangeover.py
@@ -1,3 +1,4 @@
+import unittest
 from common_tests.riken_changeover import RikenChangeover, build_iocs, build_power_supplies_list
 from utils.test_modes import TestModes
 
@@ -17,7 +18,7 @@ IOCS = build_iocs(RIKEN_SETUP)
 POWER_SUPPLIES = build_power_supplies_list(RIKEN_SETUP)
 
 
-class RikenPortChangeoverTests(RikenChangeover):
+class RikenPortChangeoverTests(RikenChangeover, unittest.TestCase):
     """
     Tests for a riken port changeover.
 

--- a/tests/rikenrb2modechangeover.py
+++ b/tests/rikenrb2modechangeover.py
@@ -1,3 +1,5 @@
+import unittest
+
 from common_tests.riken_changeover import RikenChangeover, build_iocs, build_power_supplies_list
 from utils.test_modes import TestModes
 
@@ -16,7 +18,7 @@ IOCS = build_iocs(RIKEN_SETUP)
 POWER_SUPPLIES = build_power_supplies_list(RIKEN_SETUP)
 
 
-class RikenRb2ModeChangeoverTests(RikenChangeover):
+class RikenRb2ModeChangeoverTests(RikenChangeover, unittest.TestCase):
     """
     Tests for a riken RB2 mode change.
 


### PR DESCRIPTION
## Description of work done

- Added the ability to run tests by calling `-t module.class.name` using [unittest loadTestsFromNames](https://docs.python.org/3/library/unittest.html#unittest.TestLoader.loadTestsFromNames) method.
- Removed the `-tn` and `-tm` arguments.
- Refactored utility functions into a separate file.
- Fixed problems with base classes in common tests caused by using the new argument. This is fixed using multiple inheritance (see https://stackoverflow.com/questions/1323455/python-unit-test-with-base-and-sub-class for a discussion of ways to fix this problem).
- Updated the readme file to document these changes.

### Related Issue

[#3363](https://github.com/ISISComputingGroup/IBEX/issues/3363)

## Acceptance criteria
- [ ] The IOC tests still pass.
- [ ] The code is of good quality.
- [ ] The documentation has been updated.
- [ ] The changes have been added to the [developer release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev).