### PR TITLE
Ticket 

### DIFF
--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -22,7 +22,7 @@ IOCS = [
     },
 ]
 
-TEST_MODES = [TestModes.DEVSIM] # TestModes.RECSIM]
+TEST_MODES = [TestModes.DEVSIM]#, TestModes.RECSIM]
 
 CHANNEL_LIST = [1, 2, 3, 4, 6, 7, 8, 9]
 
@@ -37,43 +37,35 @@ setup_tests = add_method(setUp)
 
 
 @setup_tests
-class BasicCommands(unittest.TestCase):
+class TestedCommands(unittest.TestCase):
 
     def test_that_GIVEN_a_fresh_IOC_THEN_the_IDN_is_correct(self):
         expected_idn = "MODEL 2001,4301578,B17  /A02  "
         self.ca.assert_that_pv_is("IDN", expected_idn)
 
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
+    def test_that_GIVEN_a_fresh_IOC_THEN_the_device_is_reset(self):
+        self._lewis.assert_that_emulator_value_is("number_of_times_reset", "1")
+
+    def test_that_GIVEN_a_fresh_IOC_THEN_the_read_back_elements_are_reading_and_unit(self):
+        # Then:
+        expected_read_back_elements = "READ, UNIT"
+        self.ca.assert_that_pv_is("ELEMENTS", expected_read_back_elements)
+
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
+    def test_that_GIVEN_a_fresh_IOC_THEN_the_buffer_is_cleared_before_starting(self):
+        # Then:
+        self._lewis.assert_that_emulator_value_is("number_of_times_buffer_has_been_cleared", "1")
 
 
 @setup_tests
 class ScanStartUpTests(unittest.TestCase):
 
     @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
-    def GIVEN_a_fresh_IOC_THEN_the_initialization_mode_is_set_to_continuous(self):
+    def test_that_GIVEN_a_fresh_IOC_THEN_the_initialization_mode_is_set_to_continuous(self):
         # Then:
         initialization_mode = list(self._lewis.backdoor_get_from_device("initialization_mode"))
         self._lewis.assert_that_emulator_value_is(initialization_mode, "continuous")
-
-    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
-    def GIVEN_a_fresh_IOC_THEN_the_scan_rate_is_set_to_half_a_second(self):
-        # Then:
-        expected_scan_rate = 0.5
-        scan_rate = float(self._lewis.backdoor_get_from_device("scan_rate"))
-        self._lewis.assert_that_emulator_value_is(scan_rate, expected_scan_rate)
-
-    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
-    def GIVEN_a_fresh_IOC_THEN_the_read_back_elements_are_reading_and_unit(self):
-        # Then:
-        expected_read_back_elements = "READ, UNIT"
-        self.ca.assert_that_pv_is("ELEMENTS", expected_read_back_elements)
-
-    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
-    def GIVEN_a_fresh_IOC_THEN_the_the_device_is_scanning(self):
-        # Then:
-        expected_scan_status = True
-        scan_status = bool(self._lewis.backdoor_get_from_device("scan_status"))
-        self._lewis.assert_that_emulator_value_is("scan_status", expected_scan_status)
-
 
 @setup_tests
 class BufferStartUpTests(unittest.TestCase):

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -104,6 +104,12 @@ class InitTests(unittest.TestCase):
         self.ca.process_pv("STAT:SERVICE_REQEST")
         self.ca.assert_that_pv_is("STAT:SERVICE_REQEST", 1)
 
+    @skip_if_recsim("Cannot simulate records of different types")
+    def test_that_GIVEN_a_fresh_ioc_THEN_scan_layer_is_set_to_scan_once(self):
+        # Then:
+        self.ca.process_pv("SCAN:COUNT")
+        self.ca.assert_that_pv_is("SCAN:COUNT", 1)
+
 
 @setup_tests
 class ChannelSetupTests(unittest.TestCase):

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -88,15 +88,16 @@ class TestedCommands(unittest.TestCase):
         self.ca.process_pv("BUFF:EGROUP")
         self.ca.assert_that_pv_is("BUFF:EGROUP", expected_buffer_element_group)
 
-
-@setup_tests
-class ScanStartUpTests(unittest.TestCase):
-
     @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
-    def test_that_GIVEN_a_fresh_IOC_THEN_the_initialization_mode_is_set_to_continuous(self):
+    def test_that_GIVEN_a_fresh_IOC_THEN_the_scanning_continuous_mode_is_ON(self):
         # Then:
-        initialization_mode = list(self._lewis.backdoor_get_from_device("initialization_mode"))
-        self._lewis.assert_that_emulator_value_is(initialization_mode, "continuous")
+        expected_initialization_mode = "ON"
+        self.ca.process_pv("SCAN:CONT_MODE")
+        self.ca.assert_that_pv_is("SCAN:CONT_MODE", expected_initialization_mode)
+
+
+# @setup_tests
+# class ScanStartUpTests(unittest.TestCase):
 
 # @setup_tests
 # class BufferStartUpTests(unittest.TestCase):
@@ -115,7 +116,6 @@ class ChannelSetupTests(unittest.TestCase):
     def GIVEN_a_fresh_IOC_with_one_channels_set_to_active_THEN_only_the_active_channels_are_set_to_scan(self):
         # Given:
         self.ca.set_pv_value("CHAN:01:ACTIVE", 1)
-        self.ca.process_pv("startup")
 
         # Then:
         expected_channels = "1"
@@ -129,7 +129,6 @@ class ChannelSetupTests(unittest.TestCase):
 
         for i in expected_channels:
             self.ca.set_pv_value("CHAN:0{}:ACTIVE".format(i), 1)
-        self.ca.process_pv("startup")
 
         # Then:
         expected_channels = "1,2,3,4"

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -23,7 +23,7 @@ IOCS = [
     },
 ]
 
-TEST_MODES = [TestModes.DEVSIM]#, TestModes.RECSIM]
+TEST_MODES = [TestModes.DEVSIM, TestModes.RECSIM]
 
 CHANNEL_LIST = [1, 2, 3, 4, 6, 7, 8, 9]
 
@@ -38,7 +38,7 @@ setup_tests = add_method(setUp)
 
 
 @setup_tests
-class TestedCommands(unittest.TestCase):
+class BasicCommands(unittest.TestCase):
 
     def test_that_GIVEN_a_fresh_IOC_THEN_the_IDN_is_correct(self):
         expected_idn = "MODEL 2001,4301578,B17  /A02  "
@@ -52,6 +52,20 @@ class TestedCommands(unittest.TestCase):
         # Then:
         expected_read_back_elements = "READ, UNIT"
         self.ca.assert_that_pv_is("ELEMENTS", expected_read_back_elements)
+
+
+@setup_tests
+class ScanStartUpTests(unittest.TestCase):
+
+    def test_that_GIVEN_a_fresh_IOC_THEN_the_scanning_continuous_mode_is_ON(self):
+        # Then:
+        expected_initialization_mode = "ON"
+        self.ca.process_pv("SCAN:CONT_MODE")
+        self.ca.assert_that_pv_is("SCAN:CONT_MODE", expected_initialization_mode)
+
+
+@setup_tests
+class BufferStartUpTests(unittest.TestCase):
 
     @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def test_that_GIVEN_a_fresh_IOC_THEN_the_buffer_is_cleared_before_starting(self):
@@ -74,34 +88,17 @@ class TestedCommands(unittest.TestCase):
         self.ca.process_pv("BUFF:MODE")
         self.ca.assert_that_pv_is("BUFF:MODE", expected_buffer_control_mode)
 
-    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def test_that_GIVEN_a_fresh_IOC_THEN_the_buffer_size_is_250(self):
         # Then:
         expected_buffer_size = 250
         self.ca.process_pv("BUFF:SIZE")
         self.ca.assert_that_pv_is("BUFF:SIZE", expected_buffer_size)
 
-    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def test_that_GIVEN_a_fresh_IOC_THEN_the_buffer_element_group_is_full(self):
         # Then:
         expected_buffer_element_group = "FULL"
         self.ca.process_pv("BUFF:EGROUP")
         self.ca.assert_that_pv_is("BUFF:EGROUP", expected_buffer_element_group)
-
-    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
-    def test_that_GIVEN_a_fresh_IOC_THEN_the_scanning_continuous_mode_is_ON(self):
-        # Then:
-        expected_initialization_mode = "ON"
-        self.ca.process_pv("SCAN:CONT_MODE")
-        self.ca.assert_that_pv_is("SCAN:CONT_MODE", expected_initialization_mode)
-
-
-# @setup_tests
-# class ScanStartUpTests(unittest.TestCase):
-
-# @setup_tests
-# class BufferStartUpTests(unittest.TestCase):
-
 
 @setup_tests
 class ChannelSetupTests(unittest.TestCase):

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -186,7 +186,7 @@ class ErrorTests(unittest.TestCase):
 class ChannelReadingTests(unittest.TestCase):
     TEST_VOLTAGES = [0, -2.3586, +1.05e9, 589, 2, 2.8654852]
 
-    @parameterized.expand(parameterized_list(zip(TEST_VOLTAGES, CHANNEL_LIST)))
+    @parameterized.expand(parameterized_list(itertools.product(TEST_VOLTAGES, CHANNEL_LIST)))
     def GIVEN_a_fresh_IOC_THEN_the_channels_are_reading_the_correct_values_from_the_buffer(self, _, voltage, channel):
         # Then:
         self._lewis.backdoor_set_on_device("CHAN:0{}".format(channel), voltage)

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -67,6 +67,15 @@ class TestedCommands(unittest.TestCase):
         self.ca.process_pv("BUFF:SOURCE")
         self.ca.assert_that_pv_is("BUFF:SOURCE", expected_buffer_source)
 
+    @skip_if_recsim("Uses mbbi & mbbo records which do not play well with RECSIM")
+    def test_that_GIVEN_a_fresh_IOC_THEN_the_buffer_control_mode_is_set_to_always(self):
+        # Then:
+        expected_buffer_control_mode = "ALW"
+        self.ca.process_pv("BUFF:MODE")
+        self.ca.assert_that_pv_is("BUFF:MODE", expected_buffer_control_mode)
+
+
+
 
 @setup_tests
 class ScanStartUpTests(unittest.TestCase):
@@ -81,13 +90,7 @@ class ScanStartUpTests(unittest.TestCase):
 class BufferStartUpTests(unittest.TestCase):
 
     @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
