### PR TITLE
Ticket3262 add ioc knr1050

### DIFF
--- a/tests/knr1050.py
+++ b/tests/knr1050.py
@@ -19,7 +19,7 @@ IOCS = [
 ]
 
 
-TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
+TEST_MODES = [TestModes.DEVSIM, TestModes.RECSIM]
 
 
 class Knr1050Tests(unittest.TestCase):
@@ -31,14 +31,20 @@ class Knr1050Tests(unittest.TestCase):
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
         self._lewis.backdoor_run_function_on_device("reset")
         # Set the device in remote mode ready to receive instructions
-        self.ca.set_pv_value("TOGGLE:REMOTE:SP", 1)
+        self.ca.set_pv_value("REMOTE_MODE:SP", "Remote")
+        self.ca.set_pv_value("GET_REMOTE_MODE.PROC", 1)
         # Set the flow and concentrations to a default state that enable pump switch on
+        self.ca.set_pv_value("PUMP:STOP:SP", "Stop")
+        self.ca.set_pv_value("DEV_STATE", "SYS_ST_IDLE")
         self.ca.set_pv_value("FLOW:SP", 0.01)
-        self.ca.set_pv_value("PRESS:HIGH:SP", 1000)
+        self.ca.set_pv_value("PRESS:LOW:SP", 0)
+        self.ca.set_pv_value("PRESS:HIGH:SP", 100)
         self.ca.set_pv_value("CON:A:SP", 100)
         self.ca.set_pv_value("CON:B:SP", 0)
         self.ca.set_pv_value("CON:C:SP", 0)
         self.ca.set_pv_value("CON:D:SP", 0)
+        self.ca.set_pv_value("GET_STATUS.PROC", 1)
+        self.ca.set_pv_value("DISABLE:CHECK.PROC", 1)
 
 
     def _set_pressure_limit_low(self, limit):
@@ -48,11 +54,46 @@ class Knr1050Tests(unittest.TestCase):
         self._lewis.backdoor_set_on_device("pressure_limit_high", limit)
 
     @skip_if_recsim("Recsim simulation not implemented")
-    def test_GIVEN_an_ioc_WHEN_stop_pump_sent_THEN_pump_stops(self):
-        expected_pump_status = "False"
-        self.ca.set_pv_value("TOGGLE:PUMP:SP", 0)
+    def test_GIVEN_an_ioc_WHEN_start_pump_sent_THEN_pump_starts(self):
+        self.ca.set_pv_value("PUMP:START:SP", "Start")
 
+        self.ca.assert_that_pv_is("DEV_STATE", "SYS_ST_RUN")
+
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_an_ioc_WHEN_stop_pump_sent_via_ioc_THEN_device_state_idle(self):
+        expected_dev_state = "SYS_ST_OFF"
+        self.ca.set_pv_value("PUMP:STOP:SP", "Stop")
+
+        self.ca.assert_that_pv_is("DEV_STATE", expected_dev_state)
+
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_an_ioc_WHEN_pump_is_turned_on_via_ioc_THEN_pump_is_on(self):
+        self.ca.set_pv_value("PUMP:START:SP", "Start")
         pump_status = self._lewis.backdoor_get_from_device("pump_on")
+
+        self.assertEqual(pump_status, "True")
+
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_set_concentration_via_ioc_WHEN_ramp_command_sent_via_ioc_THEN_correct_concentration_set(self):
+        expected_concentrations = [0, 50, 35, 15]
+        self.ca.set_pv_value("CON:A:SP", expected_concentrations[0])
+        self.ca.set_pv_value("CON:B:SP", expected_concentrations[1])
+        self.ca.set_pv_value("CON:C:SP", expected_concentrations[2])
+        self.ca.set_pv_value("CON:D:SP", expected_concentrations[3])
+        self.ca.set_pv_value("PUMP:START:SP", 1)
+
+        concentrations = [self.ca.get_pv_value("CON:A"),
+                          self.ca.get_pv_value("CON:B"),
+                          self.ca.get_pv_value("CON:C"),
+                          self.ca.get_pv_value("CON:D")]
+        self.assertEqual(expected_concentrations, concentrations)
+
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_an_ioc_WHEN_stop_pump_sent_THEN_lewis_pump_stops(self):
+        expected_pump_status = "False"
+        self.ca.set_pv_value("PUMP:STOP:SP", "Stop")
+        pump_status = self._lewis.backdoor_get_from_device("pump_on")
+
         self.assertEqual(pump_status, expected_pump_status)
 
     @skip_if_recsim("Recsim simulation not implemented")
@@ -64,6 +105,15 @@ class Knr1050Tests(unittest.TestCase):
 
         stopped_status = self._lewis.backdoor_get_from_device("keep_last_values")
         self.assertEqual(stopped_status, "True")
+
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_an_ioc_WHEN_pump_switched_on_then_back_to_off_THEN_device_state_off(self):
+        expected_dev_state = "SYS_ST_OFF"
+        self.ca.set_pv_value("PUMP:START:SP", "Start")
+        self.ca.set_pv_value("PUMP:STOP:SP", "Stop")
+        state = self._lewis.backdoor_get_from_device("state")
+
+        self.assertEqual(expected_dev_state, state)
 
     @skip_if_recsim("Recsim simulation not implemented")
     def test_GIVEN_set_low_pressure_limit_via_backdoor_WHEN_get_low_pressure_limits_via_IOC_THEN_get_expected_pressure_limit(self):
