### PR TITLE
Ticket2133 local calib dir

### DIFF
--- a/common_tests/danfysik.py
+++ b/common_tests/danfysik.py
@@ -28,6 +28,8 @@ class DanfysikBase(object):
         self._lewis.backdoor_run_function_on_device("reset")
         self._lewis.backdoor_set_on_device("comms_initialized", True)
 
+
+class DanfysikCommon(DanfysikBase):
     def test_WHEN_polarity_setpoint_is_set_THEN_readback_updates_with_set_value(self):
         for pol in POLARITIES:
             self.ca.assert_setting_setpoint_sets_readback(pol, "POL")

--- a/tests/danfysik8000.py
+++ b/tests/danfysik8000.py
@@ -3,7 +3,7 @@ import unittest
 from utils.test_modes import TestModes
 from utils.ioc_launcher import get_default_ioc_dir
 
-from common_tests.danfysik import DanfysikBase, DEVICE_PREFIX, EMULATOR_NAME
+from common_tests.danfysik import DanfysikCommon, DEVICE_PREFIX, EMULATOR_NAME
 from utils.testing import skip_if_recsim
 
 IOCS = [
@@ -43,7 +43,7 @@ INTERLOCKS = {
 }
 
 
-class Danfysik8000Tests(DanfysikBase, unittest.TestCase):
+class Danfysik8000Tests(DanfysikCommon, unittest.TestCase):
     """
     Tests for danfysik model 8000. Tests inherited from DanfysikBase.
     """

--- a/tests/danfysik8800.py
+++ b/tests/danfysik8800.py
@@ -3,7 +3,7 @@ import unittest
 from utils.test_modes import TestModes
 from utils.ioc_launcher import get_default_ioc_dir
 
-from common_tests.danfysik import DanfysikBase, DEVICE_PREFIX, EMULATOR_NAME
+from common_tests.danfysik import DanfysikCommon, DEVICE_PREFIX, EMULATOR_NAME
 from utils.testing import skip_if_recsim
 
 IOCS = [
@@ -47,7 +47,7 @@ INTERLOCKS = {
 }
 
 
-class Danfysik8800Tests(DanfysikBase, unittest.TestCase):
+class Danfysik8800Tests(DanfysikCommon, unittest.TestCase):
     """
     Tests for danfysik model 8800. Tests inherited from DanfysikBase.
     """

--- a/tests/danfysik_common_calib.py
+++ b/tests/danfysik_common_calib.py
@@ -1,0 +1,30 @@
+import unittest
+
+from utils.test_modes import TestModes
+from utils.ioc_launcher import get_default_ioc_dir
+
+from common_tests.danfysik import DanfysikBase, DEVICE_PREFIX, EMULATOR_NAME
+
+IOCS = [
+    {
+        "name": DEVICE_PREFIX,
+        "directory": get_default_ioc_dir("DFKPS"),
+        "macros": {
+            "CALIBRATED": "1",
+            "LOCAL_CALIB": "no"
+        },
+        "emulator": EMULATOR_NAME,
+        "emulator_protocol": "model8000",
+    },
+]
+
+TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
+
+class DanfysikCommonCalibTests(DanfysikBase, unittest.TestCase):
+    """
+    Tests for danfysik model 8000. Tests inherited from DanfysikBase.
+    """
+    def test_GIVEN_local_calib_macro_set_to_no_THEN_calib_base_dir_is_common_dir(self):
+        for pv in ["FIELD:CALIB", "FIELD:SP:CALIB"]:
+            self.ca.assert_that_pv_is("{}.TDIR".format(pv), r"magnets")
+            self.ca.assert_that_pv_is("{}.BDIR".format(pv), r"C:/Instrument/Settings/config/common")

--- a/tests/danfysik_local_calib.py
+++ b/tests/danfysik_local_calib.py
@@ -1,0 +1,34 @@
+import unittest
+
+from utils.test_modes import TestModes
+from utils.ioc_launcher import get_default_ioc_dir
+
+from common_tests.danfysik import DanfysikBase, DEVICE_PREFIX, EMULATOR_NAME
+from genie_python import genie as g
+
+
+IOCS = [
+    {
+        "name": DEVICE_PREFIX,
+        "directory": get_default_ioc_dir("DFKPS"),
+        "macros": {
+            "CALIBRATED": "1",
+            "LOCAL_CALIB": "yes"
+        },
+        "emulator": EMULATOR_NAME,
+        "emulator_protocol": "model8000",
+    },
+]
+TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
+
+
+class DanfysikLocalCalibTests(DanfysikBase, unittest.TestCase):
+    """
+    Tests for danfysik model 8000. Tests inherited from DanfysikBase.
+    """
+    def test_GIVEN_local_calib_macro_set_to_no_THEN_calib_base_dir_is_common_dir(self):
+        g.set_instrument(None)
+        inst = g.get_instrument()
+        for pv in ["FIELD:CALIB", "FIELD:SP:CALIB"]:
+            self.ca.assert_that_pv_is("{}.TDIR".format(pv), r"calib/magnets")
+            self.ca.assert_that_pv_is("{}.BDIR".format(pv), r"C:/Instrument/Settings/config/{}".format(inst))


### PR DESCRIPTION
Ticket: https://github.com/ISISComputingGroup/IBEX/issues/2133

Tests for setting `LOCAL_CALIB` macro on the Danfysik OPI which tells the IOC to look for calibration files in the local instrument config directory instead of the common one.

Did not add tests for the same change in the Eurotherm as that IOC sets a completely different path in DEVSIM anyway.