### PR TITLE
Ticket 4611: Fixed logic to only start test modules and all test classes

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -108,7 +108,8 @@ def load_and_run_tests(test_names, failfast):
     modes = set()
 
     for module in modules_to_be_tested:
-        module.tests = [test for test in test_names if test.startswith(module.name)]
+        # Add tests that are either the module or a subset of the module i.e. module.TestClass
+        module.tests = [test for test in test_names if test == module.name or test.startswith(module.name + ".")]
         modes.update(module.modes)
 
     test_results = []


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/4611

To test:
* Run `python run_tests.py -t gem_jaws gem_jaws_manager` before the merge, confirm that the `gem_jaws_manager` tests are also run in the `gem_jaws` environment
* Run the same after and confirm this isn't the case
* Confirm that you can still run test classes by doing something like `python run_tests.py -t attocube.AttocubeTests.test_WHEN_moved_to_position_THEN_position_reached attocube.AttocubeTests.test_GIVEN_device_not_connected_THEN_pv_in_alarm`