@@ -82,16 +132,18 @@ class Knr1050Tests(unittest.TestCase):
         self.ca.assert_that_pv_is("PRESS:HIGH", expected_pressure)
 
     @skip_if_recsim("Recsim simulation not implemented")
-    def test_GIVEN_set_low_pressure_limit_via_ioc_WHEN_get_low_pressure_limit_via_backdoor_THEN_get_expected_pressure_limit(self):
+    def test_GIVEN_set_low_pressure_limit_via_ioc_WHEN_get_low_pressure_limit_THEN_get_expected_pressure_limit(self):
         expected_pressure = 10
         self.ca.set_pv_value("PRESS:LOW:SP", expected_pressure)
-
-        self.assertEqual(int(self._lewis.backdoor_get_from_device("pressure_limit_low")), expected_pressure)
+        self.ca.set_pv_value("GET_PRESS:LIM.PROC", 1)
+        self.ca.assert_that_pv_is("PRESS:LOW", expected_pressure)
 
     @skip_if_recsim("Recsim simulation not implemented")
     def test_GIVEN_set_high_pressure_limit_via_ioc_WHEN_get_high_pressure_limit_via_backdoor_THEN_get_expected_pressure_limit(self):
         expected_pressure = 200
         self.ca.set_pv_value("PRESS:HIGH:SP", expected_pressure)
+        self.ca.set_pv_value("GET_PRESS:LIM.PROC", 1)
+        self.ca.assert_that_pv_is("PRESS:HIGH", expected_pressure)
 
         self.assertEqual(int(self._lewis.backdoor_get_from_device("pressure_limit_high")), expected_pressure)
 
@@ -99,7 +151,7 @@ class Knr1050Tests(unittest.TestCase):
     def test_GIVEN_set_low_pressure_limit_via_ioc_WHEN_get_low_pressure_limit_via_IOC_THEN_get_expected_value(self):
         expected_pressure = 45
         self.ca.set_pv_value("PRESS:LOW:SP", expected_pressure)
-
+        self.ca.set_pv_value("GET_PRESS:LIM.PROC", 1)
         self.ca.assert_that_pv_is("PRESS:LOW", expected_pressure)
 
     @skip_if_recsim("Recsim simulation not implemented")
@@ -107,26 +159,16 @@ class Knr1050Tests(unittest.TestCase):
         expected_pressure = 500
 
         self.ca.set_pv_value("PRESS:HIGH:SP", expected_pressure)
-
+        self.ca.set_pv_value("GET_PRESS:LIM.PROC", 1)
         self.ca.assert_that_pv_is("PRESS:HIGH", expected_pressure)
-
-    @skip_if_recsim("Recsim simulation not implemented")
-    def test_GIVEN_an_ioc_WHEN_ramp_command_sent_via_ioc_THEN_ramp_starts(self):
-        ramp_status = self._lewis.backdoor_get_from_device("ramp")
-        self.assertEqual(ramp_status, "False")
-
-        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
-
-        ramp_status = self._lewis.backdoor_get_from_device("ramp")
-        self.assertEqual(ramp_status, "True")
 
     @skip_if_recsim("Recsim simulation not implemented")
     def test_GIVEN_set_flow_limit_min_via_ioc_WHEN_ramp_command_sent_via_IOC_THEN_correct_flow_limit_set(self):
         expected_flow = 0.01
         self.ca.set_pv_value("FLOW:SP", expected_flow)
-        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
+        self.ca.set_pv_value("PUMP:START:SP", "Start")
 
-        self.assertEqual(self.ca.get_pv_value("FLOW"), expected_flow)
+        self.ca.assert_that_pv_is("FLOW", expected_flow)
 
     @skip_if_recsim("Recsim simulation not implemented")
     def test_GIVEN_set_flow_limit_min_via_ioc_WHEN_get_flow_via_IOC_THEN_correct_flow_limit(self):
@@ -136,112 +178,34 @@ class Knr1050Tests(unittest.TestCase):
         self.assertEqual(self.ca.get_pv_value("FLOW"), expected_flow)
 
     @skip_if_recsim("Recsim simulation not implemented")
