### PR TITLE
tests now check to see comms go back to invalid after a motor pv is updated

### DIFF
--- a/tests/attocube.py
+++ b/tests/attocube.py
@@ -4,7 +4,8 @@ from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
 from utils.testing import get_running_lewis_and_ioc
-from time import sleep
+import time
+
 
 DEVICE_PREFIX = "ATTOCUBE_01"
 EMULATOR = "attocube_anc350"
@@ -40,12 +41,20 @@ class AttocubeTests(unittest.TestCase):
         self.ca.assert_that_pv_exists(MOTOR_RBV)
 
     def test_WHEN_moved_to_position_THEN_position_reached(self):
-        position_setpoint = 10
+        position_setpoint = 20
         self.ca.set_pv_value(MOTOR_PV, position_setpoint)
         self.ca.assert_that_pv_value_is_increasing(MOTOR_RBV, 1)
-        self.ca.assert_that_pv_is_number(MOTOR_RBV, position_setpoint, timeout=10)
+        self.ca.assert_that_pv_is_number(MOTOR_RBV, position_setpoint, timeout=20)
 
-    @unittest.skipIf(True, 'This should work but comms alarms seem to be somewhat broken see #4618')
     def test_GIVEN_device_not_connected_THEN_pv_in_alarm(self):
         self._lewis.backdoor_set_on_device('connected', False)
-        self.ca.assert_that_pv_alarm_is(MOTOR_PV, ChannelAccess.Alarms.INVALID, timeout=60)
+        self.ca.assert_that_pv_alarm_is(MOTOR_PV, ChannelAccess.Alarms.INVALID, timeout=30)
+        self._lewis.backdoor_set_on_device('connected', True)
+
+    def test_GIVEN_device_not_connected_WHEN_motor_val_set_THEN_pv_returns_to_alarm(self):
+        self._lewis.backdoor_set_on_device('connected', False)
+        time.sleep(10)
+        position_setpoint = 5
+        self.ca.set_pv_value(MOTOR_PV, position_setpoint)
+        self.ca.assert_that_pv_alarm_is(MOTOR_PV, ChannelAccess.Alarms.INVALID, timeout=30)
+        self._lewis.backdoor_set_on_device('connected', True)

--- a/tests/attocube.py
+++ b/tests/attocube.py
@@ -4,7 +4,6 @@ from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
 from utils.testing import get_running_lewis_and_ioc
-import time
 
 
 DEVICE_PREFIX = "ATTOCUBE_01"
@@ -53,7 +52,7 @@ class AttocubeTests(unittest.TestCase):
 
     def test_GIVEN_device_not_connected_WHEN_motor_val_set_THEN_pv_returns_to_alarm(self):
         self._lewis.backdoor_set_on_device('connected', False)
-        time.sleep(10)
+        self.ca.assert_that_pv_alarm_is(MOTOR_PV, ChannelAccess.Alarms.INVALID, timeout=10)
         position_setpoint = 5
         self.ca.set_pv_value(MOTOR_PV, position_setpoint)
         self.ca.assert_that_pv_alarm_is(MOTOR_PV, ChannelAccess.Alarms.INVALID, timeout=30)


### PR DESCRIPTION
### Description of work

Now tests for whether the IOC puts a PV back into alarm after the alarm has been cleared by somebody updating the PV. A previous test, which checked for whether a motor is moving and reaches an endpoint after being told to move, began failing incorrectly due to reaching its endpoint before the test could check for movement. This test has been modified such that the motor is moved further.
 
### Ticket

ISISComputingGroup/IBEX#4618
### Acceptance criteria

New test adequately checks for whether PV returns to its alarm status, other tests run as before.
Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?