### PR TITLE
Ticket 3829 - Added connection tests for 8000 & 8800 PSUs

### DIFF
--- a/common_tests/danfysik.py
+++ b/common_tests/danfysik.py
@@ -30,6 +30,21 @@ class DanfysikBase(object):
 
 
 class DanfysikCommon(DanfysikBase):
+    def _pv_alarms_when_disconnected(self, pv):
+        """Helper method to check PVs alarm when device is disconnected."""
+        self.ca.assert_that_pv_alarm_is_not(pv, ChannelAccess.Alarms.INVALID)
+        self._lewis.backdoor_set_on_device('comms_initialized', False)
+        self._lewis.backdoor_set_on_device('device_available', False)
+        self.ca.assert_that_pv_alarm_is(pv, ChannelAccess.Alarms.INVALID, timeout=10)
+
+    @skip_if_recsim("Can not test disconnection in rec sim")
+    def test_GIVEN_device_not_connected_WHEN_voltage_pv_checked_THEN_pv_in_alarm(self):
+        self._pv_alarms_when_disconnected("VOLT")
+
+    @skip_if_recsim("Can not test disconnection in rec sim")
+    def test_GIVEN_device_not_connected_WHEN_current_pv_checked_THEN_pv_in_alarm(self):
+        self._pv_alarms_when_disconnected("CURR")
+
     def test_WHEN_polarity_setpoint_is_set_THEN_readback_updates_with_set_value(self):
         for pol in POLARITIES:
             self.ca.assert_setting_setpoint_sets_readback(pol, "POL")

--- a/tests/danfysik8000.py
+++ b/tests/danfysik8000.py
@@ -61,19 +61,3 @@ class Danfysik8000Tests(DanfysikCommon, unittest.TestCase):
             self.ca.assert_that_pv_is(ilk_pv, "Interlock")
             self._lewis.backdoor_command(["device", "disable_interlock", ilk_name])
             self.ca.assert_that_pv_is(ilk_pv, "OK")
-
-    @skip_if_recsim("Can not test disconnection in rec sim")
-    def test_GIVEN_device_not_connected_WHEN_voltage_pv_checked_THEN_pv_in_alarm(self):
-        sleep(5)
-        self._lewis.backdoor_set_on_device('comms_initialized', False)
-        self._lewis.backdoor_set_on_device('device_available', False)
-        sleep(10)
-        self.ca.assert_that_pv_alarm_is('VOLT', ChannelAccess.Alarms.INVALID)
-
-    @skip_if_recsim("Can not test disconnection in rec sim")
-    def test_GIVEN_device_not_connected_WHEN_current_pv_checked_THEN_pv_in_alarm(self):
-        sleep(5)
-        self._lewis.backdoor_set_on_device('comms_initialized', False)
-        self._lewis.backdoor_set_on_device('device_available', False)
-        sleep(10)
-        self.ca.assert_that_pv_alarm_is('CURR', ChannelAccess.Alarms.INVALID)

--- a/tests/danfysik8000.py
+++ b/tests/danfysik8000.py
@@ -1,7 +1,4 @@
 import unittest
-from time import sleep
-
-from utils.channel_access import ChannelAccess
 
 from utils.test_modes import TestModes
 from utils.ioc_launcher import get_default_ioc_dir

--- a/tests/danfysik8000.py
+++ b/tests/danfysik8000.py
@@ -1,4 +1,7 @@
 import unittest
+from time import sleep
+
+from utils.channel_access import ChannelAccess
 
 from utils.test_modes import TestModes
 from utils.ioc_launcher import get_default_ioc_dir
@@ -58,3 +61,19 @@ class Danfysik8000Tests(DanfysikCommon, unittest.TestCase):
             self.ca.assert_that_pv_is(ilk_pv, "Interlock")
             self._lewis.backdoor_command(["device", "disable_interlock", ilk_name])
             self.ca.assert_that_pv_is(ilk_pv, "OK")
+
+    @skip_if_recsim("Can not test disconnection in rec sim")
+    def test_GIVEN_device_not_connected_WHEN_voltage_pv_checked_THEN_pv_in_alarm(self):
+        sleep(5)
+        self._lewis.backdoor_set_on_device('comms_initialized', False)
+        self._lewis.backdoor_set_on_device('device_available', False)
+        sleep(10)
+        self.ca.assert_that_pv_alarm_is('VOLT', ChannelAccess.Alarms.INVALID)
+
+    @skip_if_recsim("Can not test disconnection in rec sim")
+    def test_GIVEN_device_not_connected_WHEN_current_pv_checked_THEN_pv_in_alarm(self):
+        sleep(5)
+        self._lewis.backdoor_set_on_device('comms_initialized', False)
+        self._lewis.backdoor_set_on_device('device_available', False)
+        sleep(10)
+        self.ca.assert_that_pv_alarm_is('CURR', ChannelAccess.Alarms.INVALID)

