### PR TITLE
Ticket3962 moxa and julabo

### DIFF
--- a/common_tests/moxa12XX.py
+++ b/common_tests/moxa12XX.py
@@ -58,13 +58,23 @@ class Moxa12XXBase(object):
     def get_channel_format(self):
         pass
 
+    @abstractmethod
+    def get_scaling_factor(self):
+        pass
+
     def setUp(self):
 
         self.NUMBER_OF_CHANNELS = self.get_number_of_channels()
 
         self.CHANNELS = range(self.NUMBER_OF_CHANNELS)
 
+        self.SCALING_FACTOR = self.get_scaling_factor()
+
         self.low_alarm_limit, self.high_alarm_limit = self.get_alarm_limits()
+
+        # Alarm limits are in scaled units, these are normalised to 'device units' for clarity in the tests.
+        self.low_alarm_limit /= self.SCALING_FACTOR
+        self.high_alarm_limit /= self.SCALING_FACTOR
 
         self._lewis, self._ioc = get_running_lewis_and_ioc("moxa12xx", self.get_device_prefix())
 
@@ -82,53 +92,45 @@ class Moxa12XXBase(object):
             self._lewis.backdoor_run_function_on_device(self.get_setter_function_name(),
                                                         (self.get_starting_reg_addr() + register_offset, test_value))
 
-            self.ca.assert_that_pv_is_number("CH{:01d}:{PV}".format(channel, PV=self.get_PV_name()),
-                                             test_value, tolerance=0.1*abs(test_value))
+            expected_value = self.SCALING_FACTOR * test_value
 
-    def test_WHEN_device_voltage_is_below_low_limit_THEN_PV_shows_major_alarm(self):
-        for channel in range(self.get_number_of_channels()):
+            self.ca.assert_that_pv_is_number("CH{:01d}:{PV}".format(channel, PV=self.get_PV_name()),
+                                             expected_value, tolerance=0.1*abs(expected_value))
+
+    def test_WHEN_device_voltage_is_within_user_limits_THEN_PV_shows_no_alarm(self):
+        for channel in self.CHANNELS:
             register_offset = channel * self.get_registers_per_channel()
 
-            valid_value = 0.5*(self.low_alarm_limit + self.high_alarm_limit)
+            value_to_set = 0.5*(self.low_alarm_limit + self.high_alarm_limit)
 
-            self._lewis.backdoor_run_function_on_device(self.get_setter_function_name(),
-                                                        (self.get_starting_reg_addr() + register_offset, valid_value))
-
-            self.ca.assert_that_pv_is_number("CH{:01d}:{PV}".format(channel, PV=self.get_PV_name()),
-                                             valid_value, tolerance=0.1*valid_value)
-
-            self.ca.assert_that_pv_alarm_is("CH{:01d}:{PV}".format(channel, PV=self.get_PV_name()), self.ca.Alarms.NONE)
-
-            value_to_set = self.low_alarm_limit - 1.0
+            expected_value = self.SCALING_FACTOR * value_to_set
 
             self._lewis.backdoor_run_function_on_device(self.get_setter_function_name(),
                                                         (self.get_starting_reg_addr() + register_offset, value_to_set))
 
             self.ca.assert_that_pv_is_number("CH{:01d}:{PV}".format(channel, PV=self.get_PV_name()),
-                                             value_to_set, tolerance=0.1*value_to_set)
+                                             expected_value, tolerance=0.1*abs(expected_value))
 
             self.ca.assert_that_pv_alarm_is("CH{:01d}:{PV}".format(channel, PV=self.get_PV_name()),
-                                            self.ca.Alarms.MAJOR)
+                                            self.ca.Alarms.NONE)
 
-    def test_WHEN_device_voltage_is_above_high_limit_THEN_PV_shows_major_alarm(self):
-        for channel in range(self.get_number_of_channels()):
+    def test_WHEN_device_voltage_is_outside_user_limits_THEN_PV_shows_major_alarm(self):
+        test_values = [self.low_alarm_limit - 1.0, self.high_alarm_limit + 1.0]
+
+        for channel, value_to_set in product(self.CHANNELS, test_values):
             register_offset = channel * self.get_registers_per_channel()
 
-            valid_value = 0.5*(self.low_alarm_limit + self.high_alarm_limit)
-
-            self._lewis.backdoor_run_function_on_device(self.get_setter_function_name(),
-                                                        (self.get_starting_reg_addr() + register_offset, valid_value))
-
-            self.ca.assert_that_pv_alarm_is("CH{:01d}:{PV}".format(channel, PV=self.get_PV_name()), self.ca.Alarms.NONE)
-
-            value_to_set = self.high_alarm_limit + 1.0
+            expected_value = self.SCALING_FACTOR * value_to_set
 
             self._lewis.backdoor_run_function_on_device(self.get_setter_function_name(),
                                                         (self.get_starting_reg_addr() + register_offset, value_to_set))
+
+            self.ca.assert_that_pv_is_number("CH{:01d}:{PV}".format(channel, PV=self.get_PV_name()),
+                                             expected_value, tolerance=0.1*abs(expected_value))
 
             self.ca.assert_that_pv_alarm_is("CH{:01d}:{PV}".format(channel, PV=self.get_PV_name()),
                                             self.ca.Alarms.MAJOR)
 
     def test_WHEN_a_channel_is_aliased_THEN_a_PV_with_that_alias_exists(self):