-    def GIVEN_a_fresh_IOC_THEN_the_buffer_control_mode_is_set_to_always(self):
-        # Then:
-        expected_buffer_control_mode = "ALWAYS"
-        self.ca.assert_that_pv_is("BUFF:CNTRL:STATUS", expected_buffer_control_mode)
-
-    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
-    def GIVEN_a_fresh_IOC_THEN_the_buffer_size_is_1000(self):
+    def test_that_GIVEN_a_fresh_IOC_THEN_the_buffer_size_is_1000(self):
         # Then:
         expected_buffer_size = 1000
         self.ca.assert_that_pv_is("BUFF:SIZE", expected_buffer_size)

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -1,7 +1,6 @@
-from hamcrest import assert_that, is_, greater_than, equal_to
+from hamcrest import assert_that, is_, greater_than, greater_than_or_equal_to
 from parameterized import parameterized
 import unittest
-import time
 
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
@@ -62,7 +61,7 @@ class InitTests(unittest.TestCase):
 
     def test_that_GIVEN_a_fresh_IOC_THEN_the_read_back_elements_are_reading_and_unit(self):
         # Then:
-        expected_read_back_elements = "READ, UNIT"
+        expected_read_back_elements = "READ, CHAN, UNIT"
         self.ca.assert_that_pv_is("ELEMENTS", expected_read_back_elements)
 
     def test_that_GIVEN_a_fresh_IOC_THEN_the_scanning_continuous_mode_is_ON(self):
@@ -77,7 +76,7 @@ class InitTests(unittest.TestCase):
         number_of_times_buffer_has_been_cleared = int(self._lewis.backdoor_run_function_on_device(
             "get_number_of_times_buffer_has_been_cleared_via_the_backdoor")[0])
 
-        assert_that(number_of_times_buffer_has_been_cleared, is_(greater_than(1)))
+        assert_that(number_of_times_buffer_has_been_cleared, is_(greater_than_or_equal_to(1)))
 
     @skip_if_recsim("Uses mbbi & mbbo records which do not play well with RECSIM")
     def test_that_GIVEN_a_fresh_IOC_THEN_the_buffer_reads_raw_values(self):
@@ -149,7 +148,7 @@ class ChannelSetupTests(unittest.TestCase):
 
     @parameterized.expand(parameterized_list(range(1, 11)))
     @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
-    def test_that_GIVEN_a_fresh_IOC_with_one_channels_set_to_active_THEN_the_IOC_scans_on_that_channel(
+    def test_that_GIVEN_a_fresh_IOC_with_one_channels_set_to_active_THEN_the_IOC_reads_from_that_channel(
             self, _, channel):
         # Given:
         self.ca.set_pv_value("CHAN:{:02d}:ACTIVE".format(channel), 1)

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -5,7 +5,7 @@ import unittest
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
-from utils.testing import get_running_lewis_and_ioc, add_method, parameterized_list
+from utils.testing import get_running_lewis_and_ioc, add_method, parameterized_list, skip_if_recsim
 
 
 DEVICE_PREFIX = "KHLY2001_01"
@@ -20,9 +20,7 @@ IOCS = [
     },
 ]
 
-# Only one test does not uses the lewis backdoor feature.
-# Therefore these tests only run in DEVSIM.
-TEST_MODES = [TestModes.DEVSIM]
+TEST_MODES = [TestModes.RECSIM]#, TestModes.DEVSIM]
 
 CHANNEL_LIST = range(1, 11)
 
@@ -68,11 +66,13 @@ class InitTests(unittest.TestCase):
 
     def test_that_GIVEN_a_fresh_IOC_THEN_it_is_set_up(self):
         # Then:
-        self._lewis.assert_that_emulator_value_is_greater_than("number_of_times_device_has_been_reset", 1)
         self.__assert_that_the_devices_status_register_is_setup()
-        self._assert_that_the_buffer_is_setup()
+        self._assert_that_reading_elements_are_set_to_reading_channel_and_unit()
         self._assert_that_device_trigger_mode_is_setup()
+
+    def _assert_that_reading_elements_are_set_to_reading_channel_and_unit(self):
         self.ca.assert_that_pv_is("ELEMENTS", "READ, CHAN, UNIT")
+        self.ca.assert_that_pv_after_processing_is("BUFF:EGROUP", "FULL")
 
     def _assert_that_device_trigger_mode_is_setup(self):
         self.ca.assert_that_pv_after_processing_is("INIT:CONT_MODE", "OFF")
@@ -80,51 +80,65 @@ class InitTests(unittest.TestCase):
         self.ca.assert_that_pv_after_processing_is("SCAN:TRIG:SOURCE", "IMM")
 
     def __assert_that_the_devices_status_register_is_setup(self):
-        number_of_times_status_register_has_been_reset_and_cleared = int(self._lewis.backdoor_run_function_on_device(
-            "get_number_of_times_status_register_has_been_reset_and_cleared_via_the_backdoor")[0])
-
-        assert_that(number_of_times_status_register_has_been_reset_and_cleared, is_(greater_than_or_equal_to(1)))
         self.ca.assert_that_pv_after_processing_is("STAT:MEAS", 512)
         self.ca.assert_that_pv_after_processing_is("STAT:SERVICE_REQEST", 1)
 
-    def _assert_that_the_buffer_is_setup(self):
+    @skip_if_recsim("Mbbi's don't work with RECSIM.")
+    def test_that_GIVEN_a_fresh_IOC_THEN_the_buffer_source_is_set(self):
+        self.ca.assert_that_pv_after_processing_is("BUFF:SOURCE", "SENS1")
+
+    @skip_if_recsim("Lewis backdoor doesn't work in RECSIM.")
+    def test_that_GIVEN_a_fresh_IOC_THEN_the_device_buffer_and_status_register_have_been_reset(self):
         number_of_times_buffer_has_been_cleared = int(self._lewis.backdoor_run_function_on_device(
             "get_number_of_times_buffer_has_been_cleared_via_the_backdoor")[0])
+        number_of_times_status_register_has_been_reset_and_cleared = int(
+            self._lewis.backdoor_run_function_on_device(
+                "get_number_of_times_status_register_has_been_reset_and_cleared_via_the_backdoor")[0])
 
-        self.ca.assert_that_pv_after_processing_is("BUFF:SOURCE", "SENS1")
-        self.ca.assert_that_pv_after_processing_is("BUFF:EGROUP", "FULL")
         assert_that(number_of_times_buffer_has_been_cleared, is_(greater_than_or_equal_to(1)))
+        assert_that(number_of_times_status_register_has_been_reset_and_cleared, is_(greater_than_or_equal_to(1)))
+        self._lewis.assert_that_emulator_value_is_greater_than("number_of_times_device_has_been_reset", 1)
 
 
 @setup_tests
-class ReadingTests(unittest.TestCase):
+class SingleShotTests(unittest.TestCase):
 
-    def _setup_channel_to_test(self, channel, value=None):
+    def _setup_channel_to_test(self, channel, value):
         self.ca.set_pv_value("CHAN:{0:02d}:ACTIVE".format(channel), "ACTIVE")
         self.ca.assert_that_pv_is("CHAN:{0:02d}:ACTIVE".format(channel), "ACTIVE")
-        if value is not None:
-            self._lewis.backdoor_run_function_on_device("set_channel_value_via_the_backdoor", [channel, value])
+        self._lewis.backdoor_run_function_on_device("set_channel_value_via_the_backdoor", [channel, value])
 
-    @parameterized.expand(parameterized_list(range(1, 11)))
+    # @parameterized.expand(parameterized_list(range(1, 11)))
     def test_that_GIVEN_one_channels_set_to_active_THEN_the_voltage_value_for_that_channel_are_read(
-            self, _, channel):
+            self):#, _, channel):
+        channel = 2
         # Given:
         expected_value = 9.84412
-        _setup_channel_to_test(self.ca, self._lewis, channel, expected_value)
+        self._setup_channel_to_test(channel, expected_value)
 
         # Then:
         self.ca.assert_that_pv_is("CHAN:{0:02d}:READ".format(channel), expected_value)
 
-    @parameterized.expand(parameterized_list(range(1, 11)))
+    # @parameterized.expand(parameterized_list(range(1, 11)))
     def test_that_GIVEN_one_channel_set_to_active_THEN_the_measurement_units_for_that_channel_are_read(
-            self, _, channel):
+            self):#, _, channel):
+        channel = 2
         # Given:
         expected_value = 9.2
-        _setup_channel_to_test(self.ca, self._lewis, channel, expected_value)
+        self._setup_channel_to_test(channel, expected_value)
 
         # Then:
         expected_unit = "VDC"
         self.ca.assert_that_pv_is("CHAN:{0:02d}:UNIT".format(channel), expected_unit)
+
+
+@setup_tests
+class ScanningTests(unittest.TestCase):
+
+    def _setup_channel_to_test(self, channel, value):
+        self.ca.set_pv_value("CHAN:{0:02d}:ACTIVE".format(channel), "ACTIVE")
+        self.ca.assert_that_pv_is("CHAN:{0:02d}:ACTIVE".format(channel), "ACTIVE")
+        self._lewis.backdoor_run_function_on_device("set_channel_value_via_the_backdoor", [channel, value])
 
     def test_that_GIVEN_two_active_channels_THEN_the_IOC_is_setup_to_scan_on_those_channels(self):
         # Given:
@@ -140,15 +154,6 @@ class ReadingTests(unittest.TestCase):
             "get_number_of_times_buffer_has_been_cleared_via_the_backdoor")[0])
         assert_that(number_of_times_buffer_has_been_cleared, is_(greater_than(1)))
 
-    def test_that_GIVEN_five_active_channels_THEN_the_IOC_sets_the_device_to_scan_on_those__channels(self):
-        # Given:
-        channels = (1, 2, 3, 8, 9)
-        map(self._setup_channel_to_test, channels)
-
-        # Then:
-        expected_string = "1,2,3,8,9"
-        self.ca.process_pv("SCAN:CHAN")
-        self.ca.assert_that_pv_is("SCAN:CHAN", expected_string)
 
     def test_that_GIVEN_only_channels_2_and_5_active_THEN_the_readings_are_read_into_channels_2_and_5(
             self):

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -1,5 +1,6 @@
 import ast
 import itertools
+from hamcrest import assert_that, is_
 from parameterized import parameterized
 import unittest
 import time
@@ -55,7 +56,16 @@ class TestedCommands(unittest.TestCase):
     @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def test_that_GIVEN_a_fresh_IOC_THEN_the_buffer_is_cleared_before_starting(self):
         # Then:
