### PR TITLE
Ticket3667 - GENESYS address changed from float to integer.

### DIFF
--- a/tests/tdk_lambda_genesys.py
+++ b/tests/tdk_lambda_genesys.py
@@ -87,7 +87,7 @@ class TdkLambdaGenesysTests(unittest.TestCase):
         try:
             for curr in [0.123, 0.456]:
                 self._lewis.backdoor_set_on_device("comms_initialized", False)
-                self._lewis.backdoor_set_on_device("current", curr)
+                self._write_current(curr)
                 # Should be able to re-initialize comms and read the new current
                 self.ca.assert_that_pv_is_number("1:CURR", curr, tolerance=0.01, timeout=30)
 


### PR DESCRIPTION
### Description of work

Changes the protocal file for the TDK_Lambda_Genesys's address from float to int ([commit](https://github.com/ISISComputingGroup/EPICS-TDKLambdaGenesys/commit/35f479f8287c04da5158d49045ff10d0a40a38f6)). The DeviceEmulator's tdk_lambda_genesys interface was modified so that it will catch floats (if passed) when matching a regular expression ([pull](https://github.com/ISISComputingGroup/EPICS-DeviceEmulator/pull/2)). Config macro ([pull](https://github.com/ISISComputingGroup/EPICS-ioc/pull/332))

### Ticket

Fixes: https://github.com/ISISComputingGroup/IBEX/issues/3667

### Acceptance criteria

Genesys power supplys address is an integer.

### Unit tests

The TDK_lambda_genesys DeviceEmulators was modified so that when the initialize_comms command is built, the regular expression it checks against uses endOfString() to ensure that there's no decimal places in the address.

### System tests

None

### Documentation

None

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

