### PR TITLE
Ticket 4611: Double check existence PV and remove autosave files

### DIFF
--- a/common_tests/jaws_manager_utils.py
+++ b/common_tests/jaws_manager_utils.py
@@ -2,7 +2,6 @@ from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import IOCRegister
 import six
 import abc
-from time import sleep
 
 UNDERLYING_GAP_SP = "MOT:JAWS{}:{}GAP:SP"
 UNDERLYING_CENT_SP = "MOT:JAWS{}:{}CENT:SP"
@@ -16,11 +15,11 @@ class JawsManagerBase(object):
     """
     def setUp(self):
         self._ioc = IOCRegister.get_running("GALIL_01")
-        ChannelAccess().assert_that_pv_exists("MOT:MTR0101", timeout=30)
-        for jaw in range(1, self.get_num_of_jaws() + 1):
-            ChannelAccess().assert_that_pv_exists(UNDERLYING_GAP_SP.format(jaw, "V"), timeout=30)
-            ChannelAccess().assert_that_pv_exists(UNDERLYING_GAP_SP.format(jaw, "H"), timeout=30)
         self.ca = ChannelAccess()
+        self.ca.assert_that_pv_exists("MOT:MTR0101", timeout=30)
+        for jaw in range(1, self.get_num_of_jaws() + 1):
+            self.ca.assert_that_pv_exists(UNDERLYING_GAP_SP.format(jaw, "V"), timeout=30)
+            self.ca.assert_that_pv_exists(UNDERLYING_GAP_SP.format(jaw, "H"), timeout=30)
         self.ca.assert_that_pv_exists(self.get_sample_pv() + ":{}GAP:SP".format("V"), timeout=30)
 
     def get_sample_pv(self):

--- a/run_tests.py
+++ b/run_tests.py
@@ -25,7 +25,7 @@ def clean_environment():
     Cleans up the test environment between tests.
     """
     autosave_directory = os.path.join(var_dir, "autosave")
-    files = glob.glob('{}/*/*'.format(autosave_directory))
+    files = glob.glob('{}/*SIM/*'.format(autosave_directory))
     for autosave_file in files:
         try:
             os.remove(autosave_file)

--- a/run_tests.py
+++ b/run_tests.py
@@ -8,6 +8,7 @@ import sys
 import traceback
 import unittest
 import xmlrunner
+import glob
 
 from run_utils import package_contents, modified_environment
 from run_utils import ModuleTests
@@ -17,6 +18,19 @@ from utils.emulator_launcher import LewisLauncher, NullEmulatorLauncher
 from utils.ioc_launcher import IocLauncher, EPICS_TOP
 from utils.free_ports import get_free_ports
 from utils.test_modes import TestModes
+
+
+def clean_environment():
+    """
+    Cleans up the test environment between tests.
+    """
+    autosave_directory = os.path.join(var_dir, "autosave")
+    files = glob.glob('{}/*/*'.format(autosave_directory))
+    for autosave_file in files:
+        try:
+            os.remove(autosave_file)
+        except Exception as e:
+            print("Failed to delete {}: {}".format(autosave_file, e))
 
 
 def make_device_launchers_from_module(test_module, mode):
@@ -103,6 +117,7 @@ def load_and_run_tests(test_names, failfast):
         modules_to_be_tested_in_current_mode = [module for module in modules_to_be_tested if mode in module.modes]
 
         for module in modules_to_be_tested_in_current_mode:
+            clean_environment()
             device_launchers = make_device_launchers_from_module(module.file, mode)
             test_results.append(
                 run_tests(arguments.prefix, module.tests, device_collection_launcher(device_launchers), failfast))

--- a/tests/attocube.py
+++ b/tests/attocube.py
@@ -4,7 +4,6 @@ from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
 from utils.testing import get_running_lewis_and_ioc
-from time import sleep
 
 
 DEVICE_PREFIX = "ATTOCUBE_01"
