### PR TITLE
Ticket 3929 - MOXA e1210: Added test that checks the counter correctly increases.

### DIFF
--- a/tests/moxa1210.py
+++ b/tests/moxa1210.py
@@ -1,7 +1,5 @@
 from __future__ import division
 import unittest
-from random import randint
-from time import sleep
 
 from utils.test_modes import TestModes
 from utils.channel_access import ChannelAccess
@@ -11,17 +9,18 @@ from parameterized import parameterized
 
 
 # Device prefix
-DEVICE_PREFIX = "MOXA1210_01"
+DEVICE_PREFIX = "MOXA12XX_01"
 
 IOCS = [
     {
         "name": DEVICE_PREFIX,
-        "directory": get_default_ioc_dir("MOXA1210"),
-        "emulator": "moxa1210",
-        "emulator_protocol": "modbus",
+        "directory": get_default_ioc_dir("MOXA12XX"),
+        "emulator": "moxa12xx",
+        "emulator_protocol": "MOXA_1210",
         "macros": {
             "IEOS": r"\\r\\n",
             "OEOS": r"\\r\\n",
+            "MODELNO": "1210"
         }
     },
 ]
@@ -36,7 +35,7 @@ class Moxa1210Tests(unittest.TestCase):
     """
 
     def setUp(self):
-        self._lewis, self._ioc = get_running_lewis_and_ioc("moxa1210", DEVICE_PREFIX)
+        self._lewis, self._ioc = get_running_lewis_and_ioc("moxa12xx", DEVICE_PREFIX)
 
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
 
@@ -54,33 +53,24 @@ class Moxa1210Tests(unittest.TestCase):
         We typically want to preserve our counter values for each channel even upon restart. For testing purposes
         this function will reset the counter values to 0. 
         """
-        self.ca.set_pv_value("CH{:02d}:DI:CNT".format(channel), 0)
+        self.ca.set_pv_value("CH{:01d}:DI:CNT".format(channel), 0)
 
     @parameterized.expand([
-        ("CH{:02d}".format(channel), channel) for channel in CHANNELS
+        ("CH{:01d}".format(channel), channel) for channel in CHANNELS
     ])
     def test_WHEN_DI_input_is_switched_on_THEN_only_that_channel_readback_changes_to_state_just_set(self, _, channel):
         self._lewis.backdoor_run_function_on_device("set_di", (channel, (True,)))
-        self.ca.assert_that_pv_is("CH{:02d}:DI".format(channel), "High")
+        self.ca.assert_that_pv_is("CH{:01d}:DI".format(channel), "High")
 
         # Test that all other channels are still off
         for test_channel in CHANNELS:
             if test_channel == channel:
                 continue
 
-            self.ca.assert_that_pv_is("CH{:02d}:DI".format(test_channel), "Low")
+            self.ca.assert_that_pv_is("CH{:01d}:DI".format(test_channel), "Low")
 
     @parameterized.expand([
-        ("CH{:02d}:DI:CNT".format(channel), channel) for channel in CHANNELS
-    ])
-    def test_WHEN_di_input_is_triggered_THEN_di_counter_increases(self, channel_pv, channel):
-        self.resetDICounter(channel)
-        self._lewis.backdoor_run_function_on_device("set_di", (channel, (True,)))
-
-        self.ca.assert_that_pv_is(channel_pv, 1)
-
-    @parameterized.expand([
-        ("CH{:02d}:DI:CNT".format(channel), channel) for channel in CHANNELS
+        ("CH{:01d}:DI:CNT".format(channel), channel) for channel in CHANNELS
     ])
     def test_WHEN_di_input_is_triggered_a_number_of_times_THEN_di_counter_matches(self, channel_pv, channel):
         self.resetDICounter(channel)


### PR DESCRIPTION
Each DI can be triggered which will increament the DI's associated counter (EPICS layer record). Typically we want these counter values to remain persistent even on restart (as they are a safety feature). 

The new tests trigger each DI and then check their counter has incremented correctly. The resetDICounter function allows for these to be reset, but add considerable time to the test length, as such it shouldn't be in setUP.