### PR TITLE
Ticket3795 crashed ioc

### DIFF
--- a/tests/simple.py
+++ b/tests/simple.py
@@ -1,0 +1,38 @@
+import unittest
+import os
+
+from utils.channel_access import ChannelAccess
+from utils.ioc_launcher import ProcServLauncher
+from utils.testing import get_running_lewis_and_ioc
+
+DEVICE_PREFIX = "SIMPLE"
+
+EPICS_ROOT = os.getenv("EPICS_KIT_ROOT")
+
+IOCS = [
+    {
+        "LAUNCHER": ProcServLauncher,
+        "name": DEVICE_PREFIX,
+        "directory": os.path.realpath(os.path.join(EPICS_ROOT, "ISIS", "SimpleIoc", "master", "iocBoot", "iocsimple")),
+        "macros": {},
+    },
+]
+
+
+TEST_MODES = [None, ]
+
+
+class SimpleTests(unittest.TestCase):
+    """
+    Tests for the Simple IOC
+    """
+
+    def setUp(self):
+        self._lewis, self._ioc = get_running_lewis_and_ioc("Simple", DEVICE_PREFIX)
+        self.assertIsNotNone(self._lewis)
+        self.assertIsNotNone(self._ioc)
+
+        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
+
+    def test_that_always_passes(self):
+        pass

--- a/tests/simple.py
+++ b/tests/simple.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+from unittest import skip
 
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import ProcServLauncher
@@ -34,5 +35,7 @@ class SimpleTests(unittest.TestCase):
 
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
 
+    @skip("This test is not ready yet")
     def test_that_always_passes(self):
         pass
+

--- a/utils/ioc_launcher.py
+++ b/utils/ioc_launcher.py
@@ -1,6 +1,7 @@
 import subprocess
 import os
 from time import sleep
+from abc import ABCMeta
 
 from utils.channel_access import ChannelAccess
 from utils.log_file import log_filename, LogFileManager
@@ -20,6 +21,14 @@ def get_default_ioc_dir(iocname, iocnum=1):
         the path
     """
     return os.path.join(EPICS_TOP, "ioc", "master", iocname, "iocBoot", "ioc{}-IOC-{:02d}".format(iocname, iocnum))
+
+
+def check_if_ioc_already_running(ca, device, test_pv="DISABLE"):
+    try:
+        print("Check that IOC is not running")
+        ca.assert_that_pv_does_not_exist(test_pv)
+    except AssertionError as ex:
+        raise AssertionError("IOC '{}' appears to already be running: {}".format(device, ex))
 
 
 class IOCRegister(object):
@@ -54,7 +63,120 @@ class IOCRegister(object):
         cls.RunningIOCs[name] = ioc
 
 
-class IocLauncher(object):
+class BaseLauncher(object):
+    __metaclass__ = ABCMeta
+
+    def open(self):
+        pass
+
+    def close(self):
+        pass
+
+    def _set_environment_vars(self):
+        pass
+
+
+class ProcServLauncher(BaseLauncher):
+    """
+    Launches an IOC from procServ.exe
+    """
+
+    ICPTOOLS = "C:\\Instrument\\Apps\\EPICS\\tools\\master"
+
+    def __init__(self, **kwargs):
+        """
+        Constructor which calls ProcServ to boot an IOC
+
+        Args:
+            device: String, Device name
+            directory: String, the directory where st.cmd for the IOC is found
+            var_dir: location of directory to write the log file
+            port: The port to use
+        """
+
+        self._directory = kwargs['directory']
+        self._device = kwargs['device']
+        self._var_dir = kwargs['var_dir']
+        self.port = kwargs['port']
+
+        self.use_rec_sim = False
+
+        self._process = None
+        self.log_file_manager = None
+        self._ca = None
+        self.macros = None
+
+    def _get_channel_access(self):
+        """
+        :return (ChannelAccess): the channel access component
+        """
+        if self._ca is None:
+            self._ca = ChannelAccess(device_prefix=self._device)
+
+        return self._ca
+
+    def _set_environment_vars(self):
+        settings = os.environ.copy()
+
+        # Set the port
+        settings['EMULATOR_PORT'] = str(self.port)
+        return settings
+
+    def _log_filename(self):
+        return log_filename("ioc", self._device, self.use_rec_sim, self._var_dir)
+
+    def open(self):
+        """
+        Spawns the daemon IOC process using procServ.exe
+
+        Returns:
+
+        """
+
+        st_cmd_path = os.path.join(self._directory, "st.cmd")
+
+        if not os.path.isfile(st_cmd_path):
+            print("St.cmd path not found: '{0}'".format(st_cmd_path))
+
+        ca = self._get_channel_access()
+
+        check_if_ioc_already_running(ca, self._device)
+
+        ioc_run_command = ["{}\\cygwin_bin\\procServ.exe".format(self.ICPTOOLS),
+                           '--logstamp', '--logfile', ' --timefmt="%%Y-%%m-%%d %%H:%%M:%%S"',
+                           st_cmd_path, '--restrict', '--ignore=^D^C', '--noautorestart', '--wait',
+                           '--name={}'.format(self._device),
+                           '--pidfile="/cygdrive/c/windows/temp/EPICS_{}"'.format(self._device),
+                           '--logport={:d}'.format(self.port + 1), '--chdir="{}"'.format(self._directory),
+                           '{:d}'.format(self.port), '%ComSpec', '/c', 'runIOC.bat', 'st.cmd']
+
+        print("Starting IOC ({})".format(self._device))
+
+        settings = self._set_environment_vars()
+
+        self.log_file_manager = LogFileManager(self._log_filename())
+        self.log_file_manager.log_file.write("Started IOC with '{0}'".format(" ".join(ioc_run_command)))
+
+        # To be able to see the IOC output for debugging, remove the redirection of stdin, stdout and stderr.
+        # This does mean that the IOC will need to be closed manually after the tests.
+        # Make sure to revert before checking code in
+        self._process = subprocess.Popen(ioc_run_command, creationflags=subprocess.CREATE_NEW_CONSOLE,
+                                         cwd=self._directory,# stdin=subprocess.PIPE,
+                                         stdout=self.log_file_manager.log_file, stderr=subprocess.STDOUT, env=settings)
+
+        self.log_file_manager.wait_for_console(MAX_TIME_TO_WAIT_FOR_IOC_TO_START)
+
+        IOCRegister.add_ioc(self._device, self)
+
+    def close(self):
+        """
+        Closes the IOC
+        """
+        if self._process is not None:
+            self._process.kill()
+
+
+class IocLauncher(BaseLauncher):
     """
     Launches an IOC for testing.
     """

--- a/utils/test_modes.py
+++ b/utils/test_modes.py
@@ -1,3 +1,26 @@
-class TestModes(object):
-    RECSIM = object()
-    DEVSIM = object()
+"""
+Possible testsing mmodes
+"""
+from enum import Enum
+
+
+class TestModes(Enum):
+    """
+    Modes in which a et of unit tests can be run
+    """
+    RECSIM = 1
+    DEVSIM = 2
+
+    @staticmethod
+    def name(mode):
+        """
+        Returns: nice name of mode
+        """
+        if mode == TestModes.RECSIM:
+            return "Rec sim"
+        elif mode == TestModes.DEVSIM:
+            return "Device sim"
+        elif mode is None:
+            return "test mode not set!!!!"
+        else:
+            return "Unknown"


### PR DESCRIPTION
Introduces a BaseLauncher class which allows arbitrary code to be excecuted by the IOC test framework when a launcher is provided for it.

ProcServLauncher is provided as an example of this, but this can not launch an IOC yet.