-    def test_GIVEN_toggle_pump_via_ioc_WHEN_toggle_off_THEN_pump_off(self):
-        self.ca.set_pv_value("TOGGLE:PUMP:SP", 0)
-        pump_state = self._lewis.backdoor_get_from_device("pump_on")
-
-        self.assertEqual(pump_state, "False")
-
-    @skip_if_recsim("Recsim simulation not implemented")
-    def test_GIVEN_toggle_pump_via_ioc_WHEN_toggle_off_THEN_ramp_off(self):
-        self.ca.set_pv_value("TOGGLE:PUMP:SP", 0)
-        ramp_state = self._lewis.backdoor_get_from_device("ramp")
-
-        self.assertEqual(ramp_state, "False")
-
-    @skip_if_recsim("Recsim simulation not implemented")
-    def test_GIVEN_toggle_pump_via_ioc_WHEN_toggle_on_THEN_pump_on(self):
-        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
-        ramp_state = self._lewis.backdoor_get_from_device("pump_on")
-
-        self.assertEqual(ramp_state, "True")
-
-    @skip_if_recsim("Recsim simulation not implemented")
-    def test_GIVEN_set_concentration_via_ioc_WHEN_ramp_command_sent_via_ioc_THEN_correct_concentration_set(self):
-        expected_concentrations = [0, 50, 35, 15]
-        self.ca.set_pv_value("CON:A:SP", expected_concentrations[0])
-        self.ca.set_pv_value("CON:B:SP", expected_concentrations[1])
-        self.ca.set_pv_value("CON:C:SP", expected_concentrations[2])
-        self.ca.set_pv_value("CON:D:SP", expected_concentrations[3])
-        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
-
-        concentrations = [self.ca.get_pv_value("CON:A"),
-                          self.ca.get_pv_value("CON:B"),
-                          self.ca.get_pv_value("CON:C"),
-                          self.ca.get_pv_value("CON:D")]
-        self.assertEqual(expected_concentrations, concentrations)
-
-    @skip_if_recsim("Recsim simulation not implemented")
-    def test_GIVEN_toggle_pump_via_ioc_WHEN_toggle_on_THEN_pump_on(self):
-        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
-        pump_state = self._lewis.backdoor_get_from_device("pump_on")
-
-        self.assertEqual(pump_state, "True")
-
-    @skip_if_recsim("Recsim simulation not implemented")
-    def test_GIVEN_toggle_pump_via_ioc_WHEN_toggle_off_THEN_device_state_idle(self):
-        expected_dev_state = "SYS_ST_OFF"
-        self.ca.set_pv_value("TOGGLE:PUMP:SP", 0)
-        state = self._lewis.backdoor_get_from_device("state")
-
-        self.assertEqual(expected_dev_state, state)
-
-    @skip_if_recsim("Recsim simulation not implemented")
-    def test_GIVEN_toggle_pump_via_ioc_WHEN_toggle_on_THEN_device_state_run(self):
-        expected_dev_state = "SYS_ST_RUN"
-        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
-        state = self._lewis.backdoor_get_from_device("state")
-
-        self.assertEqual(expected_dev_state, state)
-
-    @skip_if_recsim("Recsim simulation not implemented")
-    def test_GIVEN_toggle_pump_via_ioc_WHEN_toggle_on_then_off_THEN_device_state_off(self):
-        expected_dev_state = "SYS_ST_OFF"
-        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
-        self.ca.set_pv_value("TOGGLE:PUMP:SP", 0)
-        state = self._lewis.backdoor_get_from_device("state")
-
-        self.assertEqual(expected_dev_state, state)
-
-    @skip_if_recsim("Recsim simulation not implemented")
-    def test_GIVEN_ioc_turned_on_WHEN_get_status_THEN_off_status_returned(self):
-        expected_dev_state_num = "1"
-        state_num = self._lewis.backdoor_get_from_device("state_num")
-
-        self.assertEqual(expected_dev_state_num, state_num)
-
-    @skip_if_recsim("Recsim simulation not implemented")
-    def test_GIVEN_ioc_turned_on_WHEN_get_status_THEN_run_status_returned(self):
-        expected_dev_state_num = "3"
-        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
-        state_num = self._lewis.backdoor_get_from_device("state_num")
-
-        self.assertEqual(expected_dev_state_num, state_num)
-
-    @skip_if_recsim("Recsim simulation not implemented")
-    def test_GIVEN_ioc_turned_on_WHEN_get_inst_state_via_ioc_THEN_off_state_returned(self):
+    def test_GIVEN_ioc_turned_on_WHEN_get_dev_state_via_ioc_THEN_off_state_returned(self):
         expected_dev_state = 'SYS_ST_OFF'
-        state = self.ca.get_pv_value("INST_STATE")
+        state = self.ca.get_pv_value("DEV_STATE")
 
         self.assertEqual(expected_dev_state, state)
 
     @skip_if_recsim("Recsim simulation not implemented")
     def test_GIVEN_ioc_turned_on_WHEN_set_local_mode_via_IOC_THEN_disabled_mode(self):
         expected_mode = 'Disabled'
-        self.ca.set_pv_value("TOGGLE:REMOTE:SP", 0)
+        self.ca.set_pv_value("LOCAL_MODE:SP", "Local")
 
         self.ca.assert_that_pv_is("DISABLE", expected_mode)
 
     @skip_if_recsim("Recsim simulation not implemented")
     def test_GIVEN_local_mode_WHEN_set_pump_on_via_IOC_THEN_pump_disabled(self):
-        self.ca.set_pv_value("TOGGLE:REMOTE:SP", 0)
-        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
+        self.ca.set_pv_value("LOCAL_MODE:SP", "Local")
+        self.ca.set_pv_value("PUMP:START:SP", "Start")
 
-        self.ca.assert_that_pv_is("INST_STATE", 'SYS_ST_OFF')
+        self.ca.assert_that_pv_is("DEV_STATE", 'SYS_ST_OFF')
 
     @skip_if_recsim("Recsim simulation not implemented")
     def test_GIVEN_incorrect_gradients_WHEN_set_pump_on_via_IOC_THEN_pump_disabled(self):
         self.ca.set_pv_value("CON:A:SP", 50)  # sum of gradients =/= 100%
