### PR TITLE
Ticket3623 loq aperture

### DIFF
--- a/test_support/loq_aperture/axes.cmd
+++ b/test_support/loq_aperture/axes.cmd
@@ -1,0 +1,1 @@
+$(IFIOC_GALIL_01) dbLoadRecords("$(AXIS)/db/axis.db","P=$(MYPVPREFIX)MOT:,AXIS=APERTURE,mAXIS=MTR0101")

--- a/test_support/loq_aperture/motionSetPoints/aperture.txt
+++ b/test_support/loq_aperture/motionSetPoints/aperture.txt
@@ -1,0 +1,8 @@
+# Convert sample position names to motor coordinates
+Blank_01     10.000000
+Aperture_01  15.000000
+Blank_02     20.000000
+Aperture_02  25.000000
+Blank_03     30.000000
+Aperture_03  35.000000
+Blank_04     40.000000

--- a/test_support/loq_aperture/motionSetPoints/aperture.txt
+++ b/test_support/loq_aperture/motionSetPoints/aperture.txt
@@ -1,8 +1,6 @@
 # Convert sample position names to motor coordinates
-Blank_01     0.000000
-Aperture_01  10.000000
-Blank_02     20.000000
-Aperture_02  30.000000
-Blank_03     40.000000
-Aperture_03  50.000000
-Blank_04     60.000000
+Aperture_large   02.900000
+Stop_01          15.400000
+Aperture_medium  27.900000
+Stop_02          40.400000
+Aperture_small   52.900000

--- a/test_support/loq_aperture/motionSetPoints/aperture.txt
+++ b/test_support/loq_aperture/motionSetPoints/aperture.txt
@@ -1,8 +1,8 @@
 # Convert sample position names to motor coordinates
-Blank_01     10.000000
-Aperture_01  15.000000
+Blank_01     0.000000
+Aperture_01  10.000000
 Blank_02     20.000000
-Aperture_02  25.000000
-Blank_03     30.000000
-Aperture_03  35.000000
-Blank_04     40.000000
+Aperture_02  30.000000
+Blank_03     40.000000
+Aperture_03  50.000000
+Blank_04     60.000000

--- a/test_support/loq_aperture/motionsetpoints.cmd
+++ b/test_support/loq_aperture/motionsetpoints.cmd
@@ -1,0 +1,9 @@
+epicsEnvSet "LOOKUPFILE1" "$(ICPCONFIGROOT)/motionSetPoints/aperture.txt"
+
+motionSetPointsConfigure("LOOKUPFILE1","LOOKUPFILE1")
+
+# The tolerance must be large to make sure that LOCN always points to the closest setpoint
+$(IFIOC_GALIL_01) dbLoadRecords("$(MOTIONSETPOINTS)/db/motionSetPoints.db","P=$(MYPVPREFIX)LKUP:APERTURE:,NAME1=APERTURE,AXIS1=$(MYPVPREFIX)MOT:APERTURE,TOL=1000,LOOKUP=LOOKUPFILE1")
+
+# Load the records which control closing the aperture
+$(IFIOC_GALIL_01) dbLoadRecords("$(MOTOREXT)/db/loqAperture.db", "P=$(MYPVPREFIX), SETPTAXIS=$(MYPVPREFIX)LKUP:APERTURE:")

--- a/test_support/loq_aperture/motionsetpoints.cmd
+++ b/test_support/loq_aperture/motionsetpoints.cmd
@@ -3,7 +3,7 @@ epicsEnvSet "LOOKUPFILE1" "$(ICPCONFIGROOT)/motionSetPoints/aperture.txt"
 motionSetPointsConfigure("LOOKUPFILE1","LOOKUPFILE1")
 
 # The tolerance must be large to make sure that LOCN always points to the closest setpoint
