### PR TITLE
Ticket 4611: Added correct existence PVs

### DIFF
--- a/tests/fins.py
+++ b/tests/fins.py
@@ -13,7 +13,8 @@ IOCS = [
     {
         "name": DEVICE_PREFIX,
         "directory": get_default_ioc_dir("FINS"),
-        "macros": { "PLCIP" : "127.0.0.1" },
+        "pv_for_existence": "BENCH:FLOW1",
+        "macros": {"PLCIP" : "127.0.0.1"},
         "emulator": "Fins",
     },
 ]

--- a/tests/gem_jaws.py
+++ b/tests/gem_jaws.py
@@ -10,6 +10,8 @@ IOCS = [
     {
         "name": "LINMOT_01",
         "directory": get_default_ioc_dir("LINMOT"),
+        "custom_prefix": "MOT",
+        "pv_for_existence": "MTR0101",
         "macros": {
             "AXIS1": "yes",
             "AXIS2": "yes",


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/4611

The GEM jaws are now failing because the framework is not waiting for the IOC to be stopped as it's looking for a PV that never existed.

To test:
* Run the gem_jaws tests w/o this PR confirm there is a warning about the DISABLE PV not existing
* Run again with this PR, this warning is gone