### PR TITLE
Ticket3918 1240 1262

### DIFF
--- a/common_tests/moxa12XX.py
+++ b/common_tests/moxa12XX.py
@@ -1,0 +1,134 @@
+from __future__ import division
+import six
+
+from abc import ABCMeta, abstractmethod
+
+from utils.channel_access import ChannelAccess
+from utils.testing import get_running_lewis_and_ioc
+from itertools import product
+
+
+@six.add_metaclass(ABCMeta)
+class Moxa12XXBase(object):
+    """
+    Tests for a moxa ioLogik e1240. (8x DC Voltage/Current measurements)
+    """
+
+    @abstractmethod
+    def get_device_prefix(self):
+        pass
+
+    @abstractmethod
+    def get_PV_name(self):
+        pass
+
+    @abstractmethod
+    def get_number_of_channels(self):
+        pass
+
+    @abstractmethod
+    def get_setter_function_name(self):
+        pass
+
+    @abstractmethod
+    def get_starting_reg_addr(self):
+        pass
+
+    @abstractmethod
+    def get_test_values(self):
+        pass
+
+    @abstractmethod
+    def get_raw_ir_setter(self):
+        pass
+
+    @abstractmethod
+    def get_raw_ir_pv(self):
+        pass
+
+    @abstractmethod
+    def get_alarm_limits(self):
+        pass
+
+    @abstractmethod
+    def get_registers_per_channel(self):
+        pass
+
+    @abstractmethod
+    def get_channel_format(self):
+        pass
+
+    def setUp(self):
+
+        self.NUMBER_OF_CHANNELS = self.get_number_of_channels()
+
+        self.CHANNELS = range(self.NUMBER_OF_CHANNELS)
+
+        self.low_alarm_limit, self.high_alarm_limit = self.get_alarm_limits()
+
+        self._lewis, self._ioc = get_running_lewis_and_ioc("moxa12xx", self.get_device_prefix())
+
+        self.ca = ChannelAccess(device_prefix=self.get_device_prefix())
+
+        # Sends a backdoor command to the device to reset all input registers (IRs) to 0
+        reset_value = 0
+        self._lewis.backdoor_run_function_on_device("set_ir", (self.get_starting_reg_addr(),
+                                                               [reset_value]*self.get_registers_per_channel()*self.NUMBER_OF_CHANNELS))
+
+    def test_WHEN_an_AI_input_is_changed_THEN_that_channel_readback_updates(self):
+        for channel, test_value in product(self.CHANNELS, self.get_test_values()):
+            register_offset = channel * self.get_registers_per_channel()
+
+            self._lewis.backdoor_run_function_on_device(self.get_setter_function_name(),
+                                                        (self.get_starting_reg_addr() + register_offset, test_value))
+
+            self.ca.assert_that_pv_is_number("CH{:01d}:{PV}".format(channel, PV=self.get_PV_name()),
+                                             test_value, tolerance=0.1*abs(test_value))
+
+    def test_WHEN_device_voltage_is_below_low_limit_THEN_PV_shows_major_alarm(self):
+        for channel in range(self.get_number_of_channels()):
+            register_offset = channel * self.get_registers_per_channel()
+
+            valid_value = 0.5*(self.low_alarm_limit + self.high_alarm_limit)
+
+            self._lewis.backdoor_run_function_on_device(self.get_setter_function_name(),
+                                                        (self.get_starting_reg_addr() + register_offset, valid_value))
+
+            self.ca.assert_that_pv_is_number("CH{:01d}:{PV}".format(channel, PV=self.get_PV_name()),
+                                             valid_value, tolerance=0.1*valid_value)
+
+            self.ca.assert_that_pv_alarm_is("CH{:01d}:{PV}".format(channel, PV=self.get_PV_name()), self.ca.Alarms.NONE)
+
+            value_to_set = self.low_alarm_limit - 1.0
+
+            self._lewis.backdoor_run_function_on_device(self.get_setter_function_name(),
+                                                        (self.get_starting_reg_addr() + register_offset, value_to_set))
+
+            self.ca.assert_that_pv_is_number("CH{:01d}:{PV}".format(channel, PV=self.get_PV_name()),
+                                             value_to_set, tolerance=0.1*value_to_set)
+
+            self.ca.assert_that_pv_alarm_is("CH{:01d}:{PV}".format(channel, PV=self.get_PV_name()),
+                                            self.ca.Alarms.MAJOR)
+
+    def test_WHEN_device_voltage_is_above_high_limit_THEN_PV_shows_major_alarm(self):
+        for channel in range(self.get_number_of_channels()):
+            register_offset = channel * self.get_registers_per_channel()
+
+            valid_value = 0.5*(self.low_alarm_limit + self.high_alarm_limit)
+
+            self._lewis.backdoor_run_function_on_device(self.get_setter_function_name(),
+                                                        (self.get_starting_reg_addr() + register_offset, valid_value))
+
+            self.ca.assert_that_pv_alarm_is("CH{:01d}:{PV}".format(channel, PV=self.get_PV_name()), self.ca.Alarms.NONE)
+
+            value_to_set = self.high_alarm_limit + 1.0
+
+            self._lewis.backdoor_run_function_on_device(self.get_setter_function_name(),
+                                                        (self.get_starting_reg_addr() + register_offset, value_to_set))
+
+            self.ca.assert_that_pv_alarm_is("CH{:01d}:{PV}".format(channel, PV=self.get_PV_name()),
+                                            self.ca.Alarms.MAJOR)
+
+    def test_WHEN_a_channel_is_aliased_THEN_a_PV_with_that_alias_exists(self):
+        for channel in range(self.get_number_of_channels()):
+            self.ca.assert_that_pv_exists(self.get_channel_format().format(channel))

--- a/tests/moxa1210.py
+++ b/tests/moxa1210.py
@@ -26,7 +26,10 @@ IOCS = [
 ]
 
 TEST_MODES = [TestModes.DEVSIM, ]
-CHANNELS = range(16)
+
+NUMBER_OF_CHANNELS = 16
+
+CHANNELS = range(NUMBER_OF_CHANNELS)
 
 
 class Moxa1210Tests(unittest.TestCase):

--- a/tests/moxa1210.py
+++ b/tests/moxa1210.py
@@ -9,12 +9,12 @@ from parameterized import parameterized
 
 
 # Device prefix
-DEVICE_PREFIX = "MOXA1210_01"
+DEVICE_PREFIX = "MOXA12XX_01"
 
 IOCS = [
     {
         "name": DEVICE_PREFIX,
-        "directory": get_default_ioc_dir("MOXA1210"),
+        "directory": get_default_ioc_dir("MOXA12XX"),
         "emulator": "moxa12xx",
         "emulator_protocol": "modbus",
         "macros": {

--- a/tests/moxa1210.py
+++ b/tests/moxa1210.py
@@ -15,7 +15,7 @@ IOCS = [
     {
         "name": DEVICE_PREFIX,
         "directory": get_default_ioc_dir("MOXA1210"),
-        "emulator": "moxa1210",
+        "emulator": "moxa12xx",
         "emulator_protocol": "modbus",
         "macros": {
             "IEOS": r"\\r\\n",
@@ -31,11 +31,11 @@ CHANNELS = range(16)
 
 class Moxa1210Tests(unittest.TestCase):
     """
-    Tests for the Moxa ioLogik e1210
+    Tests for the Moxa ioLogik e1210. (16x Discrete inputs)
     """
 
     def setUp(self):
-        self._lewis, self._ioc = get_running_lewis_and_ioc("moxa1210", DEVICE_PREFIX)
+        self._lewis, self._ioc = get_running_lewis_and_ioc("moxa12xx", DEVICE_PREFIX)
 
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
 

--- a/tests/moxa1210.py
+++ b/tests/moxa1210.py
@@ -16,7 +16,7 @@ IOCS = [
         "name": DEVICE_PREFIX,
         "directory": get_default_ioc_dir("MOXA12XX"),
         "emulator": "moxa12xx",
-        "emulator_protocol": "modbus",
+        "emulator_protocol": "MOXA_1210",
         "macros": {
             "IEOS": r"\\r\\n",
             "OEOS": r"\\r\\n",

--- a/tests/moxa1210.py
+++ b/tests/moxa1210.py
@@ -48,11 +48,11 @@ class Moxa1210Tests(unittest.TestCase):
     ])
     def test_WHEN_DI_input_is_switched_on_THEN_only_that_channel_readback_changes_to_state_just_set(self, _, channel):
         self._lewis.backdoor_run_function_on_device("set_di", (channel, (True,)))
-        self.ca.assert_that_pv_is("CH{:02d}:DI".format(channel), "High")
+        self.ca.assert_that_pv_is("CH{:d}:DI".format(channel), "High")
 
         # Test that all other channels are still off
         for test_channel in CHANNELS:
             if test_channel == channel:
                 continue
 
-            self.ca.assert_that_pv_is("CH{:02d}:DI".format(test_channel), "Low")
+            self.ca.assert_that_pv_is("CH{:d}:DI".format(test_channel), "Low")

--- a/tests/moxa1210.py
+++ b/tests/moxa1210.py
@@ -20,6 +20,7 @@ IOCS = [
         "macros": {
             "IEOS": r"\\r\\n",
             "OEOS": r"\\r\\n",
+            "MODELNO": "1210"
         }
     },
 ]

--- a/tests/moxa1240.py
+++ b/tests/moxa1240.py
@@ -4,11 +4,7 @@ import unittest
 from common_tests.moxa12XX import Moxa12XXBase
 
 from utils.test_modes import TestModes
-from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
-from utils.testing import get_running_lewis_and_ioc
-from parameterized import parameterized
-from itertools import product
 
 
 # Device prefix
@@ -47,19 +43,12 @@ TEST_MODES = [TestModes.DEVSIM, ]
 NUMBER_OF_CHANNELS = 8
 CHANNELS = range(NUMBER_OF_CHANNELS)
 
-RANGE_STATUSES = {0: "NORMAL",
-                  1: "BURNOUT",
-                  2: "OVERRANGE",
-                  3: "UNDERRANGE"}
-
 MIN_VOLT_MEAS = 0.0
 MAX_VOLT_MEAS = 10.0
 
 TEST_VALUES = [MIN_VOLT_MEAS,
                MAX_VOLT_MEAS,
                0.5*(MIN_VOLT_MEAS + MAX_VOLT_MEAS)]
-
-FLUSH_VALUE = 0
 
 
 class Moxa1240TestsFromBase(Moxa12XXBase, unittest.TestCase):
@@ -100,63 +89,3 @@ class Moxa1240TestsFromBase(Moxa12XXBase, unittest.TestCase):
     def get_channel_format(self):
         return CHANNEL_FORMAT
 
-
-class Moxa1240Tests(unittest.TestCase):
-    """
-    Tests for a moxa ioLogik e1240. (8x DC Voltage/Current measurements)
-    """
-
-    def setUp(self):
-        self._lewis, self._ioc = get_running_lewis_and_ioc("moxa12xx", DEVICE_PREFIX)
-
-        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
-
-        # Write zero to each input register to clear the data in the emulator
-        flush_value = 0
-        self._lewis.backdoor_run_function_on_device("set_ir", (AI_REGISTER_OFFSET, [flush_value]*NUMBER_OF_CHANNELS))
-        for test_channel in CHANNELS:
-            self.ca.assert_that_pv_is_number("CH{:01d}:AI:RAW".format(test_channel), flush_value, tolerance=0.1)
-
-    @parameterized.expand([
-        ("CH{:01d}".format(channel), channel, test_value) for channel, test_value in product(CHANNELS, TEST_VALUES)
-    ])
-    def test_WHEN_an_AI_input_is_changed_THEN_that_channel_readback_updates(self, _, channel, test_value):
-        self._lewis.backdoor_run_function_on_device("set_1240_voltage", (channel + AI_REGISTER_OFFSET, test_value))
-
-        self.ca.assert_that_pv_is_number("CH{:01d}:AI:RBV".format(channel), test_value, tolerance=0.1)
-
-    @parameterized.expand([
-        ("CH{:01d}".format(channel), channel) for channel in CHANNELS
-    ])
-    def test_WHEN_device_voltage_is_below_low_limit_THEN_PV_shows_major_alarm(self, _, channel):
-        voltage_to_set = LOW_ALARM_LIMIT - 1.0
-
-        self.ca.assert_that_pv_alarm_is("CH{:01d}:AI:RBV".format(channel), self.ca.Alarms.NONE)
-
-        self._lewis.backdoor_run_function_on_device("set_1240_voltage", (channel + AI_REGISTER_OFFSET, voltage_to_set))
-
-        self.ca.assert_that_pv_alarm_is("CH{:01d}:AI:RBV".format(channel), self.ca.Alarms.MAJOR)
-
-    @parameterized.expand([
-        ("CH{:01d}".format(channel), channel) for channel in CHANNELS
-    ])
-    def test_WHEN_device_voltage_is_above_high_limit_THEN_PV_shows_major_alarm(self, _, channel):
-        valid_voltage = 0.5*(HIGH_ALARM_LIMIT + LOW_ALARM_LIMIT)
-
-        self._lewis.backdoor_run_function_on_device("set_1240_voltage", (channel + AI_REGISTER_OFFSET, valid_voltage))
-
-        self.ca.assert_that_pv_alarm_is("CH{:01d}:AI:RBV".format(channel), self.ca.Alarms.NONE)
-
-        voltage_to_set = HIGH_ALARM_LIMIT + 1.0
-
-        self.ca.assert_that_pv_alarm_is("CH{:01d}:AI:RBV".format(channel), self.ca.Alarms.NONE)
-
-        self._lewis.backdoor_run_function_on_device("set_1240_voltage", (channel + AI_REGISTER_OFFSET, voltage_to_set))
-
-        self.ca.assert_that_pv_alarm_is("CH{:01d}:AI:RBV".format(channel), self.ca.Alarms.MAJOR)
-
-    @parameterized.expand([
-        ("CH{:01d}".format(channel), channel) for channel in CHANNELS
-    ])
-    def test_WHEN_a_channel_is_aliased_THEN_a_PV_with_that_alias_exists(self, _, channel):
-        self.ca.assert_that_pv_exists(IOCS[0]["macros"]["CHAN{:01d}NAME".format(channel)])

--- a/tests/moxa1240.py
+++ b/tests/moxa1240.py
@@ -1,0 +1,57 @@
+from __future__ import division
+import unittest
+
+from utils.test_modes import TestModes
+from utils.channel_access import ChannelAccess
+from utils.ioc_launcher import get_default_ioc_dir
+from utils.testing import get_running_lewis_and_ioc
+from parameterized import parameterized
+
+
+# Device prefix
+DEVICE_PREFIX = "MOXA1210_01"
+
+IOCS = [
+    {
+        "name": DEVICE_PREFIX,
+        "directory": get_default_ioc_dir("MOXA1210"),
+        "emulator": "moxa12xx",
+        "emulator_protocol": "modbus",
+        "macros": {
+            "IEOS": r"\\r\\n",
+            "OEOS": r"\\r\\n",
+            "MODELNO": "1240"
+        }
+    },
+]
+
+TEST_MODES = [TestModes.DEVSIM, ]
+CHANNELS = range(7)
+
+TEST_VALUE = 1.23
+
+
+class Moxa1240Tests(unittest.TestCase):
+    """
+    Tests for a moxa ioLogik e1240. (7x DC Voltage/Current measurements)
+    """
+
+    def setUp(self):
+        self._lewis, self._ioc = get_running_lewis_and_ioc("moxa12xx", DEVICE_PREFIX)
+
+        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
+
+        # Sends a backdoor command to the device to set an analogue input (AI) value
+        self._lewis.backdoor_run_function_on_device("set_ai", (0, [0.0]*16))
+        for test_channel in CHANNELS:
+            self.ca.assert_that_pv_is("CH{:02d}:DI".format(test_channel), 0.0)
+
+    @parameterized.expand([
+        ("CH{:02d}".format(channel), channel) for channel in CHANNELS
+    ])
+    def test_WHEN_an_AI_input_is_changed_THEN_that_channel_readback_updates(self, _, channel):
+        self._lewis.backdoor_run_function_on_device("set_ai", (channel, TEST_VALUE))
+
+        # Verify that the new value has been written and read back
+        for test_channel in CHANNELS:
+            self.ca.assert_that_pv_is("CH{:02d}:AI".format(test_channel), TEST_VALUE)

--- a/tests/moxa1240.py
+++ b/tests/moxa1240.py
@@ -16,7 +16,7 @@ IOCS = [
         "name": DEVICE_PREFIX,
         "directory": get_default_ioc_dir("MOXA12XX"),
         "emulator": "moxa12xx",
-        "emulator_protocol": "modbus",
+        "emulator_protocol": "MOXA_1240",
         "macros": {
             "IEOS": r"\\r\\n",
             "OEOS": r"\\r\\n",

--- a/tests/moxa1240.py
+++ b/tests/moxa1240.py
@@ -26,7 +26,7 @@ IOCS = [
 ]
 
 TEST_MODES = [TestModes.DEVSIM, ]
-CHANNELS = range(1)
+CHANNELS = range(7)
 
 TEST_VALUE = 50
 
@@ -52,6 +52,4 @@ class Moxa1240Tests(unittest.TestCase):
     def test_WHEN_an_AI_input_is_changed_THEN_that_channel_readback_updates(self, _, channel):
         self._lewis.backdoor_run_function_on_device("set_ir", (channel, [TEST_VALUE, ]))
 
-        # Verify that the new value has been written and read back
-        for test_channel in CHANNELS:
-            self.ca.assert_that_pv_is_number("CH{:01d}:AI:RAW".format(test_channel), TEST_VALUE, tolerance=0.1)
+        self.ca.assert_that_pv_is_number("CH{:01d}:AI:RAW".format(channel), TEST_VALUE, tolerance=0.1)

--- a/tests/moxa1262.py
+++ b/tests/moxa1262.py
@@ -1,0 +1,123 @@
+from __future__ import division
+import unittest
+
+from utils.test_modes import TestModes
+from utils.channel_access import ChannelAccess
+from utils.ioc_launcher import get_default_ioc_dir
+from utils.testing import get_running_lewis_and_ioc
+from parameterized import parameterized
+
+
+# Device prefix
+DEVICE_PREFIX = "MOXA12XX_01"
+
+LOW_ALARM_LIMIT = 20.0
+HIGH_ALARM_LIMIT = 80.0
+
+IOCS = [
+    {
+        "name": DEVICE_PREFIX,
+        "directory": get_default_ioc_dir("MOXA12XX"),
+        "emulator": "moxa12xx",
+        "emulator_protocol": "MOXA_1262",
+        "macros": {
+            "IEOS": r"\\r\\n",
+            "OEOS": r"\\r\\n",
+            "MODELNO": "1262",
+            "CHAN0NAME": "CHANNEL0",
+            "CHAN1NAME": "CHANNEL1",
+            "CHAN2NAME": "CHANNEL2",
+            "CHAN3NAME": "CHANNEL3",
+            "CHAN4NAME": "CHANNEL4",
+            "CHAN5NAME": "CHANNEL5",
+            "CHAN6NAME": "CHANNEL6",
+            "CHAN7NAME": "CHANNEL7",
+            "CHAN0LOWLIMIT": LOW_ALARM_LIMIT,
+            "CHAN1LOWLIMIT": LOW_ALARM_LIMIT,
+            "CHAN2LOWLIMIT": LOW_ALARM_LIMIT,
+            "CHAN3LOWLIMIT": LOW_ALARM_LIMIT,
+            "CHAN4LOWLIMIT": LOW_ALARM_LIMIT,
+            "CHAN5LOWLIMIT": LOW_ALARM_LIMIT,
+            "CHAN6LOWLIMIT": LOW_ALARM_LIMIT,
+            "CHAN7LOWLIMIT": LOW_ALARM_LIMIT,
+            "CHAN0HILIMIT": HIGH_ALARM_LIMIT,
+            "CHAN1HILIMIT": HIGH_ALARM_LIMIT,
+            "CHAN2HILIMIT": HIGH_ALARM_LIMIT,
+            "CHAN3HILIMIT": HIGH_ALARM_LIMIT,
+            "CHAN4HILIMIT": HIGH_ALARM_LIMIT,
+            "CHAN5HILIMIT": HIGH_ALARM_LIMIT,
+            "CHAN6HILIMIT": HIGH_ALARM_LIMIT,
+            "CHAN7HILIMIT": HIGH_ALARM_LIMIT,
+        }
+    },
+]
+
+TEST_MODES = [TestModes.DEVSIM, ]
+CHANNELS = range(7)
+
+AI_REGISTER_OFFSET = 0x810
+
+RANGE_STATUSES = {0: "NORMAL",
+                  1: "BURNOUT",
+                  2: "OVERRANGE",
+                  3: "UNDERRANGE"}
+
+TEST_VALUE = 50.0
+
+
+class Moxa1262Tests(unittest.TestCase):
+    """
+    Tests for a moxa ioLogik e1262. (7x Thermocopule measurements)
+    """
+
+    def setUp(self):
+        self._lewis, self._ioc = get_running_lewis_and_ioc("moxa12xx", DEVICE_PREFIX)
+
+        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
+
+        # Sends a backdoor command to the device to set an analogue input (AI) value
+        self._lewis.backdoor_run_function_on_device("set_ir", (AI_REGISTER_OFFSET, [0]*16))
+
+    @parameterized.expand([
+        ("CH{:01d}".format(channel), channel) for channel in CHANNELS
+    ])
+    def test_WHEN_an_AI_input_is_changed_THEN_that_channel_readback_updates(self, _, channel):
+        channel_address = AI_REGISTER_OFFSET + 2 * channel
+
+        self._lewis.backdoor_run_function_on_device("set_1262_temperature", (channel_address, TEST_VALUE))
+
+        self.ca.assert_that_pv_is_number("CH{:01d}:TEMP:RBV".format(channel), TEST_VALUE, tolerance=0.1)
+
+    @parameterized.expand([
+        ("CH{:01d}".format(channel), channel) for channel in CHANNELS
+    ])
+    def test_WHEN_device_temperature_is_below_low_limit_THEN_PV_shows_major_alarm(self, _, channel):
+        channel_address = AI_REGISTER_OFFSET + 2 * channel
+
+        temperature_to_set = LOW_ALARM_LIMIT - 10.0
+
+        self._lewis.backdoor_run_function_on_device("set_1262_temperature", (channel_address, temperature_to_set))
+
+        self.ca.assert_that_pv_is_number("CH{:01d}:TEMP:RBV".format(channel), temperature_to_set)
+
+        self.ca.assert_that_pv_alarm_is("CH{:01d}:TEMP:RBV".format(channel), self.ca.Alarms.MAJOR)
+
+    @parameterized.expand([
+        ("CH{:01d}".format(channel), channel) for channel in CHANNELS
+    ])
+    def test_WHEN_device_temperature_is_above_high_limit_THEN_PV_shows_major_alarm(self, _, channel):
+        channel_address = AI_REGISTER_OFFSET + 2 * channel
+
+        temperature_to_set = HIGH_ALARM_LIMIT + 10.0
+
+        self._lewis.backdoor_run_function_on_device("set_1262_temperature", (channel_address, temperature_to_set))
+
+        self.ca.assert_that_pv_is_number("CH{:01d}:TEMP:RBV".format(channel), temperature_to_set)
+
+        self.ca.assert_that_pv_alarm_is("CH{:01d}:TEMP:RBV".format(channel), self.ca.Alarms.MAJOR)
+
+    @parameterized.expand([
+        ("CH{:01d}".format(channel), channel) for channel in CHANNELS
+    ])
+    def test_WHEN_a_channel_is_aliased_THEN_a_PV_with_that_alias_exists(self, _, channel):
+        self.ca.assert_that_pv_exists(IOCS[0]["macros"]["CHAN{:01d}NAME".format(channel)])

--- a/tests/moxa1262.py
+++ b/tests/moxa1262.py
@@ -6,13 +6,28 @@ from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.testing import get_running_lewis_and_ioc
 from parameterized import parameterized
+from itertools import product
 
+from common_tests.moxa12XX import Moxa12XXBase
 
 # Device prefix
+CHANNEL_FORMAT = "CHANNEL{:1d}"
 DEVICE_PREFIX = "MOXA12XX_01"
 
 LOW_ALARM_LIMIT = 20.0
 HIGH_ALARM_LIMIT = 80.0
+
+NUMBER_OF_CHANNELS = 8
+
+macros = {
+    "IEOS": r"\\r\\n",
+    "OEOS": r"\\r\\n",
+    "MODELNO": "1262",
+}
+for channel in range(NUMBER_OF_CHANNELS):
+    macros["CHAN{:1d}NAME".format(channel)] = CHANNEL_FORMAT.format(channel)
+    macros["CHAN{:1d}LOWLIMIT".format(channel)] = LOW_ALARM_LIMIT
+    macros["CHAN{:1d}HILIMIT".format(channel)] = HIGH_ALARM_LIMIT
 
 IOCS = [
     {
@@ -20,40 +35,16 @@ IOCS = [
         "directory": get_default_ioc_dir("MOXA12XX"),
         "emulator": "moxa12xx",
         "emulator_protocol": "MOXA_1262",
-        "macros": {
-            "IEOS": r"\\r\\n",
-            "OEOS": r"\\r\\n",
-            "MODELNO": "1262",
-            "CHAN0NAME": "CHANNEL0",
-            "CHAN1NAME": "CHANNEL1",
-            "CHAN2NAME": "CHANNEL2",
-            "CHAN3NAME": "CHANNEL3",
-            "CHAN4NAME": "CHANNEL4",
-            "CHAN5NAME": "CHANNEL5",
-            "CHAN6NAME": "CHANNEL6",
-            "CHAN7NAME": "CHANNEL7",
-            "CHAN0LOWLIMIT": LOW_ALARM_LIMIT,
-            "CHAN1LOWLIMIT": LOW_ALARM_LIMIT,
-            "CHAN2LOWLIMIT": LOW_ALARM_LIMIT,
-            "CHAN3LOWLIMIT": LOW_ALARM_LIMIT,
-            "CHAN4LOWLIMIT": LOW_ALARM_LIMIT,
-            "CHAN5LOWLIMIT": LOW_ALARM_LIMIT,
-            "CHAN6LOWLIMIT": LOW_ALARM_LIMIT,
-            "CHAN7LOWLIMIT": LOW_ALARM_LIMIT,
-            "CHAN0HILIMIT": HIGH_ALARM_LIMIT,
-            "CHAN1HILIMIT": HIGH_ALARM_LIMIT,
-            "CHAN2HILIMIT": HIGH_ALARM_LIMIT,
-            "CHAN3HILIMIT": HIGH_ALARM_LIMIT,
-            "CHAN4HILIMIT": HIGH_ALARM_LIMIT,
-            "CHAN5HILIMIT": HIGH_ALARM_LIMIT,
-            "CHAN6HILIMIT": HIGH_ALARM_LIMIT,
-            "CHAN7HILIMIT": HIGH_ALARM_LIMIT,
-        }
+        "macros": macros
     },
 ]
 
 TEST_MODES = [TestModes.DEVSIM, ]
-CHANNELS = range(7)
+
+NUMBER_OF_CHANNELS = 8
+REGISTERS_PER_CHANNEL = 2
+
+CHANNELS = range(NUMBER_OF_CHANNELS)
 
 AI_REGISTER_OFFSET = 0x810
 
@@ -62,12 +53,55 @@ RANGE_STATUSES = {0: "NORMAL",
                   2: "OVERRANGE",
                   3: "UNDERRANGE"}
 
-TEST_VALUE = 50.0
+LARGEST_OBSERVABLE_VALUE = 3.4e38
+SMALLEST_TYPE_K_MEAS = -180.0
+LARGEST_TYPE_K_MEAS = 1300.0
+
+TEST_VALUES = [LARGEST_OBSERVABLE_VALUE, SMALLEST_TYPE_K_MEAS, LARGEST_TYPE_K_MEAS]
+
+
+class Moxa1262TestsFromBase(Moxa12XXBase, unittest.TestCase):
+    """
+    Tests for the moxa 1262 (8x Thermocouple measurements) imported from base class
+    """
+
+    def get_device_prefix(self):
+        return DEVICE_PREFIX
+
+    def get_PV_name(self):
+        return "TEMP"
+
+    def get_number_of_channels(self):
+        return NUMBER_OF_CHANNELS
+
+    def get_setter_function_name(self):
+        return "set_1262_temperature"
+
+    def get_starting_reg_addr(self):
+        return AI_REGISTER_OFFSET
+
+    def get_test_values(self):
+        return TEST_VALUES
+
+    def get_raw_ir_setter(self):
+        return "set_ir"
+
+    def get_raw_ir_pv(self):
+        return "get_ir"
+
+    def get_alarm_limits(self):
+        return [LOW_ALARM_LIMIT, HIGH_ALARM_LIMIT]
+
+    def get_registers_per_channel(self):
+        return REGISTERS_PER_CHANNEL
+
+    def get_channel_format(self):
+        return CHANNEL_FORMAT
 
 
 class Moxa1262Tests(unittest.TestCase):
     """
-    Tests for a moxa ioLogik e1262. (7x Thermocopule measurements)
+    Tests for a moxa ioLogik e1262. (8x Thermocopule measurements)
     """
 
     def setUp(self):
@@ -75,49 +109,67 @@ class Moxa1262Tests(unittest.TestCase):
 
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
 
-        # Sends a backdoor command to the device to set an analogue input (AI) value
-        self._lewis.backdoor_run_function_on_device("set_ir", (AI_REGISTER_OFFSET, [0]*16))
+        # Sends a backdoor command to the device to reset all input registers (IRs) to 0
+        reset_value = 0
+        self._lewis.backdoor_run_function_on_device("set_ir",
+                                                    (AI_REGISTER_OFFSET,
+                                                     [reset_value]*NUMBER_OF_CHANNELS*REGISTERS_PER_CHANNEL))
 
     @parameterized.expand([
-        ("CH{:01d}".format(channel), channel) for channel in CHANNELS
+        ("CH{:01d}".format(channel), channel, test_value) for channel, test_value in product(CHANNELS, TEST_VALUES)
     ])
-    def test_WHEN_an_AI_input_is_changed_THEN_that_channel_readback_updates(self, _, channel):
-        channel_address = AI_REGISTER_OFFSET + 2 * channel
+    def test_WHEN_an_AI_input_is_changed_THEN_that_channel_readback_updates(self, _, channel, test_value):
+        channel_address = AI_REGISTER_OFFSET + REGISTERS_PER_CHANNEL * channel
 
-        self._lewis.backdoor_run_function_on_device("set_1262_temperature", (channel_address, TEST_VALUE))
+        self._lewis.backdoor_run_function_on_device("set_1262_temperature", (channel_address, test_value))
 
-        self.ca.assert_that_pv_is_number("CH{:01d}:TEMP:RBV".format(channel), TEST_VALUE, tolerance=0.1)
+        self.ca.assert_that_pv_is_number("CH{:01d}:TEMP".format(channel), test_value, tolerance=max(0.1, 0.1*test_value))
 
     @parameterized.expand([
         ("CH{:01d}".format(channel), channel) for channel in CHANNELS
     ])
     def test_WHEN_device_temperature_is_below_low_limit_THEN_PV_shows_major_alarm(self, _, channel):
-        channel_address = AI_REGISTER_OFFSET + 2 * channel
+        channel_address = AI_REGISTER_OFFSET + REGISTERS_PER_CHANNEL * channel
+
+        valid_temperature = 0.5*(HIGH_ALARM_LIMIT + LOW_ALARM_LIMIT)
+
+        self._lewis.backdoor_run_function_on_device("set_1262_temperature", (channel_address, valid_temperature))
+
+        self.ca.assert_that_pv_is_number("CH{:01d}:TEMP".format(channel), valid_temperature, tolerance=0.1*valid_temperature)
+
+        self.ca.assert_that_pv_alarm_is("CH{:01d}:TEMP".format(channel), self.ca.Alarms.NONE)
 
         temperature_to_set = LOW_ALARM_LIMIT - 10.0
 
         self._lewis.backdoor_run_function_on_device("set_1262_temperature", (channel_address, temperature_to_set))
 
-        self.ca.assert_that_pv_is_number("CH{:01d}:TEMP:RBV".format(channel), temperature_to_set)
+        self.ca.assert_that_pv_is_number("CH{:01d}:TEMP".format(channel), temperature_to_set, tolerance=0.01*temperature_to_set)
 
-        self.ca.assert_that_pv_alarm_is("CH{:01d}:TEMP:RBV".format(channel), self.ca.Alarms.MAJOR)
+        self.ca.assert_that_pv_alarm_is("CH{:01d}:TEMP".format(channel), self.ca.Alarms.MAJOR)
 
     @parameterized.expand([
         ("CH{:01d}".format(channel), channel) for channel in CHANNELS
     ])
     def test_WHEN_device_temperature_is_above_high_limit_THEN_PV_shows_major_alarm(self, _, channel):
-        channel_address = AI_REGISTER_OFFSET + 2 * channel
+        channel_address = AI_REGISTER_OFFSET + REGISTERS_PER_CHANNEL * channel
+
+        valid_temperature = 0.5*(HIGH_ALARM_LIMIT + LOW_ALARM_LIMIT)
+
+        self._lewis.backdoor_run_function_on_device("set_1262_temperature", (channel_address, valid_temperature))
+
+        self.ca.assert_that_pv_is_number("CH{:01d}:TEMP".format(channel), valid_temperature, tolerance=0.1*valid_temperature)
+        self.ca.assert_that_pv_alarm_is("CH{:01d}:TEMP".format(channel), self.ca.Alarms.NONE)
 
         temperature_to_set = HIGH_ALARM_LIMIT + 10.0
 
         self._lewis.backdoor_run_function_on_device("set_1262_temperature", (channel_address, temperature_to_set))
 
-        self.ca.assert_that_pv_is_number("CH{:01d}:TEMP:RBV".format(channel), temperature_to_set)
+        self.ca.assert_that_pv_is_number("CH{:01d}:TEMP".format(channel), temperature_to_set, tolerance=0.01*temperature_to_set)
 
-        self.ca.assert_that_pv_alarm_is("CH{:01d}:TEMP:RBV".format(channel), self.ca.Alarms.MAJOR)
+        self.ca.assert_that_pv_alarm_is("CH{:01d}:TEMP".format(channel), self.ca.Alarms.MAJOR)
 
     @parameterized.expand([
         ("CH{:01d}".format(channel), channel) for channel in CHANNELS
     ])
     def test_WHEN_a_channel_is_aliased_THEN_a_PV_with_that_alias_exists(self, _, channel):
-        self.ca.assert_that_pv_exists(IOCS[0]["macros"]["CHAN{:01d}NAME".format(channel)])
+        self.ca.assert_that_pv_exists(CHANNEL_FORMAT.format(channel))

--- a/tests/moxa1262.py
+++ b/tests/moxa1262.py
@@ -2,11 +2,7 @@ from __future__ import division
 import unittest
 
 from utils.test_modes import TestModes
-from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
-from utils.testing import get_running_lewis_and_ioc
-from parameterized import parameterized
-from itertools import product
 
 from common_tests.moxa12XX import Moxa12XXBase
 
@@ -44,14 +40,7 @@ TEST_MODES = [TestModes.DEVSIM, ]
 NUMBER_OF_CHANNELS = 8
 REGISTERS_PER_CHANNEL = 2
 
-CHANNELS = range(NUMBER_OF_CHANNELS)
-
 AI_REGISTER_OFFSET = 0x810
-
-RANGE_STATUSES = {0: "NORMAL",
-                  1: "BURNOUT",
-                  2: "OVERRANGE",
-                  3: "UNDERRANGE"}
 
 LARGEST_OBSERVABLE_VALUE = 3.4e38
 SMALLEST_TYPE_K_MEAS = -180.0
@@ -97,79 +86,3 @@ class Moxa1262TestsFromBase(Moxa12XXBase, unittest.TestCase):
 
     def get_channel_format(self):
         return CHANNEL_FORMAT
-
-
-class Moxa1262Tests(unittest.TestCase):
-    """
-    Tests for a moxa ioLogik e1262. (8x Thermocopule measurements)
-    """
-
-    def setUp(self):
-        self._lewis, self._ioc = get_running_lewis_and_ioc("moxa12xx", DEVICE_PREFIX)
-
-        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
-
-        # Sends a backdoor command to the device to reset all input registers (IRs) to 0
-        reset_value = 0
-        self._lewis.backdoor_run_function_on_device("set_ir",
-                                                    (AI_REGISTER_OFFSET,
-                                                     [reset_value]*NUMBER_OF_CHANNELS*REGISTERS_PER_CHANNEL))
-
-    @parameterized.expand([
-        ("CH{:01d}".format(channel), channel, test_value) for channel, test_value in product(CHANNELS, TEST_VALUES)
-    ])
-    def test_WHEN_an_AI_input_is_changed_THEN_that_channel_readback_updates(self, _, channel, test_value):
-        channel_address = AI_REGISTER_OFFSET + REGISTERS_PER_CHANNEL * channel
-
-        self._lewis.backdoor_run_function_on_device("set_1262_temperature", (channel_address, test_value))
-
-        self.ca.assert_that_pv_is_number("CH{:01d}:TEMP".format(channel), test_value, tolerance=max(0.1, 0.1*test_value))
-
-    @parameterized.expand([
-        ("CH{:01d}".format(channel), channel) for channel in CHANNELS
-    ])
-    def test_WHEN_device_temperature_is_below_low_limit_THEN_PV_shows_major_alarm(self, _, channel):
-        channel_address = AI_REGISTER_OFFSET + REGISTERS_PER_CHANNEL * channel
-
-        valid_temperature = 0.5*(HIGH_ALARM_LIMIT + LOW_ALARM_LIMIT)
-
-        self._lewis.backdoor_run_function_on_device("set_1262_temperature", (channel_address, valid_temperature))
-
-        self.ca.assert_that_pv_is_number("CH{:01d}:TEMP".format(channel), valid_temperature, tolerance=0.1*valid_temperature)
-
-        self.ca.assert_that_pv_alarm_is("CH{:01d}:TEMP".format(channel), self.ca.Alarms.NONE)
-
-        temperature_to_set = LOW_ALARM_LIMIT - 10.0
-
-        self._lewis.backdoor_run_function_on_device("set_1262_temperature", (channel_address, temperature_to_set))
-
-        self.ca.assert_that_pv_is_number("CH{:01d}:TEMP".format(channel), temperature_to_set, tolerance=0.01*temperature_to_set)
-
-        self.ca.assert_that_pv_alarm_is("CH{:01d}:TEMP".format(channel), self.ca.Alarms.MAJOR)
-
-    @parameterized.expand([
-        ("CH{:01d}".format(channel), channel) for channel in CHANNELS
-    ])
-    def test_WHEN_device_temperature_is_above_high_limit_THEN_PV_shows_major_alarm(self, _, channel):
-        channel_address = AI_REGISTER_OFFSET + REGISTERS_PER_CHANNEL * channel
-
-        valid_temperature = 0.5*(HIGH_ALARM_LIMIT + LOW_ALARM_LIMIT)
-
-        self._lewis.backdoor_run_function_on_device("set_1262_temperature", (channel_address, valid_temperature))
-
-        self.ca.assert_that_pv_is_number("CH{:01d}:TEMP".format(channel), valid_temperature, tolerance=0.1*valid_temperature)
-        self.ca.assert_that_pv_alarm_is("CH{:01d}:TEMP".format(channel), self.ca.Alarms.NONE)
-
-        temperature_to_set = HIGH_ALARM_LIMIT + 10.0
-
-        self._lewis.backdoor_run_function_on_device("set_1262_temperature", (channel_address, temperature_to_set))
-
-        self.ca.assert_that_pv_is_number("CH{:01d}:TEMP".format(channel), temperature_to_set, tolerance=0.01*temperature_to_set)
-
-        self.ca.assert_that_pv_alarm_is("CH{:01d}:TEMP".format(channel), self.ca.Alarms.MAJOR)
-
-    @parameterized.expand([
-        ("CH{:01d}".format(channel), channel) for channel in CHANNELS
-    ])
-    def test_WHEN_a_channel_is_aliased_THEN_a_PV_with_that_alias_exists(self, _, channel):
-        self.ca.assert_that_pv_exists(CHANNEL_FORMAT.format(channel))


### PR DESCRIPTION
### Description of work

Adds tests for the moxa 1240 and 1262 devices

### To test
https://github.com/ISISComputingGroup/IBEX/issues/3918

### Acceptance criteria

- [ ] All tests pass
- [ ] The tests cover the functionality added by the new devices
- [ ] The tests are clear and can be used as a reference to the communications between the hardware and EPICS.