### PR TITLE
Ticket4694 test readonly and disp

### DIFF
--- a/tests/simple.py
+++ b/tests/simple.py
@@ -64,12 +64,17 @@ class SimpleTests(unittest.TestCase):
 
     def check_write_through_python(self, addr, recordType):
         val_before = self.ca.get_pv_value(addr)
-        if recordType in ["STRINGIN", "STRINGOUT", "BO", "BI", "MBBI"]:
-            subprocess.call(['caput', "{}{}:{}".format(os.environ["MYPVPREFIX"], DEVICE_PREFIX, addr),
-                             val_before + "1"])
-        else:
-            subprocess.call(['caput', "{}{}:{}".format(os.environ["MYPVPREFIX"], DEVICE_PREFIX, addr),
-                             str(val_before + 1)])
+        new_val = 0 if val_before == "1" or val_before == "ON" else 1
+        chan = CaChannelWrapper.get_chan("{}{}:{}".format(os.environ["MYPVPREFIX"], DEVICE_PREFIX, addr))
+        try:
+            if recordType in ["STRINGIN", "STRINGOUT"]:
+                chan.putw(str(new_val))
+            else:
+                chan.putw(new_val)
+        except CaChannelException:
+            pass
+        except TypeError as e:
+            self.fail(recordType)
         if val_before == self.ca.get_pv_value(addr):
             return False
         else:
@@ -77,80 +82,42 @@ class SimpleTests(unittest.TestCase):
 
     def check_write_through_cmd(self, addr, recordType):
         val_before = self.ca.get_pv_value(addr)
+        new_val = 0 if val_before == "1" or val_before == "ON" else 1
         FNULL = open(os.devnull, 'w')
-        if recordType in ["STRINGIN", "STRINGOUT", "BO", "BI", "MBBI"]:
-            subprocess.call(['caput', "{}{}:{}".format(os.environ["MYPVPREFIX"], DEVICE_PREFIX, addr),
-                             val_before + "1"], stdout=FNULL, stderr=subprocess.STDOUT)
-        else:
-            subprocess.call(['caput', "{}{}:{}".format(os.environ["MYPVPREFIX"], DEVICE_PREFIX, addr),
-                             str(val_before + 1)], stdout=FNULL, stderr=subprocess.STDOUT)
+        subprocess.call(['caput', "{}{}:{}".format(os.environ["MYPVPREFIX"], DEVICE_PREFIX, addr),
+                         str(new_val)], stdout=FNULL, stderr=subprocess.STDOUT)
         if val_before == self.ca.get_pv_value(addr):
             return False
         else:
             return True
 
-    def test_GIVEN_PV_with_disp_true_WHEN_written_to_through_python_THEN_nothing_changes(self):
+    def test_GIVEN_PV_write_protection_WHEN_written_to_through_python_THEN_nothing_changes(self):
         fails = []
-        for recordType in ["AO", "AI", "BO", "BI", "MBBO", "MBBI", "STRINGIN", "STRINGOUT", "CALC", "CALCOUT"]:
-            address = "CATEST:{}:DISP".format(recordType)
-            self.ca.assert_that_pv_exists(address)
-            if self.check_write_through_python(address, recordType):
-                fails.append(recordType.lower())
+        for protection in ["RO", "DISP", "RODISP"]:
+            for recordType in ["AO", "AI", "BO", "BI", "MBBO", "MBBI", "STRINGIN", "STRINGOUT", "CALC", "CALCOUT"]:
+                address = "CATEST:{}:{}".format(recordType, protection)
+                self.ca.assert_that_pv_exists(address)
+                if self.check_write_through_python(address, recordType):
+                    fails.append([recordType, protection])
         if fails:
-            self.fail("The following record types were written to by python with DISP true:\n" + "\n".join(fails))
+            protectionDict = {"RO": "in READONLY ASG", "DISP": "with DISP=1", "RODISP": "in READONLY ASG with DISP=1"}
+            failMsgs = ["{} {}".format(fail[0].lower(), protectionDict[fail[1]]) for fail in fails]
+            self.fail("Could (wrongly) use python to write to protected using pvs with the following types and settings"
+                      ":\n" + "\n".join(failMsgs))
 
     def test_GIVEN_PV_with_disp_true_WHEN_written_to_through_cmd_THEN_nothing_changes(self):
         fails = []
-        for recordType in ["AO", "AI", "BO", "BI", "MBBO", "MBBI", "STRINGIN", "STRINGOUT", "CALC", "CALCOUT"]:
-            address = "CATEST:{}:DISP".format(recordType)
-            self.ca.assert_that_pv_exists(address)
-            if self.check_write_through_cmd(address, recordType):
-                fails.append(recordType.lower())
+        for protection in ["RO", "DISP", "RODISP"]:
+            for recordType in ["AO", "AI", "BO", "BI", "MBBO", "MBBI", "STRINGIN", "STRINGOUT", "CALC", "CALCOUT"]:
+                address = "CATEST:{}:{}".format(recordType, protection)
+                self.ca.assert_that_pv_exists(address)
+                if self.check_write_through_cmd(address, recordType):
+                    fails.append([recordType, protection])
         if fails:
-            self.fail("The following record types were written to through caput with DISP true:\n" + "\n".join(fails))
-
-    def test_GIVEN_PV_in_readonly_mode_WHEN_written_to_through_python_THEN_nothing_changes(self):
-        fails = []
-        for recordType in ["AO", "AI", "BO", "BI", "MBBO", "MBBI", "STRINGIN", "STRINGOUT", "CALC", "CALCOUT"]:
-            address = "CATEST:{}:RO".format(recordType)
-            self.ca.assert_that_pv_exists(address)
-            if self.check_write_through_python(address, recordType):
-                fails.append(recordType.lower())
-        if fails:
-            self.fail(
-                "The following record types were written to through python in Readonly mode:\n" + "\n".join(fails))
-
-    def test_GIVEN_PV_in_readonly_mode_WHEN_written_to_through_cmd_THEN_nothing_changes(self):
-        fails = []
-        for recordType in ["AO", "AI", "BO", "BI", "MBBO", "MBBI", "STRINGIN", "STRINGOUT", "CALC", "CALCOUT"]:
-            address = "CATEST:{}:RO".format(recordType)
-            self.ca.assert_that_pv_exists(address)
-            if self.check_write_through_cmd(address, recordType):
-                fails.append(recordType.lower())
-        if fails:
-            self.fail("The following record types were written to through caput in Readonly mode:\n" + "\n".join(fails))
-
-    def test_GIVEN_PV_in_readonly_mode_with_disp_true_WHEN_written_to_through_python_THEN_nothing_changes(self):
-        fails = []
-        for recordType in ["AO", "AI", "BO", "BI", "MBBO", "MBBI", "STRINGIN", "STRINGOUT", "CALC", "CALCOUT"]:
-            address = "CATEST:{}:RODISP".format(recordType)
-            self.ca.assert_that_pv_exists(address)
-            if self.check_write_through_python(address, recordType):
-                fails.append(recordType.lower())
-        if fails:
-            self.fail("The following record types were written to through python in Readonly mode with disp true:\n" +
-                      "\n".join(fails))
-
-    def test_GIVEN_PV_in_readonly_mode_with_disp_true_WHEN_written_to_through_cmd_THEN_nothing_changes(self):
-        fails = []
-        for recordType in ["AO", "AI", "BO", "BI", "MBBO", "MBBI", "STRINGIN", "STRINGOUT", "CALC", "CALCOUT"]:
-            address = "CATEST:{}:RODISP".format(recordType)
-            self.ca.assert_that_pv_exists(address)
-            if self.check_write_through_python(address, recordType):
-                fails.append(recordType.lower())
-        if fails:
-            self.fail("The following record types were written to through caput in Readonly mode with disp true:\n" +
-                      "\n".join(fails))
+            protectionDict = {"RO": "in READONLY ASG", "DISP": "with DISP=1", "RODISP": "in READONLY ASG with DISP=1"}
+            failMsgs = ["{} {}".format(fail[0].lower(), protectionDict[fail[1]]) for fail in fails]
+            self.fail("Could (wrongly) use cmd to write to protected using pvs with the following types and settings"
+                      ":\n" + "\n".join(failMsgs))
 
     def test_GIVEN_PV_in_hidden_mode_WHEN_read_attempted_THEN_get_error(self):
         fails = []
@@ -164,3 +131,23 @@ class SimpleTests(unittest.TestCase):
                 continue
         if fails:
             self.fail("The following records could be read in hidden mode:\n" + "\n".join(fails))
+
+    def test_GIVEN_PV_in_READONLY_mode_or_with_disp_true_WHEN_linked_to_THEN_link_successful(self):
+        fails = []
+        for protection in ["RO", "DISP", "RODISP"]:
+            for recordType in ["AO", "AI", "BO", "BI", "MBBO", "MBBI", "STRINGIN", "STRINGOUT", "CALC", "CALCOUT"]:
+                address = "CATEST:{}:{}".format(recordType, protection)
+                addressOut = "CATEST:{}:{}:OUT".format(recordType, protection)
+                self.ca.assert_that_pv_exists(address)
+                val_before = self.ca.get_pv_value(address)
+                new_val = 0 if val_before == "1" or val_before == "ON" else 1
+                FNULL = open(os.devnull, 'w')
+                subprocess.call(['caput', "{}{}:{}".format(os.environ["MYPVPREFIX"], DEVICE_PREFIX, addressOut),
+                                 str(new_val)], stdout=FNULL, stderr=subprocess.STDOUT)
+                if val_before == self.ca.get_pv_value(address):
+                    fails.append([recordType, protection])
+        if fails:
+            protectionDict = {"RO": "in READONLY ASG", "DISP": "with DISP=1", "RODISP": "in READONLY ASG with DISP=1"}
+            failMsgs = ["{} {}".format(fail[0].lower(), protectionDict[fail[1]]) for fail in fails]
+            self.fail("OUT field failed to forward value to pvs with the following types and settings:\n" + "\n".join(
+                failMsgs))