-$(IFIOC_GALIL_01) dbLoadRecords("$(MOTIONSETPOINTS)/db/motionSetPoints.db","P=$(MYPVPREFIX)LKUP:APERTURE:,NAME1=APERTURE,AXIS1=$(MYPVPREFIX)MOT:APERTURE,TOL=1000,LOOKUP=LOOKUPFILE1")
+$(IFIOC_GALIL_01) dbLoadRecords("$(MOTIONSETPOINTS)/db/motionSetPoints.db","P=$(MYPVPREFIX)LKUP:APERTURE:,NAME1=APERTURE,AXIS1=$(MYPVPREFIX)MOT:APERTURE,TOL=10,LOOKUP=LOOKUPFILE1")
 
 # Load the records which control closing the aperture
 $(IFIOC_GALIL_01) dbLoadRecords("$(MOTOREXT)/db/loqAperture.db", "P=$(MYPVPREFIX), SETPTAXIS=$(MYPVPREFIX)LKUP:APERTURE:")

--- a/tests/fermi_chopper_lifter.py
+++ b/tests/fermi_chopper_lifter.py
@@ -9,7 +9,8 @@ from utils.test_modes import TestModes
 
 GALIL_ADDR = "128.0.0.0"
 
-test_path = os.path.realpath(os.path.join(os.getenv("EPICS_KIT_ROOT"), "support", "motorExtensions", "master", "settings", "emma_chopper_lifter"))
+test_path = os.path.realpath(os.path.join(os.getenv("EPICS_KIT_ROOT"),
+                                          "support", "motorExtensions", "master", "settings", "emma_chopper_lifter"))
 
 IOCS = [
     {

--- a/tests/fermi_chopper_lifter.py
+++ b/tests/fermi_chopper_lifter.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import IOCRegister, get_default_ioc_dir
@@ -8,6 +9,7 @@ from utils.test_modes import TestModes
 
 GALIL_ADDR = "128.0.0.0"
 
+test_path = os.path.realpath(os.path.join(os.getenv("EPICS_KIT_ROOT"), "support", "motorExtensions", "master", "settings", "emma_chopper_lifter"))
 
 IOCS = [
     {
@@ -15,7 +17,7 @@ IOCS = [
         "directory": get_default_ioc_dir("GALIL"),
         "macros": {
             "GALILADDR01": GALIL_ADDR,
-            "IFCHOPLIFT": " ",
+            "GALILCONFIGDIR": test_path.replace("\\", "/"),
         },
     },
 ]

--- a/tests/loq_aperture.py
+++ b/tests/loq_aperture.py
@@ -36,7 +36,7 @@ MOTION_SETPOINT = OrderedDict([("Aperture_large",  02.900000),
                                ("Stop_02",         40.400000),
                                ("Aperture_small",  52.900000)])
 
-test_path = os.path.realpath(os.path.join(os.path.dirname(__file__), os.pardir, "test_support", "loq_aperture"))
+test_path = os.path.realpath(os.path.join(os.getenv("EPICS_KIT_ROOT"), "support", "motorExtensions", "master", "settings", "loqAperture"))
 
 IOCS = [
     {

--- a/tests/loq_aperture.py
+++ b/tests/loq_aperture.py
@@ -1,0 +1,144 @@
+import unittest
+import os
+import math
+from unittest import skip
+
+from utils.channel_access import ChannelAccess
+from utils.ioc_launcher import IOCRegister, get_default_ioc_dir
+from parameterized import parameterized
+
+# Internal Address of device (must be 2 characters)
+from utils.test_modes import TestModes
+
+GALIL_ADDR = "128.0.0.0"
+
+PREFIX = "MOT"
+
+## Motor position tolerance
+TOLERANCE = 2e-1
+## Length of time to wait for RBV to reach setpoint
+#RBV_TIMEOUT = 50
+#
+## PV names for X/Y motors
+MOTOR = "MOT:MTR0101"
+#MOTOR_Y = "MOT:ARM:Y"
+#MOTOR_X_RBV = "MOT:ARM:X.RBV"
+#MOTOR_Y_RBV = "MOT:ARM:Y.RBV"
+#
+## PV names for "real" motors
+#MTR1 = "MOT:MTR0101"
+#MTR2 = "MOT:MTR0102"
+#
+## PV for store/active command
+#STORE_PV = "MOT:ARM:STORE"
+#STORE_SP = "ARM:STORE:SP"
+#
+## PV for tweaking X/Y position
+#TWEAK_X = "ARM:X:TWEAK"
+#TWEAK_Y = "ARM:Y:TWEAK"
+
+## PV reading closest beamstop position
+CLOSESTSHUTTER = "APERTURE:CLOSESTSHUTTER"
+
+## PV which sends the motor to closest beamstop motion set point
+CLOSEAPERTURE = "APERTURE:CLOSEAPERTURE"
+
+test_path = os.path.realpath(os.path.join(os.path.dirname(__file__), os.pardir, "test_support", "loq_aperture"))
+
+IOCS = [
+    {
+        "name": "GALIL_01",
+        "directory": get_default_ioc_dir("GALIL"),
+        "macros": {
+            "GALILADDR": GALIL_ADDR,
+            "IFLOQAPERTURE": " ",
+            "MTRCTRL": "1",
+            "GALILCONFIGDIR": test_path,
+            "ICPCONFIGROOT": test_path,
+        },
+    },
+]
+
+
+TEST_MODES = [TestModes.DEVSIM]
+
+#@skip("This test is very unstable. It should work; it has been disabled so that we can see other failures on Jenkins")
+class LoqApertureTests(unittest.TestCase):
+    """
+    Tests for the LOQ Aperture
+    """
+    def setUp(self):
+        self._ioc = IOCRegister.get_running("GALIL_01")
+        self.ca = ChannelAccess(default_timeout=30)
+        self.ca.assert_that_pv_exists(MOTOR, timeout=60)
+        self.ca.assert_that_pv_exists(CLOSESTSHUTTER)
+        self.ca.assert_that_pv_exists(CLOSEAPERTURE)
+
+
+    # BX refers to a blanking plate; AX refers to an aperture hole. Closest positions defined in ticket 3623
+    @parameterized.expand([
+        ("start_B1", 0, 0),
+        ("start_A1", 1, 2),
+        ("start_B2", 2, 2),
+        ("start_A2", 3, 4),
+        ("start_B3", 4, 4),
+        ("start_A3", 5, 4),
+        ("start_B4", 6, 6),
+    ])
+    def test_GIVEN_motor_on_an_aperture_position_WHEN_motor_set_to_closest_beamstop_THEN_motor_moves_to_closest_beamstop(self, _, start_pos, closest_stop):
+        # GIVEN
+        self.ca.set_pv_value(MOTOR, start_pos)
+        self.ca.assert_that_pv_is_number(MOTOR, start_pos, TOLERANCE)
+        self.ca.assert_that_pv_is_number(MOTOR, start_pos, tolerance=TOLERANCE)
+
+        # WHEN
+        self.ca.process_pv(CLOSEAPERTURE)
+
+        # THEN
+        self.ca.assert_that_pv_is_number(CLOSESTSHUTTER, closest_stop)
+        self.ca.assert_that_pv_is_number(MOTOR, closest_stop, timeout=5)
+
+#    @parameterized.expand([
+#        ("start_B1", 0, 0),
+#        ("start_A1", 1, 2),
+#        ("start_B2", 2, 2),
+#        ("start_A2", 3, 4),
+#        ("start_B3", 4, 4),
+#        ("start_A3", 5, 4),
+#        ("start_B4", 6, 6),
+#    ])
+#    def test_GIVEN_motor_between_setpoint_positions_WHEN_motor_set_to_closest_beamstop_THEN_motor_moves_to_closest_beamstop(self, start_pos, closest_stop):
+#        # GIVEN
+#        self.ca.set_pv_value(MOTOR, start_pos)
+#        self.ca.assert_that_pv_is_number(MOTOR, start_pos, TOLERANCE)
+#        self.ca.assert_that_pv_is_number(MOTOR, start_pos, tolerance=TOLERANCE)
+#
+#        # WHEN
+#        self.ca.process_pv(CLOSEAPERTURE)
+#
+#        # THEN
+#        self.ca.assert_that_pv_is_number(CLOSESTSHUTTER, closest_stop)
+#        self.ca.assert_that_pv_is_number(MOTOR, closest_stop, timeout=60)
+
+
+#    def _set_pv_value(self, pv_name, value):
+#        self.ca.set_pv_value("{0}:{1}".format(PREFIX, pv_name), value)
+#
+#    def _set_x(self, value):
+#        self._set_pv_value("ARM:X:SP", value)
+#
+#    def _set_y(self, value):
+#        self._set_pv_value("ARM:Y:SP", value)
+#
+#    def _assert_setpoint_and_readback_reached(self, x_position, y_position):
+#        """
+#        Check that both the setpoint for has been set and the readback value reaches that setpoint
+#        :param x_position: the expected value to move the x axis to
+#        :param y_position: the expected value to move the y axis to
+#        :return:
+#        """
+#        self.ca.assert_that_pv_is_number(MOTOR_X, x_position, TOLERANCE)
+#        self.ca.assert_that_pv_is_number(MOTOR_Y, y_position, TOLERANCE)
+#        self.ca.assert_that_pv_is_number(MOTOR_X_RBV, x_position, TOLERANCE, timeout=RBV_TIMEOUT)
+#        self.ca.assert_that_pv_is_number(MOTOR_Y_RBV, y_position, TOLERANCE, timeout=RBV_TIMEOUT)
+

--- a/tests/loq_aperture.py
+++ b/tests/loq_aperture.py
@@ -47,6 +47,15 @@ CLOSESTSHUTTER = "APERTURE:CLOSESTSHUTTER"
 ## PV which sends the motor to closest beamstop motion set point
 CLOSEAPERTURE = "APERTURE:CLOSEAPERTURE"
 
+## Test motion set points located in test_support/loq_aperture
+MOTION_SETPOINTS = {"Blank_01":     0.000000,
+                    "Aperture_01":  10.000000,
+                    "Blank_02":     20.000000,
+                    "Aperture_02":  30.000000,
+                    "Blank_03":     40.000000,
+                    "Aperture_03":  50.000000,
+                    "Blank_04":     60.000000}
+
 test_path = os.path.realpath(os.path.join(os.path.dirname(__file__), os.pardir, "test_support", "loq_aperture"))
 
 IOCS = [
@@ -81,18 +90,19 @@ class LoqApertureTests(unittest.TestCase):
 
     # BX refers to a blanking plate; AX refers to an aperture hole. Closest positions defined in ticket 3623
     @parameterized.expand([
-        ("start_B1", 0, 0),
-        ("start_A1", 1, 2),
-        ("start_B2", 2, 2),
-        ("start_A2", 3, 4),
-        ("start_B3", 4, 4),
-        ("start_A3", 5, 4),
-        ("start_B4", 6, 6),
+        ("Blank_01", 0, 0),
+        ("Aperture_01", 1, 2),
+        ("Blank_02", 2, 2),
+        ("Aperture_02", 3, 4),
+        ("Blank_03", 4, 4),
+        ("Aperture_03", 5, 4),
+        ("Blank_04", 6, 6),
     ])
-    def test_GIVEN_motor_on_an_aperture_position_WHEN_motor_set_to_closest_beamstop_THEN_motor_moves_to_closest_beamstop(self, _, start_pos, closest_stop):
+    def test_GIVEN_motor_on_an_aperture_position_WHEN_motor_set_to_closest_beamstop_THEN_motor_moves_to_closest_beamstop(self, start_position, start_index, closest_stop):
         # GIVEN
-        self.ca.set_pv_value(POSITION_SP, start_pos)
-        self.ca.assert_that_pv_is_number(POSITION_INDEX, start_pos, tolerance=TOLERANCE)
+        self.ca.set_pv_value(POSITION_SP, start_index)
+        self.ca.assert_that_pv_is_number(POSITION_INDEX, start_index, tolerance=TOLERANCE)
+        self.ca.assert_that_pv_is_number(MOTOR, MOTION_SETPOINTS[start_position], tolerance=TOLERANCE)
 
         # WHEN
         self.ca.process_pv(CLOSEAPERTURE)

--- a/tests/loq_aperture.py
+++ b/tests/loq_aperture.py
@@ -37,6 +37,10 @@ MOTOR = "MOT:MTR0101"
 #TWEAK_X = "ARM:X:TWEAK"
 #TWEAK_Y = "ARM:Y:TWEAK"
 
+## Axis position index PV and SP
+POSITION_INDEX = "LKUP:APERTURE:IPOSN"
+POSITION_SP = "LKUP:APERTURE:IPOSN:SP"
+
 ## PV reading closest beamstop position
 CLOSESTSHUTTER = "APERTURE:CLOSESTSHUTTER"
 
@@ -53,8 +57,8 @@ IOCS = [
             "GALILADDR": GALIL_ADDR,
             "IFLOQAPERTURE": " ",
             "MTRCTRL": "1",
-            "GALILCONFIGDIR": test_path,
-            "ICPCONFIGROOT": test_path,
+            "GALILCONFIGDIR": test_path.replace("\\", "/"),
+            "ICPCONFIGROOT": test_path.replace("\\", "/"),
         },
     },
 ]
@@ -87,16 +91,15 @@ class LoqApertureTests(unittest.TestCase):
     ])
     def test_GIVEN_motor_on_an_aperture_position_WHEN_motor_set_to_closest_beamstop_THEN_motor_moves_to_closest_beamstop(self, _, start_pos, closest_stop):
         # GIVEN
-        self.ca.set_pv_value(MOTOR, start_pos)
-        self.ca.assert_that_pv_is_number(MOTOR, start_pos, TOLERANCE)
-        self.ca.assert_that_pv_is_number(MOTOR, start_pos, tolerance=TOLERANCE)
+        self.ca.set_pv_value(POSITION_SP, start_pos)
+        self.ca.assert_that_pv_is_number(POSITION_INDEX, start_pos, tolerance=TOLERANCE)
 
         # WHEN
         self.ca.process_pv(CLOSEAPERTURE)
 
         # THEN
         self.ca.assert_that_pv_is_number(CLOSESTSHUTTER, closest_stop)
-        self.ca.assert_that_pv_is_number(MOTOR, closest_stop, timeout=5)
+        self.ca.assert_that_pv_is_number(POSITION_INDEX, closest_stop, timeout=5)
 
 #    @parameterized.expand([
 #        ("start_B1", 0, 0),

--- a/tests/loq_aperture.py
+++ b/tests/loq_aperture.py
@@ -36,7 +36,8 @@ MOTION_SETPOINT = OrderedDict([("Aperture_large",  02.900000),
                                ("Stop_02",         40.400000),
                                ("Aperture_small",  52.900000)])
 
-test_path = os.path.realpath(os.path.join(os.getenv("EPICS_KIT_ROOT"), "support", "motorExtensions", "master", "settings", "loqAperture"))
+test_path = os.path.realpath(os.path.join(os.getenv("EPICS_KIT_ROOT"),
+                                          "support", "motorExtensions", "master", "settings", "loqAperture"))
 
 IOCS = [
     {

--- a/tests/oscillating_collimator.py
+++ b/tests/oscillating_collimator.py
@@ -3,6 +3,8 @@ import unittest
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import IOCRegister, get_default_ioc_dir
 
+import os
+
 # IP address of device
 from utils.test_modes import TestModes
 
@@ -18,6 +20,7 @@ VELOCITY = "VEL:SP"
 DISTANCE = "DIST:SP"
 DISCRIMINANT = "VEL:SP:DISC:CHECK"
 
+test_path = os.path.realpath(os.path.join(os.getenv("EPICS_KIT_ROOT"), "support", "motorExtensions", "master", "settings", "oscillatingCollimator"))
 
 IOCS = [
     {
@@ -26,7 +29,8 @@ IOCS = [
         "macros": {
             "GALILADDR": GALIL_ADDR,
             "MTRCTRL": "01",
-            "IFOSCCOL": " ",
+            "GALILCONFIGDIR": test_path.replace("\\", "/"),
+            "ICPCONFIGROOT": test_path.replace("\\", "/"),
         },
     },
 ]

--- a/tests/oscillating_collimator.py
+++ b/tests/oscillating_collimator.py
@@ -30,7 +30,6 @@ IOCS = [
             "GALILADDR": GALIL_ADDR,
             "MTRCTRL": "01",
             "GALILCONFIGDIR": test_path.replace("\\", "/"),
-            "ICPCONFIGROOT": test_path.replace("\\", "/"),
         },
     },
 ]

--- a/tests/oscillating_collimator.py
+++ b/tests/oscillating_collimator.py
@@ -20,7 +20,8 @@ VELOCITY = "VEL:SP"
 DISTANCE = "DIST:SP"
 DISCRIMINANT = "VEL:SP:DISC:CHECK"
 
-test_path = os.path.realpath(os.path.join(os.getenv("EPICS_KIT_ROOT"), "support", "motorExtensions", "master", "settings", "oscillatingCollimator"))
+test_path = os.path.realpath(os.path.join(os.getenv("EPICS_KIT_ROOT"),
+                                          "support", "motorExtensions", "master", "settings", "oscillatingCollimator"))
 
 IOCS = [
     {

--- a/tests/vertical_jaws.py
+++ b/tests/vertical_jaws.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import IOCRegister, get_default_ioc_dir
@@ -23,12 +24,15 @@ all_motors = [MOTOR_N, MOTOR_S,
 
 TEST_POSITIONS = [-5, 0, 10, 10e-1]
 
+test_path = os.path.realpath(os.path.join(os.getenv("EPICS_KIT_ROOT"), "support", "jaws", "master", "settings"))
+
 IOCS = [
     {
         "name": DEVICE_PREFIX,
         "directory": get_default_ioc_dir("GALIL"),
         "macros": {
             "MTRCTRL": "01",
+            "GALILCONFIGDIR": test_path.replace("\\", "/"),
         },
     },
 ]

--- a/tests/vertical_jaws.py
+++ b/tests/vertical_jaws.py
@@ -24,6 +24,7 @@ all_motors = [MOTOR_N, MOTOR_S,
 
 TEST_POSITIONS = [-5, 0, 10, 10e-1]
 
+# Tests will fail if JAWS support module is not up to date and built
 test_path = os.path.realpath(os.path.join(os.getenv("EPICS_KIT_ROOT"), "support", "jaws", "master", "settings"))
 
 IOCS = [

--- a/tests/xyarmbeamstop.py
+++ b/tests/xyarmbeamstop.py
@@ -55,7 +55,8 @@ STORE_SP = "ARM:STORE:SP"
 TWEAK_X = "ARM:X:TWEAK"
 TWEAK_Y = "ARM:Y:TWEAK"
 
-test_path = os.path.realpath(os.path.join(os.getenv("EPICS_KIT_ROOT"), "support", "motorExtensions", "master", "settings", "xyBeamstop"))
+test_path = os.path.realpath(os.path.join(os.getenv("EPICS_KIT_ROOT"),
+                                          "support", "motorExtensions", "master", "settings", "xyBeamstop"))
 
 IOCS = [
     {

--- a/tests/xyarmbeamstop.py
+++ b/tests/xyarmbeamstop.py
@@ -1,6 +1,7 @@
 import unittest
 import math
 from unittest import skip
+import os
 
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import IOCRegister, get_default_ioc_dir
@@ -54,6 +55,7 @@ STORE_SP = "ARM:STORE:SP"
 TWEAK_X = "ARM:X:TWEAK"
 TWEAK_Y = "ARM:Y:TWEAK"
 
+test_path = os.path.realpath(os.path.join(os.getenv("EPICS_KIT_ROOT"), "support", "motorExtensions", "master", "settings", "xyBeamstop"))
 
 IOCS = [
     {
@@ -61,14 +63,16 @@ IOCS = [
         "directory": get_default_ioc_dir("GALIL"),
         "macros": {
             "GALILADDR": GALIL_ADDR,
-            "IFXYBEAMSTOP": " ",
             "MTRCTRL": "1",
+            "IFXYBEAMSTOP": " ",
+            "GALILCONFIGDIR": test_path.replace("\\", "/"),
         },
     },
 ]
 
 
 TEST_MODES = [TestModes.DEVSIM]
+
 
 @skip("This test is very unstable. It should work; it has been disabled so that we can see other failures on Jenkins")
 class XyarmbeamstopTests(unittest.TestCase):


### PR DESCRIPTION
### Description

Adds IOC tests for the LOQ aperture.

Also modifies existing GALIL motor extensions to simplify the boot process. All relevant files are now held in GALILCONFIGDIR, which must be set by a macro at the start of the IOC tests.

### To test
https://github.com/ISISComputingGroup/IBEX/issues/3623
