### PR TITLE
Added a new REFL test for in_mode parameters

### DIFF
--- a/test_config/good_for_refl/refl/config.py
+++ b/test_config/good_for_refl/refl/config.py
@@ -57,6 +57,9 @@ def get_beamline():
     # Do not want parameters for init tests to be moved by other tests.
     params_without_init = [s3_enabled, slit1_pos, theta_ang, slit3_pos, detector_position, detector_angle,
                            theta_auto]
+    
+    params_for_mode_testing = [slit1_pos, theta_ang, slit3_pos, detector_position, s3_enabled]
+
     # DRIVES
     drivers = [DisplacementDriver(s1, MotorPVWrapper("MOT:MTR0101")),
                DisplacementDriver(s3, MotorPVWrapper("MOT:MTR0102"), S3_OUT_POSITION),
@@ -71,7 +74,8 @@ def get_beamline():
     nr_inits = {}
     nr_mode = BeamlineMode("NR", [param.name for param in params_without_init], nr_inits)
     polarised_mode = BeamlineMode("POLARISED", [param.name for param in params_without_init], nr_inits)
-    modes = [nr_mode, polarised_mode]
+    testing_mode = BeamlineMode("TESTING", [param.name for param in params_for_mode_testing], nr_inits)
+    modes = [nr_mode, polarised_mode, testing_mode]
 
     beam_start = PositionAndAngle(0.0, 0.0, 0.0)
     bl = Beamline(comps, params_all, drivers, modes, beam_start)

--- a/tests/refl.py
+++ b/tests/refl.py
@@ -214,3 +214,24 @@ class ReflTests(unittest.TestCase):
         expected = IN_COMP_INIT_POS
 
         self.ca.assert_that_pv_is("PARAM:IN_POS", expected)
+
+    def test_GIVEN_mode_is_NR_WHEN_change_mode_THEN_monitor_updates_to_new_mode_and_PVs_inmode_are_labeled_as_such(self):
+        
+        expected_mode_value = "TESTING"
+        PARAM_PREFIX = "PARAM:"
+        IN_MODE_SUFFIX = ":IN_MODE"
+        expected_in_mode_value = "YES"
+        expected_out_of_mode_value = "NO"
+
+        with self.ca.assert_that_pv_monitor_is("BL:MODE", expected_mode_value), \
+             self.ca.assert_that_pv_monitor_is("BL:MODE.VAL", expected_mode_value):
+                self.ca.set_pv_value("BL:MODE:SP", expected_mode_value)
+
+        test_in_mode_param_names = ["S1", "S3", "THETA", "DET_POS", "S3_ENABLED"]
+        test_out_of_mode_params = ["DET_ANG", "THETA_AUTO"]
+
+        for param in test_in_mode_param_names:
+            self.ca.assert_that_pv_monitor_is("{}{}{}".format(PARAM_PREFIX, param, IN_MODE_SUFFIX), expected_in_mode_value)
+        
+        for param in test_out_of_mode_params:
+            self.ca.assert_that_pv_monitor_is("{}{}{}".format(PARAM_PREFIX, param, IN_MODE_SUFFIX), expected_out_of_mode_value)


### PR DESCRIPTION
### Description of work

This ticket is part of the work to provide the parameters found on the 'Components: Positions relative to beam' screen on the opi in the same order in which they are found in the config. The work also provides an indication as to whether the parameter is in the mode or not. 

### To test

[#4264](https://github.com/ISISComputingGroup/IBEX/issues/4264)