@@ -13,6 +12,8 @@ EMULATOR = "attocube_anc350"
 IOCS = [
     {
         "name": DEVICE_PREFIX,
+        "custom_prefix": "MOT",
+        "pv_for_existence": "MTR0101",
         "directory": get_default_ioc_dir("ATTOCUBE"),
         "macros": {
             "MTRCTRL": 1
@@ -24,6 +25,9 @@ IOCS = [
 
 TEST_MODES = [TestModes.DEVSIM]
 
+MOTOR_PV = "MTR0101"
+MOTOR_RBV = MOTOR_PV + ".RBV"
+
 
 class AttocubeTests(unittest.TestCase):
     """
@@ -31,16 +35,16 @@ class AttocubeTests(unittest.TestCase):
     """
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc(EMULATOR, DEVICE_PREFIX)
-        self.ca = ChannelAccess(device_prefix=None)
+        self.ca = self._ioc.ca
         self._lewis.backdoor_set_on_device('connected', True)
-        self.ca.assert_that_pv_exists("MOT:MTR0101.RBV")
+        self.ca.assert_that_pv_exists(MOTOR_RBV)
 
     def test_WHEN_moved_to_position_THEN_position_reached(self):
         position_setpoint = 5
-        self.ca.set_pv_value("MOT:MTR0101", position_setpoint)
-        self.ca.assert_that_pv_value_is_increasing("MOT:MTR0101.RBV", 1)
-        self.ca.assert_that_pv_is_number("MOT:MTR0101.RBV", position_setpoint, timeout=10)
+        self.ca.set_pv_value(MOTOR_PV, position_setpoint)
+        self.ca.assert_that_pv_value_is_increasing(MOTOR_RBV, 1)
+        self.ca.assert_that_pv_is_number(MOTOR_RBV, position_setpoint, timeout=10)
 
     def test_GIVEN_device_not_connected_THEN_pv_in_alarm(self):
         self._lewis.backdoor_set_on_device('connected', False)
-        self.ca.assert_that_pv_alarm_is('MOT:MTR0101', ChannelAccess.Alarms.INVALID, timeout=60)
+        self.ca.assert_that_pv_alarm_is(MOTOR_PV, ChannelAccess.Alarms.INVALID, timeout=60)

--- a/tests/gem_jaws_manager.py
+++ b/tests/gem_jaws_manager.py
@@ -19,7 +19,8 @@ test_path = os.path.realpath(os.path.join(os.getenv("EPICS_KIT_ROOT"),
 IOCS = [{
             "name": "GALIL_0{}".format(i),
             "directory": get_default_ioc_dir("GALIL", i),
-            "pv_for_existence": "AXIS1",
+            "custom_prefix": "MOT",
+            "pv_for_existence": "MTR0{}01".format(i),
             "macros": {
                 "GALILADDR": GALIL_ADDR,
                 "MTRCTRL": "0{}".format(i),

--- a/tests/jaws_manager.py
+++ b/tests/jaws_manager.py
@@ -18,7 +18,8 @@ test_path = os.path.realpath(os.path.join(os.getenv("EPICS_KIT_ROOT"),
 IOCS = [{
             "name": "GALIL_01",
             "directory": get_default_ioc_dir("GALIL"),
-            "pv_for_existence": "AXIS1",
+            "custom_prefix": "MOT",
+            "pv_for_existence": "MTR0101",
             "macros": {
                 "GALILADDR": GALIL_ADDR,
                 "MTRCTRL": "01",

--- a/tests/nimrod_jaws_manager.py
+++ b/tests/nimrod_jaws_manager.py
@@ -18,7 +18,8 @@ test_path = os.path.realpath(os.path.join(os.getenv("EPICS_KIT_ROOT"),
 IOCS = [{
             "name": "GALIL_0{}".format(i),
             "directory": get_default_ioc_dir("GALIL", i),
-            "pv_for_existence": "AXIS1",
+            "custom_prefix": "MOT",
+            "pv_for_existence": "MTR0{}01".format(i),
             "macros": {
                 "GALILADDR": GALIL_ADDR,
                 "MTRCTRL": "0{}".format(i),

--- a/tests/polaris_jaws_manager.py
+++ b/tests/polaris_jaws_manager.py
@@ -18,7 +18,8 @@ test_path = os.path.realpath(os.path.join(os.getenv("EPICS_KIT_ROOT"),
 IOCS = [{
             "name": "GALIL_0{}".format(i),
             "directory": get_default_ioc_dir("GALIL", i),
-            "pv_for_existence": "AXIS1",
+            "custom_prefix": "MOT",
+            "pv_for_existence": "MTR0{}01".format(i),
             "macros": {
                 "GALILADDR": GALIL_ADDR,
                 "MTRCTRL": "0{}".format(i),
@@ -29,7 +30,9 @@ IOCS = [{
 IOCS.append(
         {
             "name": "INSTETC",
-            "directory": get_default_ioc_dir("INSTETC")
+            "directory": get_default_ioc_dir("INSTETC"),
+            "custom_prefix": "CS",
+            "pv_for_existence": "MANAGER",
         })
 
 TEST_MODES = [TestModes.RECSIM]

--- a/utils/ioc_launcher.py
+++ b/utils/ioc_launcher.py
@@ -63,7 +63,7 @@ class check_existence_pv:
         try:
             self.ca.assert_that_pv_exists(self.test_pv)
         except AssertionError as ex:
-            raise AssertionError("IOC '{}' appears to not be running: {}".format(self.device, ex))
+            print("Warning, {} still does not exist after IOC start".format(self.test_pv))
 
 
 class IOCRegister(object):

--- a/utils/ioc_launcher.py
+++ b/utils/ioc_launcher.py
@@ -39,7 +39,7 @@ def get_default_ioc_dir(iocname, iocnum=1):
     return os.path.join(EPICS_TOP, "ioc", "master", iocname, "iocBoot", "ioc{}-IOC-{:02d}".format(iocname, iocnum))
 
 
-class check_existence_pv:
+class check_existence_pv(object):
     """
     Checks to see if a IOC has been started correctly by asserting that a pv does not exist on entry and does on exit
     Args:


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/4611

This PR does a few things:
* Hardens up the ATTOCUBE and JAW MANAGER tests
* Removes test autosave files between tests (see https://github.com/ISISComputingGroup/EPICS/pull/180)
* Warns if the PV that is being checked to confirm the IOC is not running still doesn't exist after running the IOC
* Bit of refactoring of the ioc_launcher to take advantage of OOP

To test:
* Confirm ATTOCUBE and JAWS_MANAGER tests work
* Confirm autosave files are removed before each test
* Run a test that checks for a PV that doesn't exist ever and confirm that it warns after the IOC has been run