### PR TITLE
Skip unstable tests

### DIFF
--- a/tests/attocube.py
+++ b/tests/attocube.py
@@ -39,17 +39,20 @@ class AttocubeTests(unittest.TestCase):
         self._lewis.backdoor_set_on_device('connected', True)
         self.ca.assert_that_pv_exists(MOTOR_RBV)
 
+    @unittest.skip("Fix in https://github.com/ISISComputingGroup/IBEX/issues/4841")
     def test_WHEN_moved_to_position_THEN_position_reached(self):
         position_setpoint = 20
         self.ca.set_pv_value(MOTOR_PV, position_setpoint)
         self.ca.assert_that_pv_value_is_increasing(MOTOR_RBV, 1)
         self.ca.assert_that_pv_is_number(MOTOR_RBV, position_setpoint, timeout=20)
 
+    @unittest.skip("Fix in https://github.com/ISISComputingGroup/IBEX/issues/4841")
     def test_GIVEN_device_not_connected_THEN_pv_in_alarm(self):
         self._lewis.backdoor_set_on_device('connected', False)
         self.ca.assert_that_pv_alarm_is(MOTOR_PV, ChannelAccess.Alarms.INVALID, timeout=30)
         self._lewis.backdoor_set_on_device('connected', True)
 
+    @unittest.skip("Fix in https://github.com/ISISComputingGroup/IBEX/issues/4841")
     def test_GIVEN_device_not_connected_WHEN_motor_val_set_THEN_pv_returns_to_alarm(self):
         self._lewis.backdoor_set_on_device('connected', False)
         self.ca.assert_that_pv_alarm_is(MOTOR_PV, ChannelAccess.Alarms.INVALID, timeout=10)

--- a/tests/nimrod_jaws_manager.py
+++ b/tests/nimrod_jaws_manager.py
@@ -43,6 +43,7 @@ class NimrodJawsManagerTests(JawsManagerBase, unittest.TestCase):
         (70, 40, [60.2, 57.7, 51.6, 46.5, 43.7, 40]),
         (130, 5, [89, 78.8, 53.4, 31.9, 20.6, 5]),
     ]))
+    @unittest.skip("Fix in https://github.com/ISISComputingGroup/IBEX/issues/4841")
     def test_WHEN_sample_gap_set_THEN_other_jaws_as_expected(self, _, mod_gap, sample_gap, expected):
         self.ca.set_pv_value(MOD_GAP.format("V"), mod_gap)
         self._test_WHEN_sample_gap_set_THEN_other_jaws_as_expected("V", sample_gap, expected)


### PR DESCRIPTION
Skip some tests which are consistently failing.

To be fixed in https://github.com/ISISComputingGroup/IBEX/issues/4841