### PR TITLE
Ticket 3829 - Added connection testing for pv alarms

### DIFF
--- a/tests/rknps.py
+++ b/tests/rknps.py
@@ -68,14 +68,10 @@ class RknpsTests(unittest.TestCase):
         Args:
             pv (Str): name of the pv to check
         """
-        for IDN in IDS:
-            self.ca.assert_that_pv_alarm_is_not("{0}:{1}:{2}".format(PREFIX, IDN, pv), ChannelAccess.Alarms.INVALID, 2)
-
         self._lewis.backdoor_set_on_device("connected", False)
-        sleep(5)
 
         for IDN in IDS:
-            self.ca.assert_that_pv_alarm_is("{0}:{1}:{2}".format(PREFIX, IDN, pv), ChannelAccess.Alarms.INVALID, 2)
+            self.ca.assert_that_pv_alarm_is("{0}:{1}:{2}".format(PREFIX, IDN, pv), ChannelAccess.Alarms.INVALID, 30)
 
     def _activate_interlocks(self):
         """
@@ -220,7 +216,7 @@ class RknpsTests(unittest.TestCase):
             self.ca.set_pv_value("{}:RB4:POWER:SP".format(PREFIX), powered_on)
             self.ca.assert_that_pv_is("{}:RB4:BANNER".format(PREFIX),
                                       "on; beam to ports 3,4" if powered_on else "off; ports 3,4 safe")
-
+    #
     @skip_if_recsim("Cannot test connection in recsim")
     def test_GIVEN_device_not_connected_WHEN_current_pv_checked_THEN_pv_in_alarm(self):
         self._pv_alarms_when_disconnected("CURR")

--- a/tests/rknps.py
+++ b/tests/rknps.py
@@ -216,7 +216,7 @@ class RknpsTests(unittest.TestCase):
             self.ca.set_pv_value("{}:RB4:POWER:SP".format(PREFIX), powered_on)
             self.ca.assert_that_pv_is("{}:RB4:BANNER".format(PREFIX),
                                       "on; beam to ports 3,4" if powered_on else "off; ports 3,4 safe")
-    #
+    
     @skip_if_recsim("Cannot test connection in recsim")
     def test_GIVEN_device_not_connected_WHEN_current_pv_checked_THEN_pv_in_alarm(self):
         self._pv_alarms_when_disconnected("CURR")

--- a/tests/rknps.py
+++ b/tests/rknps.py
@@ -68,6 +68,9 @@ class RknpsTests(unittest.TestCase):
         Args:
             pv (Str): name of the pv to check
         """
+        for IDN in IDS:
+            self.ca.assert_that_pv_alarm_is_not("{0}:{1}:{2}".format(PREFIX, IDN, pv), ChannelAccess.Alarms.INVALID, 30)
+
         self._lewis.backdoor_set_on_device("connected", False)
 
         for IDN in IDS:
@@ -93,12 +96,12 @@ class RknpsTests(unittest.TestCase):
         else:
             self._lewis.backdoor_set_on_device("set_all_interlocks", False)
 
-    def test_WHEN_intelocks_are_active_THEN_ilk_is_Interlocked(self):
+    def test_WHEN_interlocks_are_active_THEN_ilk_is_Interlocked(self):
         self._activate_interlocks()
         for IDN in IDS:
             self.ca.assert_that_pv_is("{0}:{1}:ILK".format(PREFIX, IDN), "Interlock")
 
-    def test_WHEN_intelocks_are_inactive_THEN_ilk_is_not_Interlocked(self):
+    def test_WHEN_interlocks_are_inactive_THEN_ilk_is_not_Interlocked(self):
         self._disable_interlocks()
         for IDN in IDS:
             self.ca.assert_that_pv_is("{0}:{1}:ILK".format(PREFIX, IDN), "OK")

--- a/tests/rknps.py
+++ b/tests/rknps.py
@@ -1,6 +1,6 @@
 import unittest
+from time import sleep
 
-import time
 from unittest import skip
 
 from utils.channel_access import ChannelAccess
@@ -60,6 +60,7 @@ class RknpsTests(unittest.TestCase):
         self._lewis, self._ioc = get_running_lewis_and_ioc("rknps", PREFIX)
         self.ca = ChannelAccess(default_timeout=30)
         self.ca.assert_that_pv_exists("{0}:{1}:ADDRESS".format(PREFIX, ID1), timeout=30)
+        self._lewis.backdoor_set_on_device("connected", True)
 
     def _activate_interlocks(self):
         """