-        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
+        self.ca.set_pv_value("PUMP:START:SP", "Start")
 
-        self.ca.assert_that_pv_is("INST_STATE", 'SYS_ST_OFF')
+        self.ca.assert_that_pv_is("DEV_STATE", 'SYS_ST_OFF')
+
+    @skip_if_recsim("Can not test disconnection in rec sim")
+    def test_GIVEN_device_not_connected_WHEN_get_status_THEN_alarm(self):
+        self._lewis.backdoor_set_on_device('connected', False)
+        self.ca.assert_that_pv_alarm_is('GET_REMOTE_MODE', ChannelAccess.Alarms.INVALID)

--- a/tests/knr1050.py
+++ b/tests/knr1050.py
@@ -5,6 +5,7 @@ from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
 from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
 
+from parameterized import parameterized
 
 DEVICE_PREFIX = "KNR1050_01"
 
@@ -30,13 +31,105 @@ class Knr1050Tests(unittest.TestCase):
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc(device_name, DEVICE_PREFIX)
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
-        #self._lewis.backdoor_run_function_on_device("reset")
+
+    def _set_pressure_limit_low(self, limit):
+        self._lewis.backdoor_set_on_device("pressure_limit_low", limit)
+
+    def _set_pressure_limit_high(self, limit):
+        self._lewis.backdoor_set_on_device("pressure_limit_high", limit)
 
     @skip_if_recsim("In rec sim this test fails")
-    def test_GIVEN_an_IOC_WHEN_stop_issued_THEN_device_stops(self):
+    def test_GIVEN_an_ioc_WHEN_stop_issued_THEN_device_stops(self):
         stopped_status = self._lewis.backdoor_get_from_device("is_stopped")
         self.assertEqual(stopped_status, "False")
         self.ca.set_pv_value("STOP:SP", 1)
 
         stopped_status = self._lewis.backdoor_get_from_device("is_stopped")
         self.assertEqual(stopped_status, "True")
+
+    @skip_if_recsim("Relies on the backdoor")
+    def test_GIVEN_an_ioc_WHEN_stop2_command_sent_THEN_expected_stop_type(self):
+        self._lewis.backdoor_set_on_device("keep_last_values", "False")
+        stopped_status = self._lewis.backdoor_get_from_device("keep_last_values")
+        self.assertEqual(stopped_status, "False")
+        self.ca.set_pv_value("_STOP:KLV:SP", 1)
+
+        stopped_status = self._lewis.backdoor_get_from_device("keep_last_values")
+        self.assertEqual(stopped_status, "True")
+
+    @skip_if_recsim("Relies on the backdoor")
+    def test_GIVEN_set_low_pressure_limit_via_backdoor_WHEN_get_low_pressure_limits_via_IOC_THEN_get_expected_pressure_limit(self):
+        expected_pressure = 10.0
+        self._set_pressure_limit_low(expected_pressure)
+        self.ca.set_pv_value("GET_PRESS:LIM.PROC", 1)
+
+        self.ca.assert_that_pv_is("PRESS:LOW", expected_pressure)
+
+    @skip_if_recsim("Relies on the backdoor")
+    def test_GIVEN_set_high_pressure_limit_via_backdoor_WHEN_get_high_pressure_limits_via_IOC_THEN_get_expected_pressure_limit(self):
+        expected_pressure = 100.0
+        self._set_pressure_limit_high(expected_pressure)
+        self.ca.set_pv_value("GET_PRESS:LIM.PROC", 1)
+
+        self.ca.assert_that_pv_is("PRESS:HIGH", expected_pressure)
+
+    @skip_if_recsim("Relies on the backdoor")
+    def test_GIVEN_set_low_pressure_limit_via_ioc_WHEN_get_low_pressure_limit_via_backdoor_THEN_get_expected_pressure_limit(self):
+        expected_pressure = 10.0
+        self.ca.set_pv_value("PRESS:LOW:SP", expected_pressure)
+
+        self.assertEqual(float(self._lewis.backdoor_get_from_device("pressure_limit_low")), expected_pressure)
+
+    @skip_if_recsim("Relies on the backdoor")
+    def test_GIVEN_set_high_pressure_limit_via_ioc_WHEN_get_high_pressure_limit_via_backdoor_THEN_get_expected_pressure_limit(self):
+        expected_pressure = 200.0
+        self.ca.set_pv_value("PRESS:HIGH:SP", expected_pressure)
+
+        self.assertEqual(float(self._lewis.backdoor_get_from_device("pressure_limit_high")), expected_pressure)
+
+    def test_GIVEN_set_low_pressure_limit_via_ioc_WHEN_get_low_pressure_limit_via_IOC_THEN_get_expected_value(self):
+        expected_pressure = 45.55
+        self.ca.set_pv_value("PRESS:LOW:SP", expected_pressure)
+
+        self.ca.assert_that_pv_is("PRESS:LOW", expected_pressure)
+
+    def test_GIVEN_set_high_pressure_limit_via_ioc_WHEN_get_high_pressure_limit_via_IOC_THEN_get_expected_value(self):
+        expected_pressure = 1345.55
+        self.ca.set_pv_value("PRESS:HIGH:SP", expected_pressure)
+
+        self.ca.assert_that_pv_is("PRESS:HIGH", expected_pressure)
+
+    @skip_if_recsim("Relies on the backdoor")
+    def test_GIVEN_an_ioc_WHEN_ramp_command_sent_via_ioc_THEN_ramp_starts(self):
+        ramp_status = self._lewis.backdoor_get_from_device("ramp_status")
+        self.assertEqual(ramp_status, "False")
+        self.ca.set_pv_value("RAMP:SP", 1)
+
+        ramp_status = self._lewis.backdoor_get_from_device("ramp_status")
+        self.assertEqual(ramp_status, "True")
+
+    @skip_if_recsim('Relies on the backdoor')
+    def test_GIVEN_set_flow_limit_min_via_ioc_WHEN_ramp_command_sent_via_IOC_THEN_correct_flow_limit_set(self):
+        expected_flow = 1423.10
+        self.ca.set_pv_value("FLOWRATE:SP", expected_flow)
+        self.ca.set_pv_value("RAMP:SP", 1)
+
+        self.assertEqual(float(self._lewis.backdoor_get_from_device("flow_rate")), expected_flow)
+
+
+    @parameterized.expand([('A', 45),
+                           ('B', 34),
+                           ('C', 56),
+                           ('D', 76)])
+    @skip_if_recsim('Relies on the backdoor')
+    def test_GIVEN_set_concentration_A_via_ioc_WHEN_ramp_command_sent_via_ioc_THEN_correct_concentration_set(self, name, concentration):
+        self.ca.set_pv_value("CON:{}:SP".format(name), concentration)
+        self.ca.set_pv_value("RAMP:SP", 1)
+
+        self.assertEqual(float(self._lewis.backdoor_get_from_device("concentration_{}".format(name))), concentration)
+    @skip_if_recsim('Relies on the backdoor')
+    def test_GIVEN_an_ioc_WHEN_get_status_THEN_device_has_valid_instrument_state_returned(self):
+        self.ca.set_pv_value("GET_STATUS", 1)
+
+        state = self._lewis.backdoor_get_from_device("current_instrument_state")
+        pass