-        self._lewis.assert_that_emulator_value_is("number_of_times_buffer_has_been_cleared", "1")
+        number_of_times_buffer_has_been_cleared = self._lewis.backdoor_run_function_on_device(
+            "get_number_of_times_buffer_has_been_cleared")[0]
+        assert_that(number_of_times_buffer_has_been_cleared, is_("1"))
+
+    @skip_if_recsim("Uses mbbi & mbbo records which do not play well with RECSIM")
+    def test_that_GIVEN_a_fresh_IOC_THEN_the_buffer_reads_raw_values(self):
+        # Then:
+        expected_buffer_source = "SENS1"
+        self.ca.process_pv("BUFF:SOURCE")
+        self.ca.assert_that_pv_is("BUFF:SOURCE", expected_buffer_source)
 
 
 @setup_tests
@@ -69,18 +79,6 @@ class ScanStartUpTests(unittest.TestCase):
 
 @setup_tests
 class BufferStartUpTests(unittest.TestCase):
-
-    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
-    def GIVEN_a_fresh_IOC_THEN_the_buffer_is_cleared_before_starting(self):
-        # Then:
-        buffer_cleared = self._lewis.backdoor_get_from_device("buffer_cleared")
-        self._lewis.assert_that_emulator_value_is(buffer_cleared, True)
-
-    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
-    def GIVEN_a_fresh_IOC_THEN_the_buffer_reads_raw_values(self):
-        # Then:
-        expected_buffer_source = "SENS"
-        self.ca.assert_that_pv_is("BUFF:SOURCE", expected_buffer_source)
 
     @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def GIVEN_a_fresh_IOC_THEN_the_buffer_control_mode_is_set_to_always(self):

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -60,9 +60,9 @@ def _reset_readings(ca):
 
 def _clear_errors(ca):
     if IOCRegister.uses_rec_sim:
-        ca.set_pv_value("SIM:ERROR:RAW", [str(0), "No Error"])
+        ca.set_pv_value("SIM:ERROR:RAW", [str(0), "No error"])
     else:
-        ca.set_pv_value("ERROR:CLEAR:_TRIG", 1)
+        ca.set_pv_value("ERROR:CLEAR:FLAG", 1)
 
 
 def _setup_channel_to_test(ca, lewis, channel, value=None):
@@ -264,7 +264,7 @@ class ErrorTests(unittest.TestCase):
     def test_that_GIVEN_a_device_not_scanning_on_any_channels_with_no_error_THEN_the_IOC_reads_that_there_are_no_errors(
             self):
         expected_error_code = 0
-        expected_error_message = "No Error"
+        expected_error_message = "No error"
         # Then:
         self.ca.assert_that_pv_is("ERROR:RAW", "".join([str(expected_error_code), expected_error_message]))
 
@@ -288,11 +288,11 @@ class ErrorTests(unittest.TestCase):
         self.ca.assert_that_pv_is("ERROR:RAW", "".join([str(expected_error_code), expected_error_message]))
 
         # When:
-        self.ca.set_pv_value("ERROR:CLEAR:_TRIG", 1)
+        self.ca.set_pv_value("ERROR:CLEAR:FLAG", 1)
 
         # Then:
         expected_cleared_error_code = 0
-        expected_cleared_error_message = "No Error"
+        expected_cleared_error_message = "No error"
         self.ca.assert_that_pv_is("ERROR:RAW", "".join(
             [str(expected_cleared_error_code), expected_cleared_error_message]))
 
@@ -318,11 +318,11 @@ class ErrorTests(unittest.TestCase):
         self.ca.assert_that_pv_is("ERROR:RAW", "".join([str(expected_error_code), expected_error_message]))
 
         # When:
-        self.ca.set_pv_value("ERROR:CLEAR:_TRIG", 1)
+        self.ca.set_pv_value("ERROR:CLEAR:FLAG", 1)
 
         # Then:
         expected_cleared_error_code = 0
-        expected_cleared_error_message = "No Error"
+        expected_cleared_error_message = "No error"
         self.ca.assert_that_pv_is("ERROR:RAW", "".join([
             str(expected_cleared_error_code), expected_cleared_error_message]))
 
@@ -350,18 +350,18 @@ class ErrorTests(unittest.TestCase):
         self.ca.assert_that_pv_is("ERROR:RAW", "".join([str(expected_error_code), expected_error_message]))
 
         # When:
-        self.ca.set_pv_value("ERROR:CLEAR:_TRIG", 1)
+        self.ca.set_pv_value("ERROR:CLEAR:FLAG", 1)
 
         # Then:
         expected_cleared_error_code = 0
-        expected_cleared_error_message = "No Error"
+        expected_cleared_error_message = "No error"
         self.ca.assert_that_pv_is("ERROR:RAW", "".join(
             [str(expected_cleared_error_code), expected_cleared_error_message]))
 
     def test_that_GIVEN_a_device_not_scanning_on_any_channels_on_setup_THEN_the_error_code_and_error_message_are_separatated(
             self):
         expected_error_code = 0
-        expected_error_message = "No Error"
+        expected_error_message = "No error"
 
         # Then:
         self.ca.assert_that_pv_is("ERROR:MSG", expected_error_message)

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -275,6 +275,24 @@ class ScanningSetupTests(unittest.TestCase):
 @setup_tests
 class MultiChannelReadingTests(unittest.TestCase):
 
+    def test_that_GIVEN_a_fresh_IOC_with_two_channels_set_to_active_THEN_the_IOC_reads_the_values_from_the_buffer(
+            self):
+        channels = (1, 2)
+
+        # Given:
+        expected_values = (9.2, 8.3)
+
+        for channel, expected_value in zip(channels, expected_values):
+            self.ca.set_pv_value("CHAN:{:02d}:ACTIVE".format(channel), 1)
+            self._lewis.backdoor_run_function_on_device("set_channel_value_via_the_backdoor", [channel, expected_value])
+
+        # Then:
+        expected_units = ["VDC"] * 2
+        channel_readback_format = "{:.7E}{},{:02d}INTCHAN"
+        expected_array = [channel_readback_format.format(value, unit, channel) for
+                          value, unit, channel in zip(expected_values, expected_units, channels)]
+        self.ca.assert_that_pv_is("READ:BUFF", expected_array)
+
     def test_that_GIVEN_a_fresh_IOC_with_two_channels_set_to_active_THEN_the_IOC_reads_the_right_values_in_the_channels_read_pvs(
             self):
         channels = (1, 2)

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -1,4 +1,4 @@
-from hamcrest import assert_that, is_, greater_than
+from hamcrest import assert_that, is_, greater_than, equal_to
 from parameterized import parameterized
 import unittest
 import time
@@ -113,7 +113,6 @@ class InitTests(unittest.TestCase):
         # Then:
         self.ca.process_pv("SCAN:TRIG:SOURCE")
         self.ca.assert_that_pv_is("SCAN:TRIG:SOURCE", "IMM")
-
 
 
 @setup_tests
@@ -238,7 +237,7 @@ class ScanningSetupTests(unittest.TestCase):
             "get_number_of_times_buffer_has_been_cleared_via_the_backdoor")[0]
         assert_that(number_of_times_buffer_has_been_cleared, is_(greater_than("1")))
 
-    def test_that_GIVEN_IOC_with_three_active_channels_THEN_the_IOC_sets_the_device_to_scan_on_those_three_channels(self):
+    def test_that_GIVEN_IOC_with_three_active_channels_THEN_the_IOC_creates_the_correct_string_to_send_to_the_device(self):
         # Given:
         channels = (1, 2, 6)
         for channel in channels:
@@ -249,7 +248,7 @@ class ScanningSetupTests(unittest.TestCase):
         expected_channel_string = "1,2,6"
         self.ca.assert_that_pv_is("READ:CHAN:SP", expected_channel_string)
 
-    def test_that_GIVEN_IOC_with_ten_active_channels_THEN_the_IOC_sets_the_device_to_scan_on_all_channels(self):
+    def test_that_GIVEN_IOC_with_ten_active_channels_THEN_the_IOC_creates_the_correct_string_to_send_to_the_device(self):
         # Given:
         for channel in CHANNEL_LIST:
             self.ca.set_pv_value("CHAN:{0:02d}:ACTIVE".format(channel), "ACTIVE")
@@ -258,6 +257,19 @@ class ScanningSetupTests(unittest.TestCase):
         # Then:
         expected_channel_string = "1,2,3,4,5,6,7,8,9,10"
         self.ca.assert_that_pv_is("READ:CHAN:SP", expected_channel_string)
+
+    def test_that_GIVEN_IOC_with_three_active_channels_THEN_the_IOC_sets_the_device_to_scan_on_those_three_channels(self):
+        # Given:
+        channels = (1, 2, 6)
+        for channel in channels:
+            self.ca.set_pv_value("CHAN:{0:02d}:ACTIVE".format(channel), "ACTIVE")
+            self.ca.assert_that_pv_is("CHAN:{0:02d}:ACTIVE".format(channel), "ACTIVE")
+
+        # Then:
+        scanning_channels = self._lewis.backdoor_run_function_on_device(
+            "get_scan_channels_via_the_backdoor")[0].split(",")
+        expected_value = ["1", "2", "6"]
+        assert_that(scanning_channels, is_(equal_to(expected_value)))
 
 
 @setup_tests

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -1,5 +1,3 @@
-import time
-
 from hamcrest import assert_that, is_, greater_than, greater_than_or_equal_to
 from parameterized import parameterized
 import unittest

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -113,8 +113,8 @@ class InitTests(unittest.TestCase):
     @skip_if_recsim("Cannot simulate records of different types")
     def test_that_GIVEN_a_fresh_ioc_THEN_scan_trigger_is_set_to_immediate(self):
         # Then:
-        self.ca.process_pv("SCAN:TRIG")
-        self.ca.assert_that_pv_is("SCAN:TRIG", "IMM")
+        self.ca.process_pv("SCAN:TRIG:SOURCE")
+        self.ca.assert_that_pv_is("SCAN:TRIG:SOURCE", "IMM")
 
 
 @setup_tests
@@ -191,21 +191,29 @@ class SingleChannelReadingTests(unittest.TestCase):
 
 
 @setup_tests
-class BufferReadingTests(unittest.TestCase):
+class BufferSetupTests(unittest.TestCase):
 
-    def test_that_GIVEN_a_fresh_IOC_with_two_channels_set_to_active_THEN_the_IOC_reads_the_buffer(
-            self):
+    def test_that_GIVEN_two_active_channels_THEN_the_IOC_sets_the_buffer_size_to_2(self):
         channels = (1, 2)
 
         # Given:
-        expected_values = (9.2, 8.3)
-        for channel, expected_value in zip(channels, expected_values):
+        for channel in channels:
             self.ca.set_pv_value("CHAN:0{}:ACTIVE".format(channel), 1)
-            self._lewis.backdoor_run_function_on_device("set_channel_value_via_the_backdoor", [channel, expected_value])
 
-        expected_value = ""
         # Then:
-        self.ca.assert_that_pv_is("READ:BUFFER", expected_value)
+        self.ca.process_pv("BUFF:SIZE")
+        self.ca.assert_that_pv_is("BUFF:SIZE", len(channels))
+
+    def test_that_GIVEN_two_active_channels_THEN_the_measurement_scan_count_is_set_to_2(self):
+        channels = (1, 2)
+
+        # Given:
+        for channel in channels:
+            self.ca.set_pv_value("CHAN:0{}:ACTIVE".format(channel), 1)
+
+        # Then:
+        self.ca.process_pv("SCAN:MEAS:COUNT")
+        self.ca.assert_that_pv_is("SCAN:MEAS:COUNT", len(channels))
 
 
 @setup_tests
@@ -224,8 +232,6 @@ class MultiChannelReadingTests(unittest.TestCase):
         # Then:
         for channel, expected_value in zip(channels, expected_values):
             self.ca.assert_that_pv_is("CHAN:0{}:READ".format(channel), expected_value)
-
-
 
 
 @setup_tests

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -81,6 +81,13 @@ class TestedCommands(unittest.TestCase):
         self.ca.process_pv("BUFF:SIZE")
         self.ca.assert_that_pv_is("BUFF:SIZE", expected_buffer_size)
 
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
+    def test_that_GIVEN_a_fresh_IOC_THEN_the_buffer_element_group_is_full(self):
+        # Then:
+        expected_buffer_element_group = "FULL"
+        self.ca.process_pv("BUFF:EGROUP")
+        self.ca.assert_that_pv_is("BUFF:EGROUP", expected_buffer_element_group)
+
 
 @setup_tests
 class ScanStartUpTests(unittest.TestCase):

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -294,3 +294,23 @@ class MultiChannelReadingTests(unittest.TestCase):
         self.ca.assert_that_pv_is("SCAN:BUFF.NORD", len(active_channels))
         for i in range(0, len(active_channels)):
             self.ca.assert_that_pv_is("SCAN:BUFF.VAL[{}]".format(i), expected_value[i])
+
+
+@setup_tests
+class BufferParsingTests(unittest.TestCase):
+
+    def test_that_GIVEN_an_IOC_scanning_on_channel_2_and_5_THEN_the_readings_are_read_into_channels_2_and_5(
+            self):
+        # Given:
+        active_channels = (2, 5)
+        expected_values = [9.2] * len(active_channels)
+        for expected_value, channel in zip(expected_values, active_channels):
+            self.ca.set_pv_value("CHAN:{0:02d}:ACTIVE".format(channel), "ACTIVE")
+            self.ca.assert_that_pv_is("CHAN:{0:02d}:ACTIVE".format(channel), "ACTIVE")
+            self._lewis.backdoor_run_function_on_device("set_channel_value_via_the_backdoor", [channel, expected_value])
+
+        # Then:
+        for expected_value, channel in zip(expected_values, active_channels):
+            self.ca.assert_that_pv_is("CHAN:{0:02d}:READ".format(channel), expected_value)
+
+

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -14,7 +14,7 @@ IOCS = [
         "name": DEVICE_PREFIX,
         "directory": get_default_ioc_dir("KHLY2001"),
         "macros": {},
-        "emulator": "Keithley_2001",
+        "emulator": "keithley_2001",
     },
 ]
 
@@ -27,7 +27,7 @@ class Keithley_2001Tests(unittest.TestCase):
     Tests for the Keithley_2001 IOC.
     """
     def setUp(self):
-        self._lewis, self._ioc = get_running_lewis_and_ioc("Keithley_2001", DEVICE_PREFIX)
+        self._lewis, self._ioc = get_running_lewis_and_ioc("keithley_2001", DEVICE_PREFIX)
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
 
     def test_that_fails(self):

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -166,16 +166,6 @@ class ScanningSetupTests(unittest.TestCase):
 
         # Then:
         self.ca.assert_that_pv_after_processing_is("SCAN:MEAS:COUNT", len(channels))
-        self.ca.assert_that_pv_after_processing_is("BUFF:MODE", "NEXT")
-
-    def test_that_GIVEN_two_active_channels_WHEN_scanning_on_two_channels_THEN_the_buffer_mode_is_set_to_NEXT(self):
-        # Given:
-        channels = (1, 2)
-        for channel in channels:
-            self.ca.set_pv_value("CHAN:{:02d}:ACTIVE".format(channel), 1)
-
-        # Then:
-        self.ca.assert_that_pv_after_processing_is("BUFF:MODE", "NEXT")
 
     @skip_if_recsim("Can't use lewis with RECSIM")
     def test_that_GIVEN_two_active_channels_THEN_the_buffer_is_cleared(self):

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -28,10 +28,16 @@ TEST_MODES = [TestModes.DEVSIM]#, TestModes.RECSIM]
 CHANNEL_LIST = [1, 2, 3, 4, 6, 7, 8, 9]
 
 
+def _reset_channels(ca):
+    for channel in CHANNEL_LIST:
+        ca.set_pv_value("CHAN:0{}:ACTIVE".format(channel), 0)
+
+
 def setUp(self):
     self._lewis, self._ioc = get_running_lewis_and_ioc("keithley_2001", DEVICE_PREFIX)
     self.ca = ChannelAccess(default_timeout=20, device_prefix=DEVICE_PREFIX)
     self.ca.assert_that_pv_exists("IDN")
+    _reset_channels(self.ca)
 
 
 setup_tests = add_method(setUp)
@@ -108,7 +114,7 @@ class ChannelSetupTests(unittest.TestCase):
     def test_that_GIVEN_a_fresh_IOC_with_no_channels_set_to_active_THEN_the_IOC_is_in_IDLE_scan_mode(self):
         # Then:
         expected_mode = "IDLE"
-        self.ca.assert_that_pv_is("SCAN:MODE", expected_mode)
+        self.ca.assert_that_pv_is("READ:MODE", expected_mode)
 
     @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def test_that_GIVEN_a_fresh_IOC_with_one_channels_set_to_active_THEN_the_IOC_is_in_SINGLE_scan_mode(self):
@@ -117,7 +123,7 @@ class ChannelSetupTests(unittest.TestCase):
 
         # Then:
         expected_mode = "SINGLE"
-        self.ca.assert_that_pv_is("SCAN:MODE", expected_mode)
+        self.ca.assert_that_pv_is("READ:MODE", expected_mode)
 
     @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def test_that_GIVEN_a_fresh_IOC_with_first_four_channels_set_to_active_THEN_the_IOC_is_in_MULTI_scan_mode(self):
@@ -129,7 +135,7 @@ class ChannelSetupTests(unittest.TestCase):
 
         # Then:
         expected_mode = "MULTI"
-        self.ca.assert_that_pv_is("SCAN:MODE", expected_mode)
+        self.ca.assert_that_pv_is("READ:MODE", expected_mode)
 
 
 @setup_tests

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -18,8 +18,14 @@ IOCS = [
     },
 ]
 
-
 TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
+
+on_off_status = {False: "OFF", True: "ON"}
+
+
+class Status(object):
+    ON = "ON"
+    OFF = "OFF"
 
 
 class Keithley_2001Tests(unittest.TestCase):
@@ -28,7 +34,133 @@ class Keithley_2001Tests(unittest.TestCase):
     """
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("keithley_2001", DEVICE_PREFIX)
-        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
+        self.ca = ChannelAccess(default_timeout=30, device_prefix=DEVICE_PREFIX)
+        self.ca.assert_that_pv_exists("IDN")
 