--- a/tests/danfysik8800.py
+++ b/tests/danfysik8800.py
@@ -1,5 +1,4 @@
 import unittest
-from time import sleep
 
 from utils.channel_access import ChannelAccess
 
@@ -8,6 +7,7 @@ from utils.ioc_launcher import get_default_ioc_dir
 
 from common_tests.danfysik import DanfysikCommon, DEVICE_PREFIX, EMULATOR_NAME
 from utils.testing import skip_if_recsim
+
 
 IOCS = [
     {
@@ -65,19 +65,3 @@ class Danfysik8800Tests(DanfysikCommon, unittest.TestCase):
             self.ca.assert_that_pv_is(ilk_pv, "Interlock")
             self._lewis.backdoor_command(["device", "disable_interlock", ilk_name])
             self.ca.assert_that_pv_is(ilk_pv, "OK")
-
-    @skip_if_recsim("Can not test disconnection in rec sim")
-    def test_GIVEN_device_not_connected_WHEN_voltage_pv_checked_THEN_pv_in_alarm(self):
-        sleep(5)
-        self._lewis.backdoor_set_on_device('comms_initialized', False)
-        self._lewis.backdoor_set_on_device('device_available', False)
-        sleep(10)
-        self.ca.assert_that_pv_alarm_is('VOLT', ChannelAccess.Alarms.INVALID)
-
-    @skip_if_recsim("Can not test disconnection in rec sim")
-    def test_GIVEN_device_not_connected_WHEN_current_pv_checked_THEN_pv_in_alarm(self):
-        sleep(5)
-        self._lewis.backdoor_set_on_device('comms_initialized', False)
-        self._lewis.backdoor_set_on_device('device_available', False)
-        sleep(10)
-        self.ca.assert_that_pv_alarm_is('CURR', ChannelAccess.Alarms.INVALID)

--- a/tests/danfysik8800.py
+++ b/tests/danfysik8800.py
@@ -1,4 +1,7 @@
 import unittest
+from time import sleep
+
+from utils.channel_access import ChannelAccess
 
 from utils.test_modes import TestModes
 from utils.ioc_launcher import get_default_ioc_dir
@@ -62,3 +65,19 @@ class Danfysik8800Tests(DanfysikCommon, unittest.TestCase):
             self.ca.assert_that_pv_is(ilk_pv, "Interlock")
             self._lewis.backdoor_command(["device", "disable_interlock", ilk_name])
             self.ca.assert_that_pv_is(ilk_pv, "OK")
+
+    @skip_if_recsim("Can not test disconnection in rec sim")
+    def test_GIVEN_device_not_connected_WHEN_voltage_pv_checked_THEN_pv_in_alarm(self):
+        sleep(5)
+        self._lewis.backdoor_set_on_device('comms_initialized', False)
+        self._lewis.backdoor_set_on_device('device_available', False)
+        sleep(10)
+        self.ca.assert_that_pv_alarm_is('VOLT', ChannelAccess.Alarms.INVALID)
+
+    @skip_if_recsim("Can not test disconnection in rec sim")
+    def test_GIVEN_device_not_connected_WHEN_current_pv_checked_THEN_pv_in_alarm(self):
+        sleep(5)
+        self._lewis.backdoor_set_on_device('comms_initialized', False)
+        self._lewis.backdoor_set_on_device('device_available', False)
+        sleep(10)
+        self.ca.assert_that_pv_alarm_is('CURR', ChannelAccess.Alarms.INVALID)

--- a/tests/danfysik8800.py
+++ b/tests/danfysik8800.py
@@ -1,7 +1,5 @@
 import unittest
 
-from utils.channel_access import ChannelAccess
-
 from utils.test_modes import TestModes
 from utils.ioc_launcher import get_default_ioc_dir
 

--- a/utils/channel_access.py
+++ b/utils/channel_access.py
@@ -415,6 +415,20 @@ class ChannelAccess(object):
         if self.ca.pv_exists(pv_name, timeout):
             raise AssertionError("PV {pv} exists".format(pv=self._create_pv_with_prefix(pv)))
 
+    def assert_that_pv_alarm_is_not(self, pv, alarm, timeout=None):
+        """
+        Assert that a pv is not in alarm state given or timeout.
+
+        Args:
+             pv: pv name
+             alarm: alarm state (see constants ALARM_X)
+             timeout: length of time to wait for change
+        Raises:
+             AssertionError: if alarm is requested value
+             UnableToConnectToPVException: if pv does not exist within timeout
+        """
+        return self.assert_that_pv_is_not("{}.SEVR".format(pv), alarm, timeout=timeout)
+
     def assert_that_pv_alarm_is(self, pv, alarm, timeout=None):
         """
         Assert that a pv is in alarm state given or timeout.


### PR DESCRIPTION
Created connection failure alarm tests for both the 8000 and 8800 series PSU's.

The sleeps are required as the device repeatedly sends a command (UNLOCK) to re-init comms. 