### PR TITLE
Ticket4695 jaws adel

### DIFF
--- a/tests/jaws.py
+++ b/tests/jaws.py
@@ -180,7 +180,7 @@ class JawsTests(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     @parameterized.expand(parameterized_list(DIRECTIONS))
-    def test_GIVEN_underlying_mtr_ADEL_value_THEN_jaws_ADEL_field_mirrored(self, _, direction):
+    def test_GIVEN_underlying_mtr_adel_value_THEN_jaws_ADEL_field_mirrored(self, _, direction):
         motor_adel_pv = "{}.ADEL".format(self.UNDERLYING_MTRS[direction])
         jaw_adel_pv = "{}:J{}.ADEL".format(JAWS_BASE_PV, direction)
 
@@ -194,3 +194,22 @@ class JawsTests(unittest.TestCase):
 
             self.ca.assert_that_pv_is_number(motor_adel_pv, test_value)
             self.ca.assert_that_pv_is_number(jaw_adel_pv, test_value)
+
+
+    def test_GIVEN_underlying_mtr_adel_THEN_jaws_centre_and_gap_adel_mirrored(self):
+        north_motor_pv = "{}.ADEL".format(self.MTR_NORTH)
+        east_motor_pv = "{}.ADEL".format(self.MTR_EAST)
+
+        test_values = [1e-4, 1.2, 12.3]
+        for test_value in test_values:
+            # Gaps and centre ADELs are set by North (Vertical) and East (Horizontal) motors 
+            self.ca.set_pv_value(north_motor_pv, test_value)
+            self.ca.set_pv_value(east_motor_pv, test_value)
+
+            self.ca.assert_that_pv_is_number(north_motor_pv, test_value)
+
+            self.ca.assert_that_pv_is_number("{}:VCENT.ADEL".format(JAWS_BASE_PV), test_value)
+            self.ca.assert_that_pv_is_number("{}:VGAP.ADEL".format(JAWS_BASE_PV), test_value)
+
+            self.ca.assert_that_pv_is_number("{}:HCENT.ADEL".format(JAWS_BASE_PV), test_value)
+            self.ca.assert_that_pv_is_number("{}:HGAP.ADEL".format(JAWS_BASE_PV), test_value)

--- a/tests/jaws.py
+++ b/tests/jaws.py
@@ -44,7 +44,10 @@ class JawsTests(unittest.TestCase):
     MTR_SOUTH = "MOT:MTR0102"
     MTR_WEST = "MOT:MTR0103"
     MTR_EAST = "MOT:MTR0104"
-    UNDERLYING_MTRS = OrderedDict([("N", MTR_NORTH), ("S", MTR_SOUTH), ("E", MTR_EAST), ("W",  MTR_WEST)])
+    UNDERLYING_MTRS = OrderedDict([("N", MTR_NORTH),
+                                   ("S", MTR_SOUTH),
+                                   ("E", MTR_EAST),
+                                   ("W",  MTR_WEST)])
 
     def setUp(self):
         self._ioc = IOCRegister.get_running("jaws")
@@ -59,45 +62,13 @@ class JawsTests(unittest.TestCase):
         self.ca.set_pv_value("MOT:JAWS1:HGAP:SP", 0)
         self.ca.set_pv_value("MOT:JAWS1:VGAP:SP", 0)
 
-    def test_GIVEN_ioc_started_THEN_underlying_mtr_north_fields_can_be_read(self):
-        underlying_mtr = self.MTR_NORTH
-        direction_key = "JN"
+
+    @parameterized.expand(parameterized_list(DIRECTIONS))
+    def test_GIVEN_ioc_started_THEN_underlying_mtr_fields_can_be_read(self, _, direction):
+        underlying_mtr = self.UNDERLYING_MTRS[direction]
 
         expected = self.ca.get_pv_value("{}.VELO".format(underlying_mtr))
-        jaw_blade_pv = "{}:{}".format(JAWS_BASE_PV, direction_key)
-
-        actual = self.ca.get_pv_value("{}:MTR.VELO".format(jaw_blade_pv))
-
-        self.assertEqual(expected, actual)
-
-    def test_GIVEN_ioc_started_THEN_underlying_mtr_south_fields_can_be_read(self):
-        underlying_mtr = self.MTR_SOUTH
-        direction_key = "JS"
-
-        expected = self.ca.get_pv_value("{}.VELO".format(underlying_mtr))
-        jaw_blade_pv = "{}:{}".format(JAWS_BASE_PV, direction_key)
-
-        actual = self.ca.get_pv_value("{}:MTR.VELO".format(jaw_blade_pv))
-
-        self.assertEqual(expected, actual)
-
-    def test_GIVEN_ioc_started_THEN_underlying_mtr_east_fields_can_be_read(self):
-        underlying_mtr = self.MTR_EAST
-        direction_key = "JE"
-
-        expected = self.ca.get_pv_value("{}.VELO".format(underlying_mtr))
-        jaw_blade_pv = "{}:{}".format(JAWS_BASE_PV, direction_key)
-
-        actual = self.ca.get_pv_value("{}:MTR.VELO".format(jaw_blade_pv))
-
-        self.assertEqual(expected, actual)
-
-    def test_GIVEN_ioc_started_THEN_underlying_mtr_west_fields_can_be_read(self):
-        underlying_mtr = self.MTR_WEST
-        direction_key = "JW"
-
-        expected = self.ca.get_pv_value("{}.VELO".format(underlying_mtr))
-        jaw_blade_pv = "{}:{}".format(JAWS_BASE_PV, direction_key)
+        jaw_blade_pv = "{}:J{}".format(JAWS_BASE_PV, direction)
 
         actual = self.ca.get_pv_value("{}:MTR.VELO".format(jaw_blade_pv))
 
@@ -195,21 +166,16 @@ class JawsTests(unittest.TestCase):
             self.ca.assert_that_pv_is_number(motor_adel_pv, test_value)
             self.ca.assert_that_pv_is_number(jaw_adel_pv, test_value)
 
-
-    def test_GIVEN_underlying_mtr_adel_THEN_jaws_centre_and_gap_adel_mirrored(self):
-        north_motor_pv = "{}.ADEL".format(self.MTR_NORTH)
-        east_motor_pv = "{}.ADEL".format(self.MTR_EAST)
+    @parameterized.expand([("V", MTR_NORTH),
+                           ("H", MTR_EAST)])
+    def test_GIVEN_underlying_mtr_adel_THEN_jaws_centre_and_gap_adel_mirrored(self, axis, underlying_mtr):
+        motor_pv = "{}.ADEL".format(underlying_mtr)
 
         test_values = [1e-4, 1.2, 12.3]
         for test_value in test_values:
-            # Gaps and centre ADELs are set by North (Vertical) and East (Horizontal) motors 
-            self.ca.set_pv_value(north_motor_pv, test_value)
-            self.ca.set_pv_value(east_motor_pv, test_value)
+            self.ca.set_pv_value(motor_pv, test_value)
 
-            self.ca.assert_that_pv_is_number(north_motor_pv, test_value)
+            self.ca.assert_that_pv_is_number(motor_pv, test_value)
 
-            self.ca.assert_that_pv_is_number("{}:VCENT.ADEL".format(JAWS_BASE_PV), test_value)
-            self.ca.assert_that_pv_is_number("{}:VGAP.ADEL".format(JAWS_BASE_PV), test_value)
-
-            self.ca.assert_that_pv_is_number("{}:HCENT.ADEL".format(JAWS_BASE_PV), test_value)
-            self.ca.assert_that_pv_is_number("{}:HGAP.ADEL".format(JAWS_BASE_PV), test_value)
+            self.ca.assert_that_pv_is_number("{}:{}CENT.ADEL".format(JAWS_BASE_PV, axis), test_value)
+            self.ca.assert_that_pv_is_number("{}:{}GAP.ADEL".format(JAWS_BASE_PV, axis), test_value)

--- a/tests/jaws.py
+++ b/tests/jaws.py
@@ -42,8 +42,8 @@ class JawsTests(unittest.TestCase):
     """
     MTR_NORTH = "MOT:MTR0101"
     MTR_SOUTH = "MOT:MTR0102"
-    MTR_EAST = "MOT:MTR0103"
-    MTR_WEST = "MOT:MTR0104"
+    MTR_WEST = "MOT:MTR0103"
+    MTR_EAST = "MOT:MTR0104"
     UNDERLYING_MTRS = OrderedDict([("N", MTR_NORTH), ("S", MTR_SOUTH), ("E", MTR_EAST), ("W",  MTR_WEST)])
 
     def setUp(self):
@@ -182,12 +182,15 @@ class JawsTests(unittest.TestCase):
     @parameterized.expand(parameterized_list(DIRECTIONS))
     def test_GIVEN_underlying_mtr_ADEL_value_THEN_jaws_ADEL_field_mirrored(self, _, direction):
         motor_adel_pv = "{}.ADEL".format(self.UNDERLYING_MTRS[direction])
-        jaw_adel_pv = "{}:{}.ADEL".format(JAWS_BASE_PV, direction)
+        jaw_adel_pv = "{}:J{}.ADEL".format(JAWS_BASE_PV, direction)
 
         self.ca.set_pv_value(motor_adel_pv, 0.0)
         self.ca.assert_that_pv_is(motor_adel_pv, 0.0)
 
-        self.ca.set_pv_value(motor_adel_pv, 12.3)
-        self.ca.assert_that_pv_is(motor_adel_pv, 12.3)
-        self.ca.assert_that_pv_is(jaw_adel_pv, 12.3)
-        self.ca.set_pv_value(motor_adel_pv, 12.3)
+        test_values = [1e-4, 1.2, 12.3]
+
+        for test_value in test_values:
+            self.ca.set_pv_value(motor_adel_pv, test_value)
+
+            self.ca.assert_that_pv_is_number(motor_adel_pv, test_value)
+            self.ca.assert_that_pv_is_number(jaw_adel_pv, test_value)

--- a/tests/jaws.py
+++ b/tests/jaws.py
@@ -178,3 +178,16 @@ class JawsTests(unittest.TestCase):
         actual = self.ca.get_pv_value(jaws_status_readback_pv)
 
         self.assertEqual(expected, actual)
+
+    @parameterized.expand(parameterized_list(DIRECTIONS))
+    def test_GIVEN_underlying_mtr_ADEL_value_THEN_jaws_ADEL_field_mirrored(self, _, direction):
+        motor_adel_pv = "{}.ADEL".format(self.UNDERLYING_MTRS[direction])
+        jaw_adel_pv = "{}:{}.ADEL".format(JAWS_BASE_PV, direction)
+
+        self.ca.set_pv_value(motor_adel_pv, 0.0)
+        self.ca.assert_that_pv_is(motor_adel_pv, 0.0)
+
+        self.ca.set_pv_value(motor_adel_pv, 12.3)
+        self.ca.assert_that_pv_is(motor_adel_pv, 12.3)
+        self.ca.assert_that_pv_is(jaw_adel_pv, 12.3)
+        self.ca.set_pv_value(motor_adel_pv, 12.3)

--- a/tests/jaws.py
+++ b/tests/jaws.py
@@ -141,7 +141,7 @@ class JawsTests(unittest.TestCase):
         enabled_val = 0
         for mtr in self.UNDERLYING_MTRS:
             mtr_status_pv = "{}_{}".format(mtr, key)
-            self.ca.set_pv_value(mtr_status_pv.format(JAWS_BASE_PV), enabled_val)
+            self.ca.set_pv_value(mtr_status_pv, enabled_val)
 
         jaws_status_readback_pv = "{}:{}".format(JAWS_BASE_PV, key.upper())
         actual = self.ca.get_pv_value(jaws_status_readback_pv)
@@ -154,7 +154,7 @@ class JawsTests(unittest.TestCase):
         disabled_val = 1
         for mtr in self.UNDERLYING_MTRS:
             mtr_status_pv = "{}_{}".format(mtr, key)
-            self.ca.set_pv_value(mtr_status_pv.format(JAWS_BASE_PV), disabled_val)
+            self.ca.set_pv_value(mtr_status_pv, disabled_val)
 
         jaws_status_readback_pv = "{}:{}".format(JAWS_BASE_PV, key.upper())
         actual = self.ca.get_pv_value(jaws_status_readback_pv)
@@ -168,10 +168,10 @@ class JawsTests(unittest.TestCase):
         enabled_val = 1
         for mtr in self.UNDERLYING_MTRS[:2]:
             mtr_status_pv = "{}_{}".format(mtr, key)
-            self.ca.set_pv_value(mtr_status_pv.format(JAWS_BASE_PV), enabled_val)
+            self.ca.set_pv_value(mtr_status_pv, enabled_val)
         for mtr in self.UNDERLYING_MTRS[2:]:
             mtr_status_pv = "{}_{}".format(mtr, key)
-            self.ca.set_pv_value(mtr_status_pv.format(JAWS_BASE_PV), disabled_val)
+            self.ca.set_pv_value(mtr_status_pv, disabled_val)
 
         jaws_status_readback_pv = "{}:{}".format(JAWS_BASE_PV, key.upper())
         actual = self.ca.get_pv_value(jaws_status_readback_pv)

--- a/tests/jaws.py
+++ b/tests/jaws.py
@@ -6,6 +6,7 @@ from utils.ioc_launcher import IOCRegister, get_default_ioc_dir
 from utils.test_modes import TestModes
 from utils.testing import parameterized_list
 from parameterized import parameterized
+from collections import OrderedDict
 
 MTR_01 = "GALIL_01"
 
@@ -43,12 +44,12 @@ class JawsTests(unittest.TestCase):
     MTR_SOUTH = "MOT:MTR0102"
     MTR_EAST = "MOT:MTR0103"
     MTR_WEST = "MOT:MTR0104"
-    UNDERLYING_MTRS = [MTR_NORTH, MTR_SOUTH, MTR_EAST, MTR_WEST]
+    UNDERLYING_MTRS = OrderedDict([("N", MTR_NORTH), ("S", MTR_SOUTH), ("E", MTR_EAST), ("W",  MTR_WEST)])
 
     def setUp(self):
         self._ioc = IOCRegister.get_running("jaws")
         self.ca = ChannelAccess(default_timeout=30)
-        for mtr in self.UNDERLYING_MTRS:
+        for mtr in self.UNDERLYING_MTRS.values():
             self.ca.set_pv_value("{}.VMAX".format(mtr), 100)
             self.ca.set_pv_value("{}.VELO".format(mtr), 100)
 
@@ -139,7 +140,7 @@ class JawsTests(unittest.TestCase):
                            ("able", "Enable")])
     def test_GIVEN_all_jaws_have_state_set_THEN_overall_state_is_set(self, key, expected):
         enabled_val = 0
-        for mtr in self.UNDERLYING_MTRS:
+        for mtr in self.UNDERLYING_MTRS.values():
             mtr_status_pv = "{}_{}".format(mtr, key)
             self.ca.set_pv_value(mtr_status_pv, enabled_val)
 
@@ -152,7 +153,7 @@ class JawsTests(unittest.TestCase):
                            ("able", "Disable")])
     def test_GIVEN_no_jaws_have_state_set_THEN_overall_state_is_not_set(self, key, expected):
         disabled_val = 1
-        for mtr in self.UNDERLYING_MTRS:
+        for mtr in self.UNDERLYING_MTRS.values():
             mtr_status_pv = "{}_{}".format(mtr, key)
             self.ca.set_pv_value(mtr_status_pv, disabled_val)
 
@@ -166,10 +167,10 @@ class JawsTests(unittest.TestCase):
     def test_GIVEN_some_jaws_have_state_set_THEN_overall_state_is_unknown(self, key, expected):
         disabled_val = 0
         enabled_val = 1
-        for mtr in self.UNDERLYING_MTRS[:2]:
+        for mtr in self.UNDERLYING_MTRS.values()[:2]:
             mtr_status_pv = "{}_{}".format(mtr, key)
             self.ca.set_pv_value(mtr_status_pv, enabled_val)
-        for mtr in self.UNDERLYING_MTRS[2:]:
+        for mtr in self.UNDERLYING_MTRS.values()[2:]:
             mtr_status_pv = "{}_{}".format(mtr, key)
             self.ca.set_pv_value(mtr_status_pv, disabled_val)
 

--- a/tests/jaws_split.py
+++ b/tests/jaws_split.py
@@ -1,4 +1,5 @@
 import os
+from collections import OrderedDict
 
 from utils.ioc_launcher import IOCRegister, get_default_ioc_dir
 from utils.test_modes import TestModes
@@ -44,5 +45,9 @@ SplitJawsTests.MTR_SOUTH = mtr_south
 SplitJawsTests.MTR_EAST = mtr_east
 SplitJawsTests.MTR_WEST = mtr_west
 SplitJawsTests.UNDERLYING_MTRS = [mtr_north, mtr_south, mtr_east, mtr_west]
+SplitJawsTests.UNDERLYING_MTRS = OrderedDict([("N", mtr_north),
+                                   ("S", mtr_south),
+                                   ("E", mtr_east),
+                                   ("W",  mtr_west)])
 
 __all__ = ["SplitJawsTests"]


### PR DESCRIPTION
### Description of work

Adds tests to ensure that the archive deadband (ADEL) field are being copied from the underlying motors to the jaw blades, centres and gaps.

### To test
https://github.com/ISISComputingGroup/IBEX/issues/4695

### Acceptance criteria
- [ ] Tests confirm that the ADEL field is copied across
- [ ] All tests pass