-    def test_that_fails(self):
-        self.fail("You haven't implemented any tests!")
+    def test_WHEN_scan_state_set_THEN_scan_state_matches_the_set_state(self):
+        sample_data = {0: "INT", 1: "NONE"}
+        for enum_value, string_value in sample_data.items():
+            self.ca.assert_setting_setpoint_sets_readback(enum_value, "SCAN:STATE", expected_value=string_value)
+
+    @skip_if_recsim("In rec sim this test fails")
+    def test_WHEN_delay_state_set_THEN_delay_state_matches_the_set_state(self):
+        for enum_value, string_value in on_off_status.items():
+            self.ca.assert_setting_setpoint_sets_readback(enum_value, "DELAYMODE", expected_value=string_value)
+
+    def test_WHEN_source_set_THEN_source_matches_the_set_state(self):
+        sample_data = {0: "IMM", 1: "TIM", 2: "MAN", 3: "BUS", 4: "EXT"}
+        for enum_value, string_value in sample_data.items():
+            self.ca.assert_setting_setpoint_sets_readback(enum_value, "CONTROLSOURCE", expected_value=string_value)
+
+    @skip_if_recsim("In rec sim this test fails")
+    def test_WHEN_buffer_size_set_THEN_buffer_size_matches_the_set_state_AND_alarm_is_major(self):
+        expected_alarm = "MAJOR"
+        sample_data = [0, 70000]
+        for sample_data in sample_data:
+            self.ca.assert_setting_setpoint_sets_readback(sample_data, "BUFF:SIZE", expected_alarm=expected_alarm)
+
+    @skip_if_recsim("In rec sim this test fails")
+    def test_WHEN_buffer_size_set_THEN_buffer_size_matches_the_set_state_AND_alarm_is_none(self):
+        expected_alarm = "NO_ALARM"
+        sample_data = [5500, 2]
+        for sample_data in sample_data:
+            self.ca.assert_setting_setpoint_sets_readback(sample_data, "BUFF:SIZE", expected_alarm=expected_alarm)
+
+    def test_WHEN_buffer_feed_set_THEN_buffer_feed_matches_the_set_state(self):
+        sample_data = {0: "SENS", 1: "CALC", 2: "NONE"}
+        for enum_value, string_value in sample_data.items():
+            self.ca.assert_setting_setpoint_sets_readback(enum_value, "BUFF:SOURCE", expected_value=string_value)
+
+    def test_WHEN_init_state_set_THEN_init_state_matches_the_set_state(self):
+        for enum_value, string_value in on_off_status.items():
+            self.ca.assert_setting_setpoint_sets_readback(enum_value, "INITMODE", expected_value=string_value)
+
+    def test_WHEN_buffer_control_set_THEN_buffer_control_matches_the_set_state(self):
+        sample_data = {0: "NEXT", 1: "ALW", 2: "NEV"}
+        for enum_value, string_value in sample_data.items():
+            self.ca.assert_setting_setpoint_sets_readback(enum_value, "BUFF:CONTROLMODE", expected_value=string_value)
+
+    def test_WHEN_buffer_range_set_then_buffer_within_range_is_returned(self):
+        self._lewis.backdoor_set_on_device("buffer_range_readings", 10)
+        self.ca.set_pv_value("CH:START", 2)
+        self.ca.set_pv_value("COUNT", 4)
+        self.ca.process_pv("BUFF:READ")
+        expected_string = self.ca.get_pv_value("BUFF:READ")
+        self.assertNotEquals(expected_string, "[]")
+
+    def test_WHEN_sample_count_set_THEN_sample_count_matches_the_set_state_AND_within_alarm_is_major(self):
+        expected_alarm = "MAJOR"
+        sample_data = [0, 70000]
+        for set_value in sample_data:
+            self.ca.assert_setting_setpoint_sets_readback(set_value, "SAMPLECOUNT", expected_alarm=expected_alarm)
+
+    def test_WHEN_sample_count_set_THEN_sample_count_matches_the_set_state_AND_within_alarm_is_none(self):
+        expected_alarm = "NO_ALARM"
+        sample_data = [2, 55000]
+        for enum_value in sample_data:
+            self.ca.assert_setting_setpoint_sets_readback(enum_value, "SAMPLECOUNT", expected_value=enum_value,
+                                                          expected_alarm=expected_alarm)
+
+    def test_WHEN_cycles_rate_set_THEN_cycle_rate_matches_the_set_state_AND_within_alarm_is_major(self):
+        expected_alarm = "MAJOR"
+        sample_data = [0, 65.0]
+        for set_value in sample_data:
+            self.ca.assert_setting_setpoint_sets_readback(set_value, "FRES:NPLC", expected_alarm=expected_alarm)
+
+    def test_WHEN_cycles_rate_set_THEN_cycle_rate_matches_the_set_state_AND_within_alarm_is_none(self):
+        expected_alarm = "NO_ALARM"
+        sample_data = [0.1, 2.0]
+        for enum_value in sample_data:
+            self.ca.assert_setting_setpoint_sets_readback(enum_value, "FRES:NPLC", expected_value=enum_value,
+                                                          expected_alarm=expected_alarm)
+
+    @skip_if_recsim("In rec sim this test fails")
+    def test_WHEN_buffer_state_set_THEN_buffer_state_matches_the_set_state(self):
+        for enum_value, string_value in on_off_status.items():
+            self.ca.assert_setting_setpoint_sets_readback(enum_value, "DELAYMODE", expected_value=string_value)
+
+    def test_WHEN_auto_range_set_THEN_auto_range_matches_the_set_state(self):
+        for enum_value, expected_state in on_off_status.items():
+            self.ca.assert_setting_setpoint_sets_readback(enum_value, "FRES:AUTORANGE", expected_value=expected_state)
+
+    @skip_if_recsim("In rec sim this test fails")
+    def test_WHEN_time_stamp_set_to_absolute_THEN_time_stamp_matches_the_set_state(self):
+        sample_data = {0: "ABS", 1: "DELT"}
+        for enum_value, expected_state in sample_data.items():
+            self.ca.assert_setting_setpoint_sets_readback(enum_value, "TIME:FORMAT", expected_value=expected_state)
+
+    def test_WHEN_fres_digits_set_THEN_fres_digits_matches_the_set_state_AND_alarm_is_major(self):
+        expected_alarm = "MAJOR"
+        sample_data = [3, 8, 10]
+        for sample_value in sample_data:
+            self.ca.assert_setting_setpoint_sets_readback(sample_value, "FRES:DIGITS", expected_alarm=expected_alarm)
+
+    def test_WHEN_fres_digits_set_THEN_fres_digits_matches_the_set_state_AND_alarm_is_none(self):
+        expected_alarm = "NO_ALARM"
+        sample_data = [4, 6]
+        for sample_value in sample_data:
+            self.ca.assert_setting_setpoint_sets_readback(sample_value, "FRES:DIGITS", expected_alarm=expected_alarm)
+
+    def test_WHEN_start_channel_range_set_THEN_start_channel_matches_the_set_state(self):
+        sample_channels = [101, 109, 205]
+        for channel in sample_channels:
+            self.ca.assert_setting_setpoint_sets_readback(channel, "CH:START")
+
+    def test_WHEN_end_channel_range_set_THEN_end_channel_matches_the_set_state(self):
+        sample_channels = [201, 209, 210]
+        for channel in sample_channels:
+            self.ca.assert_setting_setpoint_sets_readback(channel, "CH:END")
+
+    def test_WHEN_measurement_mode_set_THEN_mesaurement_mode_matches_the_set_state(self):
+        self.ca.set_pv_value("CH:START:SP", 101)
+        self.ca.set_pv_value("CH:END:SP", 210)
+        sample_data = {0: "VOLT:DC", 1: "VOLT:AC", 2: "CURR:DC", 3: "CURR:AC", 4: "RES", 5: "FRES", 6: "CONT",
+                       7: "FREQ", 8: "PER"}
+        for measurement_enum, measurement_string in sample_data.items():
+            self.ca.assert_setting_setpoint_sets_readback(measurement_string, "MEASUREMENT",
+                                                          expected_value=measurement_string)
+
+    def test_WHEN_elements_set_THEN_elements_are_as_expected(self):
+        elements = "READ, CHAN, TST"
+        self.ca.assert_setting_setpoint_sets_readback(elements, "DATAELEMENTS")
+

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -51,7 +51,7 @@ class InitTests(unittest.TestCase):
 
     @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def test_that_GIVEN_a_fresh_IOC_THEN_the_device_is_reset(self):
-        self._lewis.assert_that_emulator_value_is("number_of_times_reset", "1")
+        self._lewis.assert_that_emulator_value_is_greater_than("number_of_times_reset", 1)
 
     @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def test_that_GIVEN_a_fresh_IOC_THEN_the_status_registers_are_reset_and_cleared(self):
@@ -74,9 +74,10 @@ class InitTests(unittest.TestCase):
     @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def test_that_GIVEN_a_fresh_IOC_THEN_the_buffer_is_cleared_before_starting(self):
         # Then:
-        number_of_times_buffer_has_been_cleared = self._lewis.backdoor_run_function_on_device(
-            "get_number_of_times_buffer_has_been_cleared_via_the_backdoor")[0]
-        assert_that(number_of_times_buffer_has_been_cleared, is_("1"))
+        number_of_times_buffer_has_been_cleared = int(self._lewis.backdoor_run_function_on_device(
+            "get_number_of_times_buffer_has_been_cleared_via_the_backdoor")[0])
+
+        assert_that(number_of_times_buffer_has_been_cleared, is_(greater_than(1)))
 
     @skip_if_recsim("Uses mbbi & mbbo records which do not play well with RECSIM")
     def test_that_GIVEN_a_fresh_IOC_THEN_the_buffer_reads_raw_values(self):

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -150,7 +150,7 @@ class SingleShotTests(unittest.TestCase):
 @setup_tests
 class ScanningSetupTests(unittest.TestCase):
 
-    def test_that_GIVEN_two_active_channels_THEN_the_IOC_is_setup_to_scan_on_those_channels(self):
+    def test_that_GIVEN_two_active_channels_WHEN_scanning_on_two_channels_THEN_the_buffer_size_is_set_to_two(self):
         # Given:
         channels = (1, 2)
         for channel in channels:
@@ -158,7 +158,25 @@ class ScanningSetupTests(unittest.TestCase):
 
         # Then:
         self.ca.assert_that_pv_after_processing_is("BUFF:SIZE", len(channels))
+
+    def test_that_GIVEN_two_active_channels_WHEN_scanning_on_two_channels_THEN_the_measurement_count_is_set_to_two(
+            self):
+        # Given:
+        channels = (1, 2)
+        for channel in channels:
+            self.ca.set_pv_value("CHAN:{:02d}:ACTIVE".format(channel), 1)
+
+        # Then:
         self.ca.assert_that_pv_after_processing_is("SCAN:MEAS:COUNT", len(channels))
+        self.ca.assert_that_pv_after_processing_is("BUFF:MODE", "NEXT")
+
+    def test_that_GIVEN_two_active_channels_WHEN_scanning_on_two_channels_THEN_the_buffer_mode_is_set_to_NEXT(self):
+        # Given:
+        channels = (1, 2)
+        for channel in channels:
+            self.ca.set_pv_value("CHAN:{:02d}:ACTIVE".format(channel), 1)
+
+        # Then:
         self.ca.assert_that_pv_after_processing_is("BUFF:MODE", "NEXT")
 
     @skip_if_recsim("Can't use lewis with RECSIM")

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -116,7 +116,7 @@ class SingleShotTests(unittest.TestCase):
 
     def _simulate_readings(self, channel, value, unit):
         if IOCRegister.uses_rec_sim:
-            simulated_reading = ["{:.7E}VDC".format(value), "{0:02d}INTCHAN".format(channel)]
+            simulated_reading = ["{:.7E}{}".format(value, unit), "{0:02d}INTCHAN".format(channel)]
             self.ca.set_pv_value("READINGS", simulated_reading)
         else:
             self._lewis.backdoor_run_function_on_device("set_channel_value_via_the_backdoor", [channel, value, unit])

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -162,3 +162,14 @@ class ErrorTests(unittest.TestCase):
         # Then:
         expected_error_status = "No error"
         self.ca.assert_that_pv_is("ERROR", expected_error_status)
+
+
+@setup_tests
+class ChannelReadingTests(unittest.TestCase):
+    TEST_VOLTAGES = [0, -2.3586, +1.05e9, 589, 2, 2.8654852]
+
+    @parameterized.expand(parameterized_list(zip(TEST_VOLTAGES, CHANNEL_LIST)))
+    def GIVEN_a_fresh_IOC_THEN_the_channels_are_reading_the_correct_values_from_the_buffer(self, _, voltage, channel):
+        # Then:
+        self._lewis.backdoor_set_on_device("CHAN:0{}".format(channel), voltage)
+        self.ca.assert_that_pv_is("CHAN:0{}".format(channel), voltage)

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -110,6 +110,12 @@ class InitTests(unittest.TestCase):
         self.ca.process_pv("SCAN:COUNT")
         self.ca.assert_that_pv_is("SCAN:COUNT", 1)
 
+    @skip_if_recsim("Cannot simulate records of different types")
+    def test_that_GIVEN_a_fresh_ioc_THEN_scan_trigger_is_set_to_immediate(self):
+        # Then:
+        self.ca.process_pv("SCAN:TRIG")
+        self.ca.assert_that_pv_is("SCAN:TRIG", "IMM")
+
 
 @setup_tests
 class ChannelSetupTests(unittest.TestCase):

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -1,6 +1,4 @@
-import ast
-import itertools
-from hamcrest import assert_that, is_
+from hamcrest import assert_that, is_, greater_than
 from parameterized import parameterized
 import unittest
 import time
