### PR TITLE
Add test for jaw centre not being changed when setting size at modera…

### DIFF
--- a/common_tests/jaws_manager_utils.py
+++ b/common_tests/jaws_manager_utils.py
@@ -37,6 +37,21 @@ class JawsManagerBase(object):
             self.ca.assert_that_pv_is_number(UNDERLYING_CENT_SP.format(jaw, direction), 10, 0.1)
             self.ca.assert_that_pv_is_number(UNDERLYING_GAP_SP.format(jaw, direction), expected_gaps[jaw - 1], 0.1)
 
+    def _test_WHEN_sizes_at_moderator_and_sample_changed_THEN_centres_of_all_jaws_unchanged(self, direction):
+        # Set up jaws initially to have "custom" centre.
+        centre = 12.34
+
+        for jaw in range(1, self.get_num_of_jaws() + 1):
+            self.ca.set_pv_value(UNDERLYING_CENT_SP.format(jaw, direction), centre)
+
+        # Now change size at sample + moderator
+        self.ca.set_pv_value("{}:{}GAP:SP".format(self.get_sample_pv(), direction), 11.111)
+        self.ca.set_pv_value(MOD_GAP.format(direction), 22.222)
+
+        # Assert that centres are unchanged
+        for jaw in range(1, self.get_num_of_jaws() + 1):
+            self.ca.assert_that_pv_is_number(UNDERLYING_CENT_SP.format(jaw, direction), centre, 0.001)
+
     def _test_WHEN_sample_gap_set_THEN_other_jaws_as_expected(self, direction, sample_gap, expected):
         self.ca.set_pv_value(self.get_sample_pv() + ":{}GAP:SP".format(direction), sample_gap)
         for i, exp in enumerate(expected):

--- a/common_tests/jaws_manager_utils.py
+++ b/common_tests/jaws_manager_utils.py
@@ -42,7 +42,8 @@ class JawsManagerBase(object):
         centre = 12.34
 
         for jaw in range(1, self.get_num_of_jaws() + 1):
-            self.ca.set_pv_value(UNDERLYING_CENT_SP.format(jaw, direction), centre)
+            # Set to centre * jaw so that each jaw is given a different centre
+            self.ca.set_pv_value(UNDERLYING_CENT_SP.format(jaw, direction), centre * jaw)
 
         # Now change size at sample + moderator
         self.ca.set_pv_value("{}:{}GAP:SP".format(self.get_sample_pv(), direction), 11.111)
@@ -50,7 +51,7 @@ class JawsManagerBase(object):
 
         # Assert that centres are unchanged
         for jaw in range(1, self.get_num_of_jaws() + 1):
-            self.ca.assert_that_pv_is_number(UNDERLYING_CENT_SP.format(jaw, direction), centre, 0.001)
+            self.ca.assert_that_pv_is_number(UNDERLYING_CENT_SP.format(jaw, direction), centre * jaw, 0.001)
 
     def _test_WHEN_sample_gap_set_THEN_other_jaws_as_expected(self, direction, sample_gap, expected):
         self.ca.set_pv_value(self.get_sample_pv() + ":{}GAP:SP".format(direction), sample_gap)

--- a/tests/jaws_manager.py
+++ b/tests/jaws_manager.py
@@ -55,3 +55,7 @@ class JawsManagerTests(JawsManagerBase, unittest.TestCase):
     @parameterized.expand(["V", "H"])
     def test_WHEN_centre_is_changed_THEN_centres_of_all_jaws_follow_and_gaps_unchanged(self, direction):
         self._test_WHEN_centre_is_changed_THEN_centres_of_all_jaws_follow_and_gaps_unchanged(direction)
+
+    @parameterized.expand(["V", "H"])
+    def test_WHEN_sizes_at_moderator_and_sample_changed_THEN_centres_of_all_jaws_unchanged(self, direction):
+        self._test_WHEN_sizes_at_moderator_and_sample_changed_THEN_centres_of_all_jaws_unchanged(direction)


### PR DESCRIPTION
Add a test verifying that setting the moderator/sample size does not change the existing centres of each jaw set (this requirement is from NIMROD).

See https://github.com/ISISComputingGroup/IBEX/issues/4672