--- a/tests/knr1050.py
+++ b/tests/knr1050.py
@@ -5,8 +5,6 @@ from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
 from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
 
-from parameterized import parameterized
-
 DEVICE_PREFIX = "KNR1050_01"
 
 device_name = "knr1050"
@@ -31,6 +29,17 @@ class Knr1050Tests(unittest.TestCase):
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc(device_name, DEVICE_PREFIX)
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
+        self._lewis.backdoor_run_function_on_device("reset")
+        # Set the device in remote mode ready to receive instructions
+        self.ca.set_pv_value("TOGGLE:REMOTE:SP", 1)
+        # Set the flow and concentrations to a default state that enable pump switch on
+        self.ca.set_pv_value("FLOW:SP", 0.01)
+        self.ca.set_pv_value("PRESS:HIGH:SP", 1000)
+        self.ca.set_pv_value("CON:A:SP", 100)
+        self.ca.set_pv_value("CON:B:SP", 0)
+        self.ca.set_pv_value("CON:C:SP", 0)
+        self.ca.set_pv_value("CON:D:SP", 0)
+
 
     def _set_pressure_limit_low(self, limit):
         self._lewis.backdoor_set_on_device("pressure_limit_low", limit)
@@ -38,16 +47,15 @@ class Knr1050Tests(unittest.TestCase):
     def _set_pressure_limit_high(self, limit):
         self._lewis.backdoor_set_on_device("pressure_limit_high", limit)
 
-    @skip_if_recsim("In rec sim this test fails")
-    def test_GIVEN_an_ioc_WHEN_stop_issued_THEN_device_stops(self):
-        stopped_status = self._lewis.backdoor_get_from_device("is_stopped")
-        self.assertEqual(stopped_status, "False")
-        self.ca.set_pv_value("STOP:SP", 1)
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_an_ioc_WHEN_stop_pump_sent_THEN_pump_stops(self):
+        expected_pump_status = "False"
+        self.ca.set_pv_value("TOGGLE:PUMP:SP", 0)
 
-        stopped_status = self._lewis.backdoor_get_from_device("is_stopped")
-        self.assertEqual(stopped_status, "True")
+        pump_status = self._lewis.backdoor_get_from_device("pump_on")
+        self.assertEqual(pump_status, expected_pump_status)
 
-    @skip_if_recsim("Relies on the backdoor")
+    @skip_if_recsim("Recsim simulation not implemented")
     def test_GIVEN_an_ioc_WHEN_stop2_command_sent_THEN_expected_stop_type(self):
         self._lewis.backdoor_set_on_device("keep_last_values", "False")
         stopped_status = self._lewis.backdoor_get_from_device("keep_last_values")
@@ -57,79 +65,183 @@ class Knr1050Tests(unittest.TestCase):
         stopped_status = self._lewis.backdoor_get_from_device("keep_last_values")
         self.assertEqual(stopped_status, "True")
 
