### PR TITLE
Add tests for explicitly setting calc mode

### DIFF
--- a/tests/jsco4180.py
+++ b/tests/jsco4180.py
@@ -37,6 +37,7 @@ class Jsco4180Tests(unittest.TestCase):
 
     def resetIocRecords(self):
         self.ca.set_pv_value("TIME", 0)
+        self.ca.set_pv_value("TIME:CALC:SP", "Time")
         self.ca.set_pv_value("TIME:RUN:SP", 60)
         self.ca.set_pv_value("TIME:MODE", "STOPPED")
         self.ca.set_pv_value("FLOWRATE:SP", 0.010)
@@ -214,4 +215,44 @@ class Jsco4180Tests(unittest.TestCase):
         self.ca.set_pv_value("TIMED:SP", 1)
         expected_value = "TIMED"
         self.ca.assert_that_pv_is("TIME:MODE", expected_value, timeout=3)
+
+    def test_GIVEN_calc_mode_is_time_WHEN_setting_time_THEN_time_and_volume_are_correctly_set(self):
+        expected_time = 600
+        expected_volume = 0.1
+        self.ca.set_pv_value("TIME:CALC:SP", "Time")
+
+        self.ca.set_pv_value("TIME:RUN:SP", expected_time)
+
+        self.ca.assert_that_pv_is("TIME:RUN:SP", expected_time, timeout=3)
+        self.ca.assert_that_pv_is("TIME:VOL:SP", expected_volume, timeout=3)
+
+    def test_GIVEN_calc_mode_is_time_WHEN_setting_volume_THEN_set_is_ignored(self):
+        expected_time = self.ca.get_pv_value("TIME:RUN:SP")
+        expected_volume = self.ca.get_pv_value("TIME:VOL:SP")
+        self.ca.set_pv_value("TIME:CALC:SP", "Time")
+
+        self.ca.set_pv_value("TIME:VOL:SP", expected_volume * 10)
+
+        self.ca.assert_that_pv_is("TIME:RUN:SP", expected_time, timeout=3)
+        self.ca.assert_that_pv_is("TIME:VOL:SP", expected_volume, timeout=3)
+
+    def test_GIVEN_calc_mode_is_volume_WHEN_setting_volume_THEN_time_and_volume_are_correctly_set(self):
+        expected_time = 600
+        expected_volume = 0.1
+        self.ca.set_pv_value("TIME:CALC:SP", "Volume")
+
+        self.ca.set_pv_value("TIME:VOL:SP", expected_volume)
+
+        self.ca.assert_that_pv_is("TIME:RUN:SP", expected_time, timeout=3)
+        self.ca.assert_that_pv_is("TIME:VOL:SP", expected_volume, timeout=3)
+
+    def test_GIVEN_calc_mode_is_volume_WHEN_setting_time_THEN_set_is_ignored(self):
+        expected_time = self.ca.get_pv_value("TIME:RUN:SP")
+        expected_volume = self.ca.get_pv_value("TIME:VOL:SP")
+        self.ca.set_pv_value("TIME:CALC:SP", "Volume")
+
+        self.ca.set_pv_value("TIME:RUN:SP", expected_time * 10)
+
+        self.ca.assert_that_pv_is("TIME:RUN:SP", expected_time, timeout=3)
+        self.ca.assert_that_pv_is("TIME:VOL:SP", expected_volume, timeout=3)
 


### PR DESCRIPTION
Added tests to check the behaviour of the IOC is correct when selecting either of the two calculation methods for running the pump in timed mode. 

I.e. writing values to `TIME:RUN:SP` and subsequent calculation of `TIME:VOL:SP` is only allowed when `TIME:CALC:SP` is set to `Time`, and vice versa for `Volume`.

Ticket:
https://github.com/ISISComputingGroup/IBEX/issues/4029

Related PRs:
https://github.com/ISISComputingGroup/ibex_gui/pull/891
https://github.com/ISISComputingGroup/EPICS-Jsco4180/pull/4