### PR TITLE
Ticket651 add ioc cryosms

### DIFF
--- a/tests/cryosms.py
+++ b/tests/cryosms.py
@@ -6,7 +6,7 @@ from utils.ioc_launcher import get_default_ioc_dir
 from utils.testing import get_running_lewis_and_ioc
 
 DEVICE_PREFIX = "CRYOSMS_01"
-EMULATOR_NAME = "HFMAGPSU"
+EMULATOR_NAME = "cryogenic_sms"
 
 IOCS = [
     {
@@ -26,9 +26,6 @@ class CryoSMSTests(unittest.TestCase):
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX, default_timeout=10)
 
         self.ca.assert_that_pv_exists("DISABLE", timeout=30)
-
-    def test_WHEN_ioc_is_started_THEN_it_is_not_disabled(self):
-        self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")
 
     def test_GIVEN_outputmode_sp_correct_WHEN_outputmode_sp_written_to_THEN_outputmode_changes(self):
         # GIVEN

--- a/tests/cryosms.py
+++ b/tests/cryosms.py
@@ -1,5 +1,6 @@
 import unittest
 
+from parameterized import parameterized
 from utils.test_modes import TestModes
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
@@ -12,12 +13,12 @@ IOCS = [
     {
         "name": DEVICE_PREFIX,
         "directory": get_default_ioc_dir("CRYOSMS"),
-        "emulator" : EMULATOR_NAME,
+        "emulator": EMULATOR_NAME,
     },
 ]
 
 
-TEST_MODES = [TestModes.DEVSIM]
+TEST_MODES = [TestModes.DEVSIM, TestModes.RECSIM]
 
 
 class CryoSMSTests(unittest.TestCase):
@@ -27,14 +28,6 @@ class CryoSMSTests(unittest.TestCase):
 
         self.ca.assert_that_pv_exists("DISABLE", timeout=30)
 
-    def test_GIVEN_outputmode_sp_correct_WHEN_outputmode_sp_written_to_THEN_outputmode_changes(self):
-        # GIVEN
-        current_outputmode = self.ca.get_pv_value("OUTPUTMODE")
-        self.ca.assert_that_pv_is("OUTPUTMODE:SP", current_outputmode, timeout=30)
-
-        # WHEN
-        new_outputmode = "AMPS" if current_outputmode == "TESLA" else "TESLA"
-        self.ca.set_pv_value("OUTPUTMODE:SP", new_outputmode)
-
-        # THEN
-        self.ca.assert_that_pv_is("OUTPUTMODE", new_outputmode, timeout=10)
+    @parameterized.expand(["TESLA", "AMPS"])
+    def test_GIVEN_outputmode_sp_correct_WHEN_outputmode_sp_written_to_THEN_outputmode_changes(self, units):
+        self.ca.assert_setting_setpoint_sets_readback(units, "OUTPUTMODE", "OUTPUTMODE:SP", timeout=10)

--- a/tests/cryosms.py
+++ b/tests/cryosms.py
@@ -2,8 +2,8 @@ import unittest
 
 from utils.test_modes import TestModes
 from utils.channel_access import ChannelAccess
-from utils.ioc_launcher import get_default_ioc_dir, IOCRegister
-from utils.testing import skip_if_recsim, get_running_lewis_and_ioc
+from utils.ioc_launcher import get_default_ioc_dir
+from utils.testing import get_running_lewis_and_ioc
 
 DEVICE_PREFIX = "CRYOSMS_01"
 EMULATOR_NAME = "HFMAGPSU"
@@ -40,4 +40,4 @@ class CryoSMSTests(unittest.TestCase):
         self.ca.set_pv_value("OUTPUTMODE:SP", new_outputmode)
 
         # THEN
-        self.ca.assert_that_pv_is("OUTPUTMODE:SP", new_outputmode)
+        self.ca.assert_that_pv_is("OUTPUTMODE:SP", new_outputmode, timeout=10)

--- a/tests/cryosms.py
+++ b/tests/cryosms.py
@@ -40,4 +40,4 @@ class CryoSMSTests(unittest.TestCase):
         self.ca.set_pv_value("OUTPUTMODE:SP", new_outputmode)
 
         # THEN
-        self.ca.assert_that_pv_is("OUTPUTMODE:SP", new_outputmode, timeout=10)
+        self.ca.assert_that_pv_is("OUTPUTMODE", new_outputmode, timeout=10)

--- a/tests/cryosms.py
+++ b/tests/cryosms.py
@@ -1,0 +1,43 @@
+import unittest
+
+from utils.test_modes import TestModes
+from utils.channel_access import ChannelAccess
+from utils.ioc_launcher import get_default_ioc_dir, IOCRegister
+from utils.testing import skip_if_recsim, get_running_lewis_and_ioc
+
+DEVICE_PREFIX = "CRYOSMS_01"
+EMULATOR_NAME = "HFMAGPSU"
+
+IOCS = [
+    {
+        "name": DEVICE_PREFIX,
+        "directory": get_default_ioc_dir("CRYOSMS"),
+        "emulator" : EMULATOR_NAME,
+    },
+]
+
+
+TEST_MODES = [TestModes.DEVSIM]
+
+
+class CryoSMSTests(unittest.TestCase):
+    def setUp(self):
+        self._lewis, self._ioc = get_running_lewis_and_ioc(EMULATOR_NAME, DEVICE_PREFIX)
+        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX, default_timeout=10)
+
+        self.ca.assert_that_pv_exists("DISABLE", timeout=30)
+
+    def test_WHEN_ioc_is_started_THEN_it_is_not_disabled(self):
+        self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")
+
+    def test_GIVEN_outputmode_sp_correct_WHEN_outputmode_sp_written_to_THEN_outputmode_changes(self):
+        # GIVEN
+        current_outputmode = self.ca.get_pv_value("OUTPUTMODE")
+        self.ca.assert_that_pv_is("OUTPUTMODE:SP", current_outputmode, timeout=30)
+
+        # WHEN
+        new_outputmode = "AMPS" if current_outputmode == "TESLA" else "TESLA"
+        self.ca.set_pv_value("OUTPUTMODE:SP", new_outputmode)
+
+        # THEN
+        self.ca.assert_that_pv_is("OUTPUTMODE:SP", new_outputmode)


### PR DESCRIPTION
### Description of work
Added a simple test which checks that the IOC is behaving as intended. Checks that OUTPUTMODE changes when OUTPUTMODE:SP is changed. For this to happen, the setpoint must write to an asyn driver, which writes to a hidden PV, which uses streamdevice to write to an emulator, which is finally read by OUTPUTMODE through streamdevice.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4826

### Acceptance criteria

The new test functions as described.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