@@ -214,6 +212,31 @@ class BufferSetupTests(unittest.TestCase):
         # Then:
         self.ca.process_pv("SCAN:MEAS:COUNT")
         self.ca.assert_that_pv_is("SCAN:MEAS:COUNT", len(channels))
+
+    def test_that_GIVEN_IOC_in_scan_mode_THEN_buffer_mode_is_set_to_stop_when_the_buffer_is_full(self):
+        channels = (1, 2)
+
+        # Given:
+        for channel in channels:
+            self.ca.set_pv_value("CHAN:0{}:ACTIVE".format(channel), 1)
+
+        # Then:
+        expected_value = "NEXT"
+        self.ca.process_pv("BUFF:MODE")
+        self.ca.assert_that_pv_is("BUFF:MODE", expected_value)
+
+    def test_that_GIVEN_IOC_in_scan_mode_THEN_buffer_is_cleared_before_reading(self):
+        channels = (1, 2)
+
+        # Given:
+        for channel in channels:
+            self.ca.set_pv_value("CHAN:0{}:ACTIVE".format(channel), 1)
+
+        # Then:
+        number_of_times_buffer_has_been_cleared = self._lewis.backdoor_run_function_on_device(
+            "get_number_of_times_buffer_has_been_cleared_via_the_backdoor")[0]
+        assert_that(number_of_times_buffer_has_been_cleared, is_(greater_than("1")))
+
 
 
 @setup_tests

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -1,0 +1,34 @@
+import unittest
+
+from utils.channel_access import ChannelAccess
+from utils.ioc_launcher import get_default_ioc_dir
+from utils.test_modes import TestModes
+from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
+
+
+DEVICE_PREFIX = "KHLY2001_01"
+
+
+IOCS = [
+    {
+        "name": DEVICE_PREFIX,
+        "directory": get_default_ioc_dir("KHLY2001"),
+        "macros": {},
+        "emulator": "Keithley_2001",
+    },
+]
+
+
+TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
+
+
+class Keithley_2001Tests(unittest.TestCase):
+    """
+    Tests for the Keithley_2001 IOC.
+    """
+    def setUp(self):
+        self._lewis, self._ioc = get_running_lewis_and_ioc("Keithley_2001", DEVICE_PREFIX)
+        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
+
+    def test_that_fails(self):
+        self.fail("You haven't implemented any tests!")

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -23,7 +23,7 @@ IOCS = [
     },
 ]
 
-TEST_MODES = [TestModes.DEVSIM, TestModes.RECSIM]
+TEST_MODES = [TestModes.DEVSIM]#, TestModes.RECSIM]
 
 CHANNEL_LIST = [1, 2, 3, 4, 6, 7, 8, 9]
 
@@ -100,36 +100,36 @@ class BufferStartUpTests(unittest.TestCase):
         self.ca.process_pv("BUFF:EGROUP")
         self.ca.assert_that_pv_is("BUFF:EGROUP", expected_buffer_element_group)
 
+
 @setup_tests
 class ChannelSetupTests(unittest.TestCase):
 
     @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
-    def GIVEN_a_fresh_IOC_with_no_channels_set_to_active_THEN_no_channels_are_set_to_scan(self):
+    def test_that_GIVEN_a_fresh_IOC_with_no_channels_set_to_active_THEN_the_IOC_is_in_IDLE_scan_mode(self):
         # Then:
-        expected_channels = "(@)"
-        self.ca.assert_that_pv_is("SCAN:CHAN:STATUS", expected_channels)
+        expected_mode = "IDLE"
+        self.ca.assert_that_pv_is("SCAN:MODE", expected_mode)
 
     @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
-    def GIVEN_a_fresh_IOC_with_one_channels_set_to_active_THEN_only_the_active_channels_are_set_to_scan(self):
+    def test_that_GIVEN_a_fresh_IOC_with_one_channels_set_to_active_THEN_the_IOC_is_in_SINGLE_scan_mode(self):
         # Given:
         self.ca.set_pv_value("CHAN:01:ACTIVE", 1)
 
         # Then:
-        expected_channels = "1"
-        self.ca.assert_that_pv_is("SCAN:CHAN:STATUS", expected_channels)
+        expected_mode = "SINGLE"
+        self.ca.assert_that_pv_is("SCAN:MODE", expected_mode)
 
     @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
-    def GIVEN_a_fresh_IOC_with_first_four_channels_set_to_active_THEN_only_the_active_channels_are_set_to_scan(
-            self):
+    def test_that_GIVEN_a_fresh_IOC_with_first_four_channels_set_to_active_THEN_the_IOC_is_in_MULTI_scan_mode(self):
         # Given:
-        expected_channels = [1, 2, 3, 4]
+        expected_channels = [1, 2, 3]
 
         for i in expected_channels:
             self.ca.set_pv_value("CHAN:0{}:ACTIVE".format(i), 1)
 
         # Then:
-        expected_channels = "1,2,3,4"
-        self.ca.assert_that_pv_is("SCAN:CHAN:STATUS", expected_channels)
+        expected_mode = "MULTI"
+        self.ca.assert_that_pv_is("SCAN:MODE", expected_mode)
 
 
 @setup_tests

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -38,7 +38,7 @@ setup_tests = add_method(setUp)
 
 
 @setup_tests
-class BasicCommands(unittest.TestCase):
+class BasicCommandsTests(unittest.TestCase):
 
     def test_that_GIVEN_a_fresh_IOC_THEN_the_IDN_is_correct(self):
         expected_idn = "MODEL 2001,4301578,B17  /A02  "

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -1,10 +1,11 @@
-import unittest
 import ast
+from parameterized import parameterized
+import unittest
 
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
-from utils.testing import get_running_lewis_and_ioc, skip_if_recsim, add_method
+from utils.testing import get_running_lewis_and_ioc, skip_if_recsim, add_method, parameterized_list
 
 
 DEVICE_PREFIX = "KHLY2001_01"