-    @skip_if_recsim("Relies on the backdoor")
+    @skip_if_recsim("Recsim simulation not implemented")
     def test_GIVEN_set_low_pressure_limit_via_backdoor_WHEN_get_low_pressure_limits_via_IOC_THEN_get_expected_pressure_limit(self):
-        expected_pressure = 10.0
+        expected_pressure = 10
         self._set_pressure_limit_low(expected_pressure)
         self.ca.set_pv_value("GET_PRESS:LIM.PROC", 1)
 
         self.ca.assert_that_pv_is("PRESS:LOW", expected_pressure)
 
-    @skip_if_recsim("Relies on the backdoor")
+    @skip_if_recsim("Recsim simulation not implemented")
     def test_GIVEN_set_high_pressure_limit_via_backdoor_WHEN_get_high_pressure_limits_via_IOC_THEN_get_expected_pressure_limit(self):
-        expected_pressure = 100.0
+        expected_pressure = 100
         self._set_pressure_limit_high(expected_pressure)
         self.ca.set_pv_value("GET_PRESS:LIM.PROC", 1)
 
         self.ca.assert_that_pv_is("PRESS:HIGH", expected_pressure)
 
-    @skip_if_recsim("Relies on the backdoor")
+    @skip_if_recsim("Recsim simulation not implemented")
     def test_GIVEN_set_low_pressure_limit_via_ioc_WHEN_get_low_pressure_limit_via_backdoor_THEN_get_expected_pressure_limit(self):
-        expected_pressure = 10.0
+        expected_pressure = 10
         self.ca.set_pv_value("PRESS:LOW:SP", expected_pressure)
 
-        self.assertEqual(float(self._lewis.backdoor_get_from_device("pressure_limit_low")), expected_pressure)
+        self.assertEqual(int(self._lewis.backdoor_get_from_device("pressure_limit_low")), expected_pressure)
 
-    @skip_if_recsim("Relies on the backdoor")
+    @skip_if_recsim("Recsim simulation not implemented")
     def test_GIVEN_set_high_pressure_limit_via_ioc_WHEN_get_high_pressure_limit_via_backdoor_THEN_get_expected_pressure_limit(self):
-        expected_pressure = 200.0
+        expected_pressure = 200
         self.ca.set_pv_value("PRESS:HIGH:SP", expected_pressure)
 
-        self.assertEqual(float(self._lewis.backdoor_get_from_device("pressure_limit_high")), expected_pressure)
+        self.assertEqual(int(self._lewis.backdoor_get_from_device("pressure_limit_high")), expected_pressure)
 
+    @skip_if_recsim("Recsim simulation not implemented")
     def test_GIVEN_set_low_pressure_limit_via_ioc_WHEN_get_low_pressure_limit_via_IOC_THEN_get_expected_value(self):
-        expected_pressure = 45.55
+        expected_pressure = 45
         self.ca.set_pv_value("PRESS:LOW:SP", expected_pressure)
 
         self.ca.assert_that_pv_is("PRESS:LOW", expected_pressure)
 
+    @skip_if_recsim("Recsim simulation not implemented")
     def test_GIVEN_set_high_pressure_limit_via_ioc_WHEN_get_high_pressure_limit_via_IOC_THEN_get_expected_value(self):
-        expected_pressure = 1345.55
+        expected_pressure = 500
+
         self.ca.set_pv_value("PRESS:HIGH:SP", expected_pressure)
 
         self.ca.assert_that_pv_is("PRESS:HIGH", expected_pressure)
 
-    @skip_if_recsim("Relies on the backdoor")
+    @skip_if_recsim("Recsim simulation not implemented")
     def test_GIVEN_an_ioc_WHEN_ramp_command_sent_via_ioc_THEN_ramp_starts(self):
-        ramp_status = self._lewis.backdoor_get_from_device("ramp_status")
+        ramp_status = self._lewis.backdoor_get_from_device("ramp")
         self.assertEqual(ramp_status, "False")
-        self.ca.set_pv_value("RAMP:SP", 1)
 
-        ramp_status = self._lewis.backdoor_get_from_device("ramp_status")
+        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
+
+        ramp_status = self._lewis.backdoor_get_from_device("ramp")
         self.assertEqual(ramp_status, "True")
 
-    @skip_if_recsim('Relies on the backdoor')
+    @skip_if_recsim("Recsim simulation not implemented")
     def test_GIVEN_set_flow_limit_min_via_ioc_WHEN_ramp_command_sent_via_IOC_THEN_correct_flow_limit_set(self):
-        expected_flow = 1423.10
-        self.ca.set_pv_value("FLOWRATE:SP", expected_flow)
-        self.ca.set_pv_value("RAMP:SP", 1)
+        expected_flow = 0.01
+        self.ca.set_pv_value("FLOW:SP", expected_flow)
+        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
 
-        self.assertEqual(float(self._lewis.backdoor_get_from_device("flow_rate")), expected_flow)
+        self.assertEqual(self.ca.get_pv_value("FLOW"), expected_flow)
 
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_set_flow_limit_min_via_ioc_WHEN_get_flow_via_IOC_THEN_correct_flow_limit(self):
+        expected_flow = 0.01
+        self.ca.set_pv_value("FLOW:SP", expected_flow)
 