--- a/tests/simple.py
+++ b/tests/simple.py
@@ -29,7 +29,7 @@ IOCS = [
 ]
 PROTECTION_TYPES = ["RO", "DISP", "RODISP", ]
 RECORD_TYPES = ["AO", "AI", "BO", "BI", "MBBO", "MBBI", "STRINGIN", "STRINGOUT", "CALC", "CALCOUT", ]
-protectionDict = {"RO": "in READONLY ASG", "DISP": "with DISP=1", "RODISP": "in READONLY ASG with DISP=1", }
+protection_dict = {"RO": "in READONLY ASG", "DISP": "with DISP=1", "RODISP": "in READONLY ASG with DISP=1", }
 
 TEST_MODES = [TestModes.RECSIM, ]
 
@@ -100,7 +100,7 @@ class SimpleTests(unittest.TestCase):
         address = "CATEST:{}:{}".format(record, protection)
         self.ca.assert_that_pv_exists(address)
         if check_write_through_python(address, record):
-            self.fail("Could (wrongly) use python to write to {} pvs {}".format(record, protectionDict[protection]))
+            self.fail("Could (wrongly) use python to write to {} pvs {}".format(record, protection_dict[protection]))
 
     @parameterized.expand(parameterized_list(itertools.product(PROTECTION_TYPES, RECORD_TYPES)))
     def test_GIVEN_PV_readonly_or_with_disp_true_WHEN_written_to_through_cmd_THEN_nothing_changes(
@@ -114,7 +114,7 @@ class SimpleTests(unittest.TestCase):
         address = "CATEST:{}:{}".format(record, protection)
         self.ca.assert_that_pv_exists(address)
         if check_write_through_cmd(address):
-            self.fail("Could (wrongly) use cmd to write to {} pvs {}".format(record, protectionDict[protection]))
+            self.fail("Could (wrongly) use cmd to write to {} pvs {}".format(record, protection_dict[protection]))
 
     @parameterized.expand(parameterized_list(RECORD_TYPES))
     def test_GIVEN_PV_in_hidden_mode_WHEN_read_attempted_THEN_get_error(self, _, record):
@@ -135,7 +135,7 @@ class SimpleTests(unittest.TestCase):
         val_before, new_val = self.get_toggle_value(address)
         write_through_cmd(address_out, new_val)
         if val_before == self.ca.get_pv_value(address):
-            self.fail("OUT field failed to forward value to {} pvs {}".format(record, protectionDict[protection]))
+            self.fail("OUT field failed to forward value to {} pvs {}".format(record, protection_dict[protection]))
 
     @parameterized.expand(parameterized_list(itertools.product(PROTECTION_TYPES, RECORD_TYPES)))
     def test_GIVEN_PV_READONLY_or_with_disp_true_WHEN_told_to_process_by_python_THEN_nothing_happens(
@@ -153,7 +153,7 @@ class SimpleTests(unittest.TestCase):
         self.ca.assert_that_pv_exists(address)
         if check_write_through_python(address):
             self.fail("Could (wrongly) use python to process protected pvs using {} pvs {}".format(
-                record, protectionDict[protection]))
+                record, protection_dict[protection]))
 
     @parameterized.expand(parameterized_list(itertools.product(PROTECTION_TYPES, RECORD_TYPES)))
     def test_GIVEN_PV_READONLY_or_with_disp_true_WHEN_told_to_process_by_cmd_THEN_nothing_changes(
@@ -167,4 +167,4 @@ class SimpleTests(unittest.TestCase):
         self.ca.assert_that_pv_exists(address)
         if check_write_through_cmd(address):
             self.fail("Could (wrongly) use cmd to process protected pvs using {} pvs {}".format(
-                record, protectionDict[protection]))
+                record, protection_dict[protection]))


### PR DESCRIPTION
The tests now check that our methods of protecting records are sufficient to prevent accidental setting of values, as per [ticket 4694](https://github.com/ISISComputingGroup/IBEX/issues/4694). We now test for:
 - Writing to records which are in the "READONLY" ASG and/or which have their "DISP" field set to "1", through both the python commands to set records and by attempting to set records via the epics terminal. If the program can do this, it throws a failure.
 - Reading any information (aside from the fact that they exist) from records with the new access security group "HIDDEN" with no read or write access. If the program can do this, it will throw a failure.
 - Forcing the processing of a record in the "READONLY" ASG and/or which have their "DISP" field set to "1",  through both the python commands and via the epics terminal, by setting its .PROC field to any value. If the program can do this, it will throw a failure.
 - Updating a protected record by changing a record which links to it from within the database. The program will throw a failure if it can NOT do this.