@@ -21,6 +22,7 @@ IOCS = [
 
 TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
 
+CHANNEL_LIST = [1, 2, 3, 4, 6, 7, 8, 9]
 
 def setUp(self):
     self._lewis, self._ioc = get_running_lewis_and_ioc("keithley_2001", DEVICE_PREFIX)
@@ -36,34 +38,27 @@ setup_tests = add_method(setUp)
 @setup_tests
 class ScanStartUpTests(unittest.TestCase):
 
-    def setUp(self):
-        self._lewis, self._ioc = get_running_lewis_and_ioc("keithley_2001", DEVICE_PREFIX)
-        self.ca = ChannelAccess(default_timeout=30, device_prefix=DEVICE_PREFIX)
-        self.ca.assert_that_pv_exists("IDN")
-        # Given:
-        self.ca.process_pv("startup")
-
-    @skip_if_recsim(" Cannot use Lewis backdoor used with RECSIM")
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def GIVEN_a_fresh_IOC_THEN_the_initialization_mode_is_set_to_continuous(self):
         # Then:
         initialization_mode = list(self._lewis.backdoor_get_from_device("initialization_mode"))
         self._lewis.assert_that_emulator_value_is(initialization_mode, "continuous")
 
-    @skip_if_recsim(" Cannot use Lewis backdoor used with RECSIM")
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def GIVEN_a_fresh_IOC_THEN_the_scan_rate_is_set_to_half_a_second(self):
         # Then:
         expected_scan_rate = 0.5
         scan_rate = float(self._lewis.backdoor_get_from_device("scan_rate"))
         self._lewis.assert_that_emulator_value_is(scan_rate, expected_scan_rate)
 
-    @skip_if_recsim(" Cannot use Lewis backdoor used with RECSIM")
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def GIVEN_a_fresh_IOC_THEN_the_read_back_elements_are_reading_and_unit(self):
         # Then:
         expected_read_back_elements = {"READ", "UNIT"}
         read_back_elements = set(ast.literal_eval(self._lewis.backdoor_get_from_device("read_back_elements")))
         self._lewis.assert_that_emulator_value_is(read_back_elements, expected_read_back_elements)
 
-    @skip_if_recsim(" Cannot use Lewis backdoor used with RECSIM")
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def GIVEN_a_fresh_IOC_THEN_the_the_device_is_set_to_scan(self):
         # Then:
         expected_scan_status = "SCANNING"
@@ -74,60 +69,51 @@ class ScanStartUpTests(unittest.TestCase):
 @setup_tests
 class BufferStartUpTests(unittest.TestCase):
 
-    @skip_if_recsim(" Cannot use Lewis backdoor used with RECSIM")
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def GIVEN_a_fresh_IOC_THEN_the_buffer_is_cleared_before_starting(self):
         # Then:
         buffer_cleared = self._lewis.backdoor_get_from_device("buffer_cleared")
-        self._lewis.assert_that_emulator_value_is(buffer_cleared, False)
+        self._lewis.assert_that_emulator_value_is(buffer_cleared, True)
 
-    @skip_if_recsim(" Cannot use Lewis backdoor used with RECSIM")
-    def GIVEN_a_fresh_IOC_THEN_buffer_autoclear_is_turned_on(self):
-        # Then:
-        voltage_precision = self._lewis.backdoor_get_from_device("buffer_autoclear")
-        self._lewis.assert_that_emulator_value_is(voltage_precision, True)
-
-    @skip_if_recsim(" Cannot use Lewis backdoor used with RECSIM")
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def GIVEN_a_fresh_IOC_THEN_the_buffer_reads_raw_values(self):
         # Then:
-        buffer_source = self._lewis.backdoor_get_from_device("buffer_source")
-        self._lewis.assert_that_emulator_value_is(buffer_source, "RAW")
+        expected_buffer_source = "SENS"
+        self.ca.assert_that_pv_is("BUFF:SOURCE", expected_buffer_source)
 
-    @skip_if_recsim(" Cannot use Lewis backdoor used with RECSIM")
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def GIVEN_a_fresh_IOC_THEN_the_buffer_control_mode_is_set_to_always(self):
         # Then:
-        buffer_control_mode = self._lewis.backdoor_get_from_device("buffer_control_mode")
-        self._lewis.assert_that_emulator_value_is(buffer_control_mode, "ALWAYS")
+        expected_buffer_control_mode = "ALWAYS"
+        self.ca.assert_that_pv_is("BUFF:CNTRL:STATUS", expected_buffer_control_mode)
 
-    @skip_if_recsim(" Cannot use Lewis backdoor used with RECSIM")
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def GIVEN_a_fresh_IOC_THEN_the_buffer_size_is_1000(self):
         # Then:
         expected_buffer_size = 1000
-        buffer_size = self._lewis.backdoor_get_from_device("buffer_size")
-        self._lewis.assert_that_emulator_value_is(buffer_size, expected_buffer_size)
+        self.ca.assert_that_pv_is("BUFF:SIZE", expected_buffer_size)
 
 
 @setup_tests
 class ChannelSetupTests(unittest.TestCase):
 
-    @skip_if_recsim(" Cannot use Lewis backdoor used with RECSIM")
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def GIVEN_a_fresh_IOC_with_no_channels_set_to_active_THEN_no_channels_are_set_to_scan(self):
         # Then:
-        expected_channels = [1]
-        channels_to_scan = list(self._lewis.backdoor_get_from_device("channels_to_scan"))
-        self._lewis.assert_that_emulator_value_is(channels_to_scan, expected_channels)
+        expected_channels = "(@)"
+        self.ca.assert_that_pv_is("SCAN:CHAN:STATUS", expected_channels)
 
-    @skip_if_recsim(" Cannot use Lewis backdoor used with RECSIM")
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def GIVEN_a_fresh_IOC_with_one_channels_set_to_active_THEN_only_the_active_channels_are_set_to_scan(self):
         # Given:
         self.ca.set_pv_value("CHAN:01:ACTIVE", 1)
         self.ca.process_pv("startup")
 
         # Then:
-        expected_channels = [1]
-        channels_to_scan = list(self._lewis.backdoor_get_from_device("channels_to_scan"))
-        self._lewis.assert_that_emulator_value_is(channels_to_scan, expected_channels)
+        expected_channels = "1"
+        self.ca.assert_that_pv_is("SCAN:CHAN:STATUS", expected_channels)
 
-    @skip_if_recsim(" Cannot use Lewis backdoor used with RECSIM")
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def GIVEN_a_fresh_IOC_with_first_four_channels_set_to_active_THEN_only_the_active_channels_are_set_to_scan(
             self):
         # Given:
@@ -138,47 +124,35 @@ class ChannelSetupTests(unittest.TestCase):
         self.ca.process_pv("startup")
 
         # Then:
-        channels_to_scan = list(self._lewis.backdoor_get_from_device("channels_to_scan"))
-        self._lewis.assert_that_emulator_value_is(channels_to_scan, expected_channels)
+        expected_channels = "1,2,3,4"
+        self.ca.assert_that_pv_is("SCAN:CHAN:STATUS", expected_channels)
 
 
 @setup_tests
 class MeasurementSetupTests(unittest.TestCase):
 
-    @skip_if_recsim(" Cannot use Lewis backdoor used with RECSIM")
-    def GIVEN_a_fresh_IOC_THEN_the_measurement_mode_for_each_channel_is_VDC(self):
+    @parameterized.expand(parameterized_list(CHANNEL_LIST))
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
+    def GIVEN_a_fresh_IOC_THEN_the_measurement_mode_for_each_channel_is_VOLT_DC(self):
         # Then:
-        expected_measurement_modes = {
-            "CHAN:01": "V:DC",
-            "CHAN:02": "V:DC",
-            "CHAN:03": "V:DC",
-            "CHAN:04": "V:DC",
-            "CHAN:06": "V:DC",
-            "CHAN:07": "V:DC",
-            "CHAN:08": "V:DC",
-            "CHAN:09": "V:DC"
-        }
-        measurement_modes = ast.literal_eval(self._lewis.backdoor_get_from_device("scan_rate"))
-        self._lewis.assert_that_emulator_value_is(measurement_modes, expected_measurement_modes)
+        expected_measurement_mode = "VOLT:DC"
+        self.ca.assert_that_pv_is("CHAN:0{}:MEAS", expected_measurement_mode)
 
-    @skip_if_recsim(" Cannot use Lewis backdoor used with RECSIM")
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def GIVEN_a_fresh_IOC_THEN_the_precision_of_VOLT_DC_measurement_mode_is_5(self):
         # Then:
         precision = 5
-        voltage_precision = self._lewis.backdoor_get_from_device("voltage_precision")
-        self._lewis.assert_that_emulator_value_is(voltage_precision, precision)
+        self.ca.assert_that_pv_is("VOLT:DC:PREC", precision)
 
-    @skip_if_recsim(" Cannot use Lewis backdoor used with RECSIM")
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def GIVEN_a_fresh_IOC_THEN_VOLT_DC_autorange_is_ON(self):
         # Then:
-        voltage_precision = self._lewis.backdoor_get_from_device("voltage_autorange")
-        self._lewis.assert_that_emulator_value_is(voltage_precision, "ON")
+        self.ca.assert_that_pv_is("VOLT:DC:RANGE:AUTO", "ON")
 
-    @skip_if_recsim(" Cannot use Lewis backdoor used with RECSIM")
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def GIVEN_a_fresh_IOC_THEN_the_auto_aperture_of_volt_dc_is_on(self):
         # Then:
-        auto_aperture_mode = self._lewis.backdoor_get_from_device("auto_aperture_mode")
-        self._lewis.assert_that_emulator_value_is(auto_aperture_mode, True)
+        self.ca.assert_that_pv_is("VOLT:DC:APER:AUTO", "ON")
 
 
 @setup_tests

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -126,6 +126,15 @@ class ChannelSetupTests(unittest.TestCase):
         self.ca.assert_that_pv_is("READ:MODE", expected_mode)
 
     @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
+    def test_that_GIVEN_a_fresh_IOC_with_one_channels_set_to_active_THEN_the_IOC_scans_on_that_channel(self):
+        # Given:
+        self.ca.set_pv_value("CHAN:01:ACTIVE", 1)
+
+        # Then:
+        expected_channel = "1"
+        self.ca.assert_that_pv_is("READ:CHANNELS", expected_channel)
+
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
     def test_that_GIVEN_a_fresh_IOC_with_first_four_channels_set_to_active_THEN_the_IOC_is_in_MULTI_scan_mode(self):
         # Given:
         expected_channels = [1, 2, 3]

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -74,7 +74,12 @@ class TestedCommands(unittest.TestCase):
         self.ca.process_pv("BUFF:MODE")
         self.ca.assert_that_pv_is("BUFF:MODE", expected_buffer_control_mode)
 
-
+    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
+    def test_that_GIVEN_a_fresh_IOC_THEN_the_buffer_size_is_250(self):
+        # Then:
+        expected_buffer_size = 250
+        self.ca.process_pv("BUFF:SIZE")
+        self.ca.assert_that_pv_is("BUFF:SIZE", expected_buffer_size)
 
 
 @setup_tests
@@ -86,14 +91,8 @@ class ScanStartUpTests(unittest.TestCase):
         initialization_mode = list(self._lewis.backdoor_get_from_device("initialization_mode"))
         self._lewis.assert_that_emulator_value_is(initialization_mode, "continuous")
 
-@setup_tests
-class BufferStartUpTests(unittest.TestCase):
-
-    @skip_if_recsim("Cannot use Lewis backdoor used with RECSIM")
-    def test_that_GIVEN_a_fresh_IOC_THEN_the_buffer_size_is_1000(self):
-        # Then:
-        expected_buffer_size = 1000
-        self.ca.assert_that_pv_is("BUFF:SIZE", expected_buffer_size)
+# @setup_tests
+# class BufferStartUpTests(unittest.TestCase):
 
 
 @setup_tests

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -95,13 +95,10 @@ class InitTests(unittest.TestCase):
 
     @skip_if_recsim("Lewis backdoor doesn't work in RECSIM.")
     def test_that_GIVEN_a_fresh_IOC_THEN_the_device_buffer_and_status_register_have_been_reset(self):
-        number_of_times_buffer_has_been_cleared = int(self._lewis.backdoor_run_function_on_device(
-            "get_number_of_times_buffer_has_been_cleared_via_the_backdoor")[0])
         number_of_times_status_register_has_been_reset_and_cleared = int(
             self._lewis.backdoor_run_function_on_device(
                 "get_number_of_times_status_register_has_been_reset_and_cleared_via_the_backdoor")[0])
 
-        assert_that(number_of_times_buffer_has_been_cleared, is_(greater_than_or_equal_to(1)))
         assert_that(number_of_times_status_register_has_been_reset_and_cleared, is_(greater_than_or_equal_to(1)))
         self._lewis.assert_that_emulator_value_is_greater_than("number_of_times_device_has_been_reset", 1)
 

--- a/utils/channel_access.py
+++ b/utils/channel_access.py
@@ -17,6 +17,18 @@ except ImportError:
             return partial(self.func, instance, *(self.args or ()), **(self.keywords or {}))
 
 
+def format_value(value):
+    """
+    Formats a value for display. Includes type information to ease debugging.
+
+    Args:
+        value: The value to format.
+    Returns:
+        string: The formatted value.
+    """
+    return "'{}' (type: '{}')".format(value, value.__class__.__name__)
+
+
 class ChannelAccess(object):
     """
     Provides the required channel access commands.
@@ -117,17 +129,6 @@ class ChannelAccess(object):
         finally:
             _set_and_check_simulated_alarm(pv, self.Alarms.NONE)
 
-    def _format_value(self, value):
-        """
-        Formats a PV value for display. Includes type information to ease debugging.
-
-        Args:
-            value: The value to format
-        Returns:
-            The formatted value
-        """
-        return "'{}' (type: '{}')".format(value, value.__class__.__name__)
-
     def _create_pv_with_prefix(self, pv):
         """
         Create the full pv name with instrument prefix.
@@ -187,11 +188,11 @@ class ChannelAccess(object):
                 return_value = func(value)
             except Exception as e:
                 return "Exception was thrown while evaluating function '{}' on pv value {}. Exception was: {} {}"\
-                    .format(func.__name__, self._format_value(value), e.__class__.__name__, e.message)
+                    .format(func.__name__, format_value(value), e.__class__.__name__, e.message)
             if return_value:
                 return None
             else:
-                return "{}{}{}".format(message, os.linesep, "Final PV value was {}".format(self._format_value(value)))
+                return "{}{}{}".format(message, os.linesep, "Final PV value was {}".format(format_value(value)))
 
         if message is None:
             message = "Expected function '{}' to evaluate to True when reading PV '{}'." \
@@ -217,7 +218,7 @@ class ChannelAccess(object):
         """
 
         if msg is None:
-            msg = "Expected PV to have value {}.".format(self._format_value(expected_value))
+            msg = "Expected PV to have value {}.".format(format_value(expected_value))
 
         return self.assert_that_pv_value_causes_func_to_return_true(
             pv, lambda val: val == expected_value, timeout=timeout, message=msg)
@@ -237,7 +238,7 @@ class ChannelAccess(object):
             UnableToConnectToPVException: if pv does not exist within timeout
         """
         if msg is None:
-            msg = "Expected PV to not have value {}.".format(self._format_value(restricted_value))
+            msg = "Expected PV to not have value {}.".format(format_value(restricted_value))
 
         return self.assert_that_pv_value_causes_func_to_return_true(
             pv, lambda val: val != restricted_value, timeout, message=msg)
@@ -273,7 +274,7 @@ class ChannelAccess(object):
             UnableToConnectToPVException: if pv does not exist within timeout
         """
         message = "Expected PV value to be equal to {} (tolerance: {})"\
-            .format(self._format_value(expected), self._format_value(tolerance))
+            .format(format_value(expected), format_value(tolerance))
 
         return self.assert_that_pv_value_causes_func_to_return_true(
             pv, lambda val: self._within_tolerance_condition(val, expected, tolerance), timeout, message=message)
@@ -292,7 +293,7 @@ class ChannelAccess(object):
              UnableToConnectToPVException: if pv does not exist within timeout
         """
         message = "Expected PV value to be not equal to {} (tolerance: {})"\
-            .format(self._format_value(restricted), self._format_value(tolerance))
+            .format(format_value(restricted), format_value(tolerance))
 
         return self.assert_that_pv_value_causes_func_to_return_true(
             pv, lambda val: not self._within_tolerance_condition(val, restricted, tolerance), timeout, message=message)
@@ -429,7 +430,7 @@ class ChannelAccess(object):
         time.sleep(wait)
 
         message = "Expected value trend to satisfy comparator '{}'. Initial value was {}."\
-            .format(comparator.__name__, self._format_value(initial_value))
+            .format(comparator.__name__, format_value(initial_value))
 
         def condition(val):
             return comparator(val, initial_value)

--- a/utils/channel_access.py
+++ b/utils/channel_access.py
@@ -238,13 +238,9 @@ class ChannelAccess(object):
             UnableToConnectToPVException: if pv does not exist within timeout
         """
 
-        if msg is None:
-            msg = "Expected PV to have value {}.".format(format_value(expected_value))
-
         self.process_pv(pv)
+        return self.assert_that_pv_is(pv, expected_value, timeout=None, msg=None)
 
-        return self.assert_that_pv_value_causes_func_to_return_true(
-            pv, lambda val: val == expected_value, timeout=timeout, message=msg)
 
     def assert_that_pv_is_not(self, pv, restricted_value, timeout=None, msg=""):
         """

--- a/utils/channel_access.py
+++ b/utils/channel_access.py
@@ -223,6 +223,29 @@ class ChannelAccess(object):
         return self.assert_that_pv_value_causes_func_to_return_true(
             pv, lambda val: val == expected_value, timeout=timeout, message=msg)
 
+    def assert_that_pv_after_processing_is(self, pv, expected_value, timeout=None, msg=None):
+        """
+        Assert that the pv has the expected value after the pv is processed
+        or that it becomes the expected value within the timeout.
+
+        Args:
+            pv: pv name
+            expected_value: expected value
+            timeout: if it hasn't changed within this time raise assertion error
+            msg: Extra message to print
+        Raises:
+            AssertionError: if value does not become requested value
+            UnableToConnectToPVException: if pv does not exist within timeout
+        """
+
+        if msg is None:
+            msg = "Expected PV to have value {}.".format(format_value(expected_value))
+
+        self.process_pv(pv)
+
+        return self.assert_that_pv_value_causes_func_to_return_true(
+            pv, lambda val: val == expected_value, timeout=timeout, message=msg)
+
     def assert_that_pv_is_not(self, pv, restricted_value, timeout=None, msg=""):
         """
         Assert that the pv does not have a particular value and optionally it does not become that value within the

--- a/utils/emulator_exceptions.py
+++ b/utils/emulator_exceptions.py
@@ -1,0 +1,7 @@
+class UnableToConnectToEmulatorException(IOError):
+    """
+    The system is unable to connect to the emulator for some reason.
+    """
+    def __init__(self, emulator_name, err):
+        super(UnableToConnectToEmulatorException, self).__init__("Unable to connect to Emnulator {0}: {1}"
+                                                                 .format(emulator_name, err))

--- a/utils/lewis_launcher.py
+++ b/utils/lewis_launcher.py
@@ -304,7 +304,7 @@ class LewisLauncher(object):
 
             message = "Expected emulator property {} to have a value greater than or equal to {}".format(
                 emulator_property, min_value)
-            return self.assert_that_emulator_value_value_causes_func_to_return_true(
+            return self.assert_that_emulator_value_causes_func_to_return_true(
                 emulator_property, lambda value: min_value <= float(value), timeout, message)
 
     def assert_that_emulator_value_is(self, emulator_property, expected_value, timeout=None, message=None):
@@ -324,10 +324,10 @@ class LewisLauncher(object):
         if message is None:
             message = "Expected PV to have value {}.".format(format_value(expected_value))
 
-        return self.assert_that_emulator_value_value_causes_func_to_return_true(
+        return self.assert_that_emulator_value_causes_func_to_return_true(
             emulator_property, lambda val: val == expected_value, timeout=timeout, msg=message)
 
-    def assert_that_emulator_value_value_causes_func_to_return_true(
+    def assert_that_emulator_value_causes_func_to_return_true(
             self, emulator_property, func, timeout=None, msg=None):
         """
         Check that a emulator property satisfies a given function within some timeout.

--- a/utils/lewis_launcher.py
+++ b/utils/lewis_launcher.py
@@ -302,7 +302,7 @@ class LewisLauncher(object):
                  UnableToConnectToPVException: if pv does not exist within timeout
             """
 
-            message = "Expected emulator property {} to have a value greater than {}".format(
+            message = "Expected emulator property {} to have a value greater than or equal to {}".format(
                 emulator_property, min_value)
             return self.assert_that_emulator_value_value_causes_func_to_return_true(
                 emulator_property, lambda value: min_value <= float(value), timeout, message)

--- a/utils/lewis_launcher.py
+++ b/utils/lewis_launcher.py
@@ -289,6 +289,24 @@ class LewisLauncher(object):
         """
         return "".join(self.backdoor_command(["device", str(variable_name)]))
 
+    def assert_that_emulator_value_is_greater_than(self, emulator_property, min_value, timeout=None):
+            """
+            Assert that an emulator property has a value greater than the expected value.
+
+            Args:
+                 emulator_property (string): Name of the emulator property.
+                 min_value (float): Minimum value (inclusive).
+                 timeout: if it hasn't changed within this time raise assertion error
+            Raises:
+                 AssertionError: if value does not become requested value
+                 UnableToConnectToPVException: if pv does not exist within timeout
+            """
+
+            message = "Expected emulator property {} to have a value greater than {}".format(
+                emulator_property, min_value)
+            return self.assert_that_emulator_value_value_causes_func_to_return_true(
+                emulator_property, lambda value: min_value <= float(value), timeout, message)
+
     def assert_that_emulator_value_is(self, emulator_property, expected_value, timeout=None, message=None):
         """
         Assert that the pv has the expected value or that it becomes the expected value within the timeout.

--- a/utils/lewis_launcher.py
+++ b/utils/lewis_launcher.py
@@ -294,7 +294,7 @@ class LewisLauncher(object):
             Assert that an emulator property has a value greater than the expected value.
 
             Args:
-                 emulator_property (string): Name of the emulator property.
+                 emulator_property (string): Name of the numerical emulator property.
                  min_value (float): Minimum value (inclusive).
                  timeout: if it hasn't changed within this time raise assertion error
             Raises:

--- a/utils/lewis_launcher.py
+++ b/utils/lewis_launcher.py
@@ -294,10 +294,10 @@ class LewisLauncher(object):
         Assert that the pv has the expected value or that it becomes the expected value within the timeout.
 
         Args:
-            emulator_property: emulator property to check
+            emulator_property (string): emulator property to check
             expected_value: expected value
-            timeout: if it hasn't changed within this time raise assertion error
-            message: Extra message to print
+            timeout (float): if it hasn't changed within this time raise assertion error
+            message (string): Extra message to print
         Raises:
             AssertionError: if emulator property is not the expected value
             UnableToConnectToPVException: if emulator property does not exist within timeout
@@ -307,25 +307,25 @@ class LewisLauncher(object):
             message = "Expected PV to have value {}.".format(format_value(expected_value))
 
         return self.assert_that_emulator_value_value_causes_func_to_return_true(
-            emulator_property, lambda val: val == expected_value, timeout=timeout, message=message)
+            emulator_property, lambda val: val == expected_value, timeout=timeout, msg=message)
 
     def assert_that_emulator_value_value_causes_func_to_return_true(
-            self, emulator_property, func, timeout=None, message=None):
+            self, emulator_property, func, timeout=None, msg=None):
         """
         Check that a emulator property satisfies a given function within some timeout.
 
         Args:
-            emulator_property: emulator property to check
+            emulator_property (string): emulator property to check
             func: a function that takes one argument, the emulator property value, and returns True if the value is
                 valid.
             timeout: time to wait for the PV to satisfy the function
-            message: custom message to print on failure
+            msg: custom message to print on failure
         Raises:
             AssertionError: If the function does not evaluate to true within the given timeout
         """
 
-        def wrapper(message):
-            value = getattr(self._device, emulator_property)
+        def wrapper(msg):
+            value = self.backdoor_get_from_device(emulator_property)
             try:
                 return_value = func(value)
             except Exception as e:
@@ -335,14 +335,14 @@ class LewisLauncher(object):
             if return_value:
                 return None
             else:
-                return "{}{}{}".format(message, os.linesep, "Final emulator property value was {}"
+                return "{}{}{}".format(msg, os.linesep, "Final emulator property value was {}"
                                        .format(format_value(value)))
 
-        if message is None:
-            message = "Expected function '{}' to evaluate to True when reading emulator property '{}'." \
+        if msg is None:
+            msg = "Expected function '{}' to evaluate to True when reading emulator property '{}'." \
                 .format(func.__name__, emulator_property)
 
-        err = self._wait_for_emulator_lambda(partial(wrapper, message), timeout)
+        err = self._wait_for_emulator_lambda(partial(wrapper, msg), timeout)
 
         if err is not None:
             raise AssertionError(err)


### PR DESCRIPTION
### Description of Work Done
- Tests for the Keithley 2001 IOC. **NB**: The tests take over 27 minutes per test mode (54 minutes in total) to run.
- Refactored `format_value` so it can be used across Lewis and Channel access utils files.
- Added Lewis assertions
- Added `assert_that_pv_after_processing_is` assertion to channel access.

### Issue
[#3476](https://github.com/ISISComputingGroup/IBEX/issues/3476)

### Acceptance Criteria

- [ ] All tests for the Keithley 2001 IOC pass.
- [ ] The refactoring of `format_value` is appropriate.
- [ ] The added Lewis assertions work and make sense.
- [ ] The added `assert_that_pv_after_processing_is` assertion to works and make sense.