-    @parameterized.expand([('A', 45),
-                           ('B', 34),
-                           ('C', 56),
-                           ('D', 76)])
-    @skip_if_recsim('Relies on the backdoor')
-    def test_GIVEN_set_concentration_A_via_ioc_WHEN_ramp_command_sent_via_ioc_THEN_correct_concentration_set(self, name, concentration):
-        self.ca.set_pv_value("CON:{}:SP".format(name), concentration)
-        self.ca.set_pv_value("RAMP:SP", 1)
+        self.assertEqual(self.ca.get_pv_value("FLOW"), expected_flow)
 
-        self.assertEqual(float(self._lewis.backdoor_get_from_device("concentration_{}".format(name))), concentration)
-    @skip_if_recsim('Relies on the backdoor')
-    def test_GIVEN_an_ioc_WHEN_get_status_THEN_device_has_valid_instrument_state_returned(self):
-        self.ca.set_pv_value("GET_STATUS", 1)
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_toggle_pump_via_ioc_WHEN_toggle_off_THEN_pump_off(self):
+        self.ca.set_pv_value("TOGGLE:PUMP:SP", 0)
+        pump_state = self._lewis.backdoor_get_from_device("pump_on")
 
-        state = self._lewis.backdoor_get_from_device("current_instrument_state")
-        pass
+        self.assertEqual(pump_state, "False")
+
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_toggle_pump_via_ioc_WHEN_toggle_off_THEN_ramp_off(self):
+        self.ca.set_pv_value("TOGGLE:PUMP:SP", 0)
+        ramp_state = self._lewis.backdoor_get_from_device("ramp")
+
+        self.assertEqual(ramp_state, "False")
+
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_toggle_pump_via_ioc_WHEN_toggle_on_THEN_pump_on(self):
+        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
+        ramp_state = self._lewis.backdoor_get_from_device("pump_on")
+
+        self.assertEqual(ramp_state, "True")
+
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_set_concentration_via_ioc_WHEN_ramp_command_sent_via_ioc_THEN_correct_concentration_set(self):
+        expected_concentrations = [0, 50, 35, 15]
+        self.ca.set_pv_value("CON:A:SP", expected_concentrations[0])
+        self.ca.set_pv_value("CON:B:SP", expected_concentrations[1])
+        self.ca.set_pv_value("CON:C:SP", expected_concentrations[2])
+        self.ca.set_pv_value("CON:D:SP", expected_concentrations[3])
+        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
+
+        concentrations = [self.ca.get_pv_value("CON:A"),
+                          self.ca.get_pv_value("CON:B"),
+                          self.ca.get_pv_value("CON:C"),
+                          self.ca.get_pv_value("CON:D")]
+        self.assertEqual(expected_concentrations, concentrations)
+
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_toggle_pump_via_ioc_WHEN_toggle_on_THEN_pump_on(self):
+        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
+        pump_state = self._lewis.backdoor_get_from_device("pump_on")
+
+        self.assertEqual(pump_state, "True")
+
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_toggle_pump_via_ioc_WHEN_toggle_off_THEN_device_state_idle(self):
+        expected_dev_state = "SYS_ST_OFF"
+        self.ca.set_pv_value("TOGGLE:PUMP:SP", 0)
+        state = self._lewis.backdoor_get_from_device("state")
+
+        self.assertEqual(expected_dev_state, state)
+
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_toggle_pump_via_ioc_WHEN_toggle_on_THEN_device_state_run(self):
+        expected_dev_state = "SYS_ST_RUN"
+        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
+        state = self._lewis.backdoor_get_from_device("state")
+
+        self.assertEqual(expected_dev_state, state)
+
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_toggle_pump_via_ioc_WHEN_toggle_on_then_off_THEN_device_state_off(self):
+        expected_dev_state = "SYS_ST_OFF"
+        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
+        self.ca.set_pv_value("TOGGLE:PUMP:SP", 0)
+        state = self._lewis.backdoor_get_from_device("state")
+
+        self.assertEqual(expected_dev_state, state)
+
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_ioc_turned_on_WHEN_get_status_THEN_off_status_returned(self):
+        expected_dev_state_num = "1"
+        state_num = self._lewis.backdoor_get_from_device("state_num")
+
+        self.assertEqual(expected_dev_state_num, state_num)
+
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_ioc_turned_on_WHEN_get_status_THEN_run_status_returned(self):
+        expected_dev_state_num = "3"
+        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
+        state_num = self._lewis.backdoor_get_from_device("state_num")
+
+        self.assertEqual(expected_dev_state_num, state_num)
+
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_ioc_turned_on_WHEN_get_inst_state_via_ioc_THEN_off_state_returned(self):
+        expected_dev_state = 'SYS_ST_OFF'
+        state = self.ca.get_pv_value("INST_STATE")
+
+        self.assertEqual(expected_dev_state, state)
+
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_ioc_turned_on_WHEN_set_local_mode_via_IOC_THEN_disabled_mode(self):
+        expected_mode = 'Disabled'
+        self.ca.set_pv_value("TOGGLE:REMOTE:SP", 0)
+
+        self.ca.assert_that_pv_is("DISABLE", expected_mode)
+
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_local_mode_WHEN_set_pump_on_via_IOC_THEN_pump_disabled(self):
+        self.ca.set_pv_value("TOGGLE:REMOTE:SP", 0)
+        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
+
+        self.ca.assert_that_pv_is("INST_STATE", 'SYS_ST_OFF')
+
+    @skip_if_recsim("Recsim simulation not implemented")
+    def test_GIVEN_incorrect_gradients_WHEN_set_pump_on_via_IOC_THEN_pump_disabled(self):
+        self.ca.set_pv_value("CON:A:SP", 50)  # sum of gradients =/= 100%
+        self.ca.set_pv_value("TOGGLE:PUMP:SP", 1)
+
+        self.ca.assert_that_pv_is("INST_STATE", 'SYS_ST_OFF')

