### PR TITLE
Ticket4160 seprtr unstable bug

### DIFF
--- a/tests/separator.py
+++ b/tests/separator.py
@@ -412,13 +412,12 @@ class StabilityTests(unittest.TestCase):
 
         return voltage_instability
 
-    def get_out_of_range_samples(self, current_values, voltage_values, filter_stride_len=0):
+    def get_out_of_range_samples(self, current_values, voltage_values):
         """
         Calculates the number of points which lie out of stability limits for a current and voltage dataset.
         Args:
             current_values: Array of input current values
             voltage_values: Array of input voltage values
-            filter_stride_len: Integer, stride length used if filtering is applied to an input array
 
         Returns:
             out_of_range_count: Integer, the number of samples in the dataset which are out of range
@@ -429,9 +428,6 @@ class StabilityTests(unittest.TestCase):
         voltage_instability = self.evaluate_voltage_instability(voltage_values)
 
         overall_instability = [curr or volt for curr, volt in zip(current_instability, voltage_instability)]
-
-        # Filtering removes stride_len elements from end of array
-        overall_instability = overall_instability[:len(voltage_instability)-filter_stride_len]
 
         out_of_range_count = sum(overall_instability)
 
@@ -471,8 +467,7 @@ class StabilityTests(unittest.TestCase):
 
         averaged_volt_data = apply_average_filter(volt_data, stride=STRIDE_LENGTH)
 
-        expected_out_of_range_samples = self.get_out_of_range_samples(curr_data, averaged_volt_data,
-                                                                      filter_stride_len=STRIDE_LENGTH)
+        expected_out_of_range_samples = self.get_out_of_range_samples(curr_data, averaged_volt_data)
 
         self.ca.assert_that_pv_is_number("_STABILITYCHECK", expected_out_of_range_samples,
                                          tolerance=0.05*expected_out_of_range_samples)
@@ -541,8 +536,7 @@ class StabilityTests(unittest.TestCase):
 
         averaged_volt_data = apply_average_filter(DAQ_DATA, stride=STRIDE_LENGTH)
 
-        expected_out_of_range_samples = self.get_out_of_range_samples(CURRENT_DATA, averaged_volt_data,
-                                                                      filter_stride_len=STRIDE_LENGTH)
+        expected_out_of_range_samples = self.get_out_of_range_samples(CURRENT_DATA, averaged_volt_data)
 
         expected_out_of_range_samples *= number_of_writes * SAMPLETIME
 

--- a/tests/separator.py
+++ b/tests/separator.py
@@ -459,7 +459,7 @@ class StabilityTests(unittest.TestCase):
 
         ("unsteady_current_steady_voltage", CURRENT_DATA, [VOLT_STEADY] * SAMPLE_LEN),
 
-        ("unsteady_current_and_voltage", simulate_current_data(), simulate_voltage_data())
+        ("unsteady_current_and_voltage", CURRENT_DATA, VOLTAGE_DATA)
     ])
     def test_GIVEN_current_and_voltage_data_WHEN_limits_are_tested_THEN_number_of_samples_out_of_range_returned(self, _, curr_data, volt_data):
         self.write_simulated_current(curr_data)
@@ -591,7 +591,7 @@ class StabilityTests(unittest.TestCase):
 
         # THEN
         self.ca.assert_that_pv_is_number("UNSTABLETIME", expected_out_of_range_samples,
-                                         tolerance=0.05*expected_out_of_range_samples)
+                                         tolerance=0.025*expected_out_of_range_samples)
 
     def test_GIVEN_power_supply_switched_on_WHEN_power_supply_out_of_stability_threshold_THEN_stability_PV_equals_zero_and_goes_into_alarm(self):
         # GIVEN

--- a/tests/separator.py
+++ b/tests/separator.py
@@ -472,16 +472,6 @@ class StabilityTests(unittest.TestCase):
         self.ca.assert_that_pv_is_number("_STABILITYCHECK", expected_out_of_range_samples,
                                          tolerance=0.05*expected_out_of_range_samples)
 
-    def test_GIVEN_noisy_voltage_data_WHEN_moving_average_is_applied_THEN_only_true_data_spikes_show_as_unstable(self):
-        curr_data = [CURR_STEADY]*SAMPLE_LEN
-        self.write_simulated_current(curr_data)
-        self.write_simulated_voltage(DAQ_DATA)
-
-        expected_out_of_range_samples = self.get_out_of_range_samples(curr_data, apply_average_filter(DAQ_DATA))
-
-        self.ca.assert_that_pv_is_number("_STABILITYCHECK", expected_out_of_range_samples + STRIDE_LENGTH,
-                                         tolerance=0.05*expected_out_of_range_samples)
-
     def test_GIVEN_noisy_voltage_data_WHEN_moving_average_is_applied_THEN_averaged_data_has_fewer_out_of_range_points(self):
         curr_data = [CURR_STEADY]*SAMPLE_LEN
         self.write_simulated_current(curr_data)
@@ -509,7 +499,9 @@ class StabilityTests(unittest.TestCase):
         self.ca.set_pv_value("WINDOWSIZE", length_of_buffer)
         self.ca.set_pv_value("RESETWINDOW", 1)
 
-        expected_out_of_range_samples = self.get_out_of_range_samples(curr_data, volt_data) * writes_per_second
+        averaged_volt_data = apply_average_filter(volt_data, stride=STRIDE_LENGTH)
+
+        expected_out_of_range_samples = self.get_out_of_range_samples(curr_data, averaged_volt_data) * writes_per_second
 
         self.STOP_DATA_THREAD.clear()
 


### PR DESCRIPTION
### Description of work

Changed the voltage upper and lower limit constants to match the data used in the tests.

Added filtering stride length into test value calculations

### To test
https://github.com/ISISComputingGroup/IBEX/issues/4160

### Acceptance criteria
- [x] All tests pass
- [x] 'Filtered data' values in the tests are calculated correctly
- [x] Tolerances on tests involving the `UNSTABLETIME` PV are smaller than `SAMPLETIME`
     - This is so the extra 1 data point which was being returned due to filtering array lengths is tested for