@@ -204,3 +205,19 @@ class RknpsTests(unittest.TestCase):
             self.ca.set_pv_value("{}:RB4:POWER:SP".format(PREFIX), powered_on)
             self.ca.assert_that_pv_is("{}:RB4:BANNER".format(PREFIX),
                                       "on; beam to ports 3,4" if powered_on else "off; ports 3,4 safe")
+
+    @skip_if_recsim("Cannot test connection in recsim")
+    def test_GIVEN_device_not_connected_WHEN_voltage_pv_checked_THEN_pv_in_alarm(self):
+        self._lewis.backdoor_set_on_device("connected", False)
+        sleep(5)
+
+        for IDN in IDS:
+            self.ca.assert_that_pv_alarm_is("{0}:{1}:VOLT".format(PREFIX, IDN), ChannelAccess.Alarms.INVALID)
+
+    @skip_if_recsim("Cannot test connection in recsim")
+    def test_GIVEN_device_not_connected_WHEN_current_pv_checked_THEN_pv_in_alarm(self):
+        self._lewis.backdoor_set_on_device("connected", False)
+        sleep(5)
+
+        for IDN in IDS:
+            self.ca.assert_that_pv_alarm_is("{0}:{1}:CURR".format(PREFIX, IDN), ChannelAccess.Alarms.INVALID)

--- a/tests/rknps.py
+++ b/tests/rknps.py
@@ -62,6 +62,21 @@ class RknpsTests(unittest.TestCase):
         self.ca.assert_that_pv_exists("{0}:{1}:ADDRESS".format(PREFIX, ID1), timeout=30)
         self._lewis.backdoor_set_on_device("connected", True)
 
+    def _pv_alarms_when_disconnected(self, pv):
+        """
+        Helper method to check PV alarm when device is disconnected
+        Args:
+            pv (Str): name of the pv to check
+        """
+        for IDN in IDS:
+            self.ca.assert_that_pv_alarm_is_not("{0}:{1}:{2}".format(PREFIX, IDN, pv), ChannelAccess.Alarms.INVALID, 2)
+
+        self._lewis.backdoor_set_on_device("connected", False)
+        sleep(5)
+
+        for IDN in IDS:
+            self.ca.assert_that_pv_alarm_is("{0}:{1}:{2}".format(PREFIX, IDN, pv), ChannelAccess.Alarms.INVALID, 2)
+
     def _activate_interlocks(self):
         """
         Activate both interlocks in the emulator.
@@ -207,17 +222,9 @@ class RknpsTests(unittest.TestCase):
                                       "on; beam to ports 3,4" if powered_on else "off; ports 3,4 safe")
 
     @skip_if_recsim("Cannot test connection in recsim")
-    def test_GIVEN_device_not_connected_WHEN_voltage_pv_checked_THEN_pv_in_alarm(self):
-        self._lewis.backdoor_set_on_device("connected", False)
-        sleep(5)
-
-        for IDN in IDS:
-            self.ca.assert_that_pv_alarm_is("{0}:{1}:VOLT".format(PREFIX, IDN), ChannelAccess.Alarms.INVALID)
+    def test_GIVEN_device_not_connected_WHEN_current_pv_checked_THEN_pv_in_alarm(self):
+        self._pv_alarms_when_disconnected("CURR")
 
     @skip_if_recsim("Cannot test connection in recsim")
-    def test_GIVEN_device_not_connected_WHEN_current_pv_checked_THEN_pv_in_alarm(self):
-        self._lewis.backdoor_set_on_device("connected", False)
-        sleep(5)
-
-        for IDN in IDS:
-            self.ca.assert_that_pv_alarm_is("{0}:{1}:CURR".format(PREFIX, IDN), ChannelAccess.Alarms.INVALID)
+    def test_GIVEN_device_not_connected_WHEN_voltage_pv_checked_THEN_pv_in_alarm(self):
+        self._pv_alarms_when_disconnected("VOLT")


### PR DESCRIPTION
Created connection failure alarm tests for the riken power supplies.