--- a/tests/knr1050.py
+++ b/tests/knr1050.py
@@ -8,13 +8,14 @@ from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
 
 DEVICE_PREFIX = "KNR1050_01"
 
+device_name = "knr1050"
 
 IOCS = [
     {
         "name": DEVICE_PREFIX,
         "directory": get_default_ioc_dir("KNR1050"),
         "macros": {},
-        "emulator": "Knr1050",
+        "emulator": device_name,
     },
 ]
 
@@ -27,8 +28,15 @@ class Knr1050Tests(unittest.TestCase):
     Tests for the Knr1050 IOC.
     """
     def setUp(self):
-        self._lewis, self._ioc = get_running_lewis_and_ioc("Knr1050", DEVICE_PREFIX)
+        self._lewis, self._ioc = get_running_lewis_and_ioc(device_name, DEVICE_PREFIX)
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
+        #self._lewis.backdoor_run_function_on_device("reset")
 
-    def test_that_fails(self):
-        self.fail("You haven't implemented any tests!")
+    @skip_if_recsim("In rec sim this test fails")
+    def test_GIVEN_an_IOC_WHEN_stop_issued_THEN_device_stops(self):
+        stopped_status = self._lewis.backdoor_get_from_device("is_stopped")
+        self.assertEqual(stopped_status, "False")
+        self.ca.set_pv_value("STOP:SP", 1)
+
+        stopped_status = self._lewis.backdoor_get_from_device("is_stopped")
+        self.assertEqual(stopped_status, "True")

--- a/tests/knr1050.py
+++ b/tests/knr1050.py
@@ -35,7 +35,7 @@ class Knr1050Tests(unittest.TestCase):
         self.ca.set_pv_value("GET_REMOTE_MODE.PROC", 1)
         # Set the flow and concentrations to a default state that enable pump switch on
         self.ca.set_pv_value("PUMP:STOP:SP", "Stop")
-        self.ca.set_pv_value("DEV_STATE", "SYS_ST_IDLE")
+        self.ca.set_pv_value("DEV_STATE", "SYS_ST_OFF")
         self.ca.set_pv_value("FLOW:SP", 0.01)
         self.ca.set_pv_value("PRESS:LOW:SP", 0)
         self.ca.set_pv_value("PRESS:HIGH:SP", 100)
@@ -57,10 +57,10 @@ class Knr1050Tests(unittest.TestCase):
     def test_GIVEN_an_ioc_WHEN_start_pump_sent_THEN_pump_starts(self):
         self.ca.set_pv_value("PUMP:START:SP", "Start")
 
-        self.ca.assert_that_pv_is("DEV_STATE", "SYS_ST_RUN")
+        self.ca.assert_that_pv_is("DEV_STATE", "SYS_ST_IDLE")
 
     @skip_if_recsim("Recsim simulation not implemented")
-    def test_GIVEN_an_ioc_WHEN_stop_pump_sent_via_ioc_THEN_device_state_idle(self):
+    def test_GIVEN_an_ioc_WHEN_stop_pump_sent_via_ioc_THEN_device_state_off(self):
         expected_dev_state = "SYS_ST_OFF"
         self.ca.set_pv_value("PUMP:STOP:SP", "Stop")
 

--- a/tests/knr1050.py
+++ b/tests/knr1050.py
@@ -1,0 +1,34 @@
+import unittest
+
+from utils.channel_access import ChannelAccess
+from utils.ioc_launcher import get_default_ioc_dir
+from utils.test_modes import TestModes
+from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
+
+
+DEVICE_PREFIX = "KNR1050_01"
+
+
+IOCS = [
+    {
+        "name": DEVICE_PREFIX,
+        "directory": get_default_ioc_dir("KNR1050"),
+        "macros": {},
+        "emulator": "Knr1050",
+    },
+]
+
+
+TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
+
+
+class Knr1050Tests(unittest.TestCase):
+    """
+    Tests for the Knr1050 IOC.
+    """
+    def setUp(self):
+        self._lewis, self._ioc = get_running_lewis_and_ioc("Knr1050", DEVICE_PREFIX)
+        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
+
+    def test_that_fails(self):
+        self.fail("You haven't implemented any tests!")


### PR DESCRIPTION
# Description of work

Rework based on the linked ticket.

- Fixed: Refactored tests and updated PV names.
- Fixed: Removed duplicate tests
- Fixed: Redesigned tests that had timing issues (set PV -> lewis backdoor timings)
- Added: Connection test

# Ticket

Fixes: https://github.com/ISISComputingGroup/IBEX/issues/3262