-        for channel in range(self.get_number_of_channels()):
+        for channel in self.CHANNELS:
             self.ca.assert_that_pv_exists(self.get_channel_format().format(channel))

--- a/tests/moxa1240.py
+++ b/tests/moxa1240.py
@@ -1,20 +1,22 @@
 from __future__ import division
 import unittest
+from itertools import product
 
 from common_tests.moxa12XX import Moxa12XXBase
 
 from utils.test_modes import TestModes
 from utils.ioc_launcher import get_default_ioc_dir
 
-
 # Device prefix
 DEVICE_PREFIX = "MOXA12XX_01"
 CHANNEL_FORMAT = "CHANNEL{:01d}"
 
-LOW_ALARM_LIMIT = 2.0
-HIGH_ALARM_LIMIT = 8.0
 
 NUMBER_OF_CHANNELS = 8
+
+SCALING_FACTOR = 10.0
+LOW_ALARM_LIMIT = 2.0 * SCALING_FACTOR
+HIGH_ALARM_LIMIT = 8.0 * SCALING_FACTOR
 
 macros = {
     "IEOS": r"\\r\\n",
@@ -25,6 +27,7 @@ for channel in range(NUMBER_OF_CHANNELS):
     macros["CHAN{:1d}NAME".format(channel)] = CHANNEL_FORMAT.format(channel)
     macros["CHAN{:1d}LOWLIMIT".format(channel)] = LOW_ALARM_LIMIT
     macros["CHAN{:1d}HILIMIT".format(channel)] = HIGH_ALARM_LIMIT
+    macros["CHAN{:1d}SCLEFACTR".format(channel)] = SCALING_FACTOR
 
 IOCS = [
     {
@@ -53,14 +56,15 @@ TEST_VALUES = [MIN_VOLT_MEAS,
 
 class Moxa1240TestsFromBase(Moxa12XXBase, unittest.TestCase):
     """
-    Tests for the moxa 40 (8x DV voltage/Current measurements) imported from base class
+    Tests for the moxa 1240 (8x DC voltage/current measurements) inherited from base class.
+    The unscaled readback test is not inherited.
     """
 
     def get_device_prefix(self):
         return DEVICE_PREFIX
 
     def get_PV_name(self):
-        return "AI:RBV"
+        return "AI:SCALED"
 
     def get_number_of_channels(self):
         return NUMBER_OF_CHANNELS
@@ -89,3 +93,15 @@ class Moxa1240TestsFromBase(Moxa12XXBase, unittest.TestCase):
     def get_channel_format(self):
         return CHANNEL_FORMAT
 
+    def get_scaling_factor(self):
+        return SCALING_FACTOR
+
+    def test_WHEN_an_AI_input_is_changed_THEN_that_unscaled_channel_readback_updates(self):
+        for channel, test_value in product(CHANNELS, TEST_VALUES):
+            register_offset = channel * self.get_registers_per_channel()
+
+            self._lewis.backdoor_run_function_on_device(self.get_setter_function_name(),
+                                                        (self.get_starting_reg_addr() + register_offset, test_value))
+
+            self.ca.assert_that_pv_is_number("CH{:01d}:AI:RBV".format(channel, PV=self.get_PV_name()),
+                                             test_value, tolerance=0.1*abs(test_value))

--- a/tests/moxa1262.py
+++ b/tests/moxa1262.py
@@ -15,6 +15,8 @@ HIGH_ALARM_LIMIT = 80.0
 
 NUMBER_OF_CHANNELS = 8
 
+SCALING_FACTOR = 1.0
+
 macros = {
     "IEOS": r"\\r\\n",
     "OEOS": r"\\r\\n",
@@ -86,3 +88,6 @@ class Moxa1262TestsFromBase(Moxa12XXBase, unittest.TestCase):
 
     def get_channel_format(self):
         return CHANNEL_FORMAT
+
+    def get_scaling_factor(self):
+        return SCALING_FACTOR

--- a/tests/wbvalve.py
+++ b/tests/wbvalve.py
@@ -22,7 +22,7 @@ IOCS = [
 ]
 
 
-TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
+TEST_MODES = [TestModes.DEVSIM, ]
 
 
 class WbvalveTests(unittest.TestCase):
@@ -34,7 +34,7 @@ class WbvalveTests(unittest.TestCase):
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
         self._lewis.backdoor_run_function_on_device('reset')
 
-    @parameterized.expand(['wb1', 'wb2'])
+    @parameterized.expand(['J1', 'J2'])
     @skip_if_recsim("Recsim behaviour not defined")
     def test_GIVEN_an_ioc_WHEN_set_valve_to_wb1on_THEN_status_is_wb1on(self, expected_value):
         self.ca.assert_setting_setpoint_sets_readback(expected_value, 'POS')


### PR DESCRIPTION
# Description of work

Bug fixes for the Moxa 12XX and WBValve tests.

The moxa12XX/moxa1240 needed to have extra tests added due to a patch which allowed the user to scale the measured value.

The WBValve was patched to change with the position names which were updated in the IOC but not the tests

# To test
https://github.com/ISISComputingGroup/IBEX/issues/3962

# Acceptance criteria
- [x] All tests pass
- [x] The Moxa1240 is tested in both raw 'device' units and scaled 'user' units.