### PR TITLE
Make system tests more stable

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -123,8 +123,13 @@ def load_and_run_tests(test_names, failfast, ask_before_running_tests):
         for module in modules_to_be_tested_in_current_mode:
             clean_environment()
             device_launchers = make_device_launchers_from_module(module.file, mode)
-            test_results.append(
-                run_tests(arguments.prefix, module.tests, device_collection_launcher(device_launchers), failfast, ask_before_running_tests))
+            try:
+                test_results.append(
+                    run_tests(arguments.prefix, module.tests, device_collection_launcher(device_launchers),
+                              failfast, ask_before_running_tests))
+            except Exception:
+                print("Error while attempting to load test suite: {}".format(traceback.format_exc()))
+                test_results.append(False)  # Fail the tests which threw an exception, but keep running other tests.
 
     return all(test_result is True for test_result in test_results)
 

--- a/tests/gem_jaws_manager.py
+++ b/tests/gem_jaws_manager.py
@@ -3,7 +3,7 @@ import unittest
 from utils.ioc_launcher import get_default_ioc_dir
 import os
 from parameterized.parameterized import parameterized
-from utils.testing import parameterized_list
+from utils.testing import parameterized_list, unstable_test
 from common_tests.jaws_manager_utils import JawsManagerBase, MOD_GAP
 from time import sleep
 
@@ -44,6 +44,7 @@ class GemJawsManagerTests(JawsManagerBase, unittest.TestCase):
         (130, 5, [83.6, 70.2, 54, 37, 16.9]),
         (100, 50, [81.4, 76.1, 69.6, 62.8, 54.7]),
     ]))
+    @unstable_test()
     def test_WHEN_sample_gap_set_THEN_other_jaws_as_expected(self, _, mod_gap, sample_gap, expected):
         self.ca.set_pv_value(MOD_GAP.format("V"), mod_gap)
         self._test_WHEN_sample_gap_set_THEN_other_jaws_as_expected("V", sample_gap, expected)

--- a/tests/gem_jaws_manager.py
+++ b/tests/gem_jaws_manager.py
@@ -3,9 +3,8 @@ import unittest
 from utils.ioc_launcher import get_default_ioc_dir
 import os
 from parameterized.parameterized import parameterized
-from utils.testing import parameterized_list, unstable_test
+from utils.testing import parameterized_list
 from common_tests.jaws_manager_utils import JawsManagerBase, MOD_GAP
-from time import sleep
 
 # IP address of device
 from utils.test_modes import TestModes
@@ -44,7 +43,7 @@ class GemJawsManagerTests(JawsManagerBase, unittest.TestCase):
         (130, 5, [83.6, 70.2, 54, 37, 16.9]),
         (100, 50, [81.4, 76.1, 69.6, 62.8, 54.7]),
     ]))
-    @unstable_test()
+    @unittest.skip("Fix as part of https://github.com/ISISComputingGroup/IBEX/issues/4841")
     def test_WHEN_sample_gap_set_THEN_other_jaws_as_expected(self, _, mod_gap, sample_gap, expected):
         self.ca.set_pv_value(MOD_GAP.format("V"), mod_gap)
         self._test_WHEN_sample_gap_set_THEN_other_jaws_as_expected("V", sample_gap, expected)

--- a/tests/instron_stress_rig.py
+++ b/tests/instron_stress_rig.py
@@ -621,6 +621,9 @@ class InstronStressRigTests(unittest.TestCase):
         expected_values = [input_values[i]/conversion_factors[i] for i in range(NUMBER_OF_CHANNELS)]
         assert len(expected_values) == len(conversion_factors) == len(input_values) == NUMBER_OF_CHANNELS
 
+        for i in range(len(conversion_factors)):
+            self.assertNotEqual(0, conversion_factors[i], "Factor {} was zero".format(i))
+
         # Do this as two separate loops so that we can verify that all 3 channel values are stored independently
         for device_channel in range(NUMBER_OF_CHANNELS):
             self.ca.set_pv_value("CHANNEL:SP.VAL", device_channel)

--- a/tests/ips.py
+++ b/tests/ips.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
-from utils.testing import get_running_lewis_and_ioc, parameterized_list
+from utils.testing import get_running_lewis_and_ioc, parameterized_list, unstable_test
 from parameterized import parameterized
 
 
@@ -234,6 +234,7 @@ class IpsTests(unittest.TestCase):
         self.ca.assert_that_pv_alarm_is("FIELD:RATE", self.ca.Alarms.NONE)
 
     @parameterized.expand(activity_state for activity_state in parameterized_list(ACTIVITY_STATES))
+    @unstable_test()
     def test_WHEN_activity_set_via_backdoor_to_clamped_THEN_alarm_major_ELSE_no_alarm(self, _, activity_state):
         self.ca.set_pv_value("ACTIVITY", activity_state)
         if activity_state == "Clamped":

--- a/tests/polaris_jaws_manager.py
+++ b/tests/polaris_jaws_manager.py
@@ -4,7 +4,7 @@ from utils.ioc_launcher import get_default_ioc_dir
 from genie_python.genie_cachannel_wrapper import WriteAccessException
 import os
 from parameterized.parameterized import parameterized
-from utils.testing import parameterized_list, ManagerMode
+from utils.testing import parameterized_list, ManagerMode, unstable_test
 from common_tests.jaws_manager_utils import JawsManagerBase, UNDERLYING_GAP_SP
 # IP address of device
 from utils.test_modes import TestModes
@@ -108,6 +108,7 @@ class PolarisJawsManagerTests(JawsManagerBase, unittest.TestCase):
             self.ca.assert_that_pv_is_number(underlying_jaw, 10)
 
     @parameterized.expand(["V", "H"])
+    @unstable_test()
     def test_GIVEN_jaw_5_readback_changed_WHEN_set_pv_called_THEN_underlying_jaw_5_changes(self, direction):
         underlying_jaw = UNDERLYING_GAP_SP.format(5, direction)
         self.ca.set_pv_value(SAMPLE_SP.format(direction), 10)

--- a/tests/refl.py
+++ b/tests/refl.py
@@ -9,6 +9,7 @@ from parameterized import parameterized
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import IOCRegister, get_default_ioc_dir, EPICS_TOP, PythonIOCLauncher
 from utils.test_modes import TestModes
+from utils.testing import unstable_test
 
 GALIL_ADDR = "128.0.0.0"
 DEVICE_PREFIX = "REFL"
@@ -200,6 +201,7 @@ class ReflTests(unittest.TestCase):
              self.ca.assert_that_pv_monitor_is("BL:MODE.VAL", expected_value):
                 self.ca.set_pv_value("BL:MODE:SP", expected_value)
 
+    @unstable_test()
     def test_GIVEN_new_parameter_setpoint_WHEN_triggering_move_THEN_SP_is_only_set_on_motor_when_difference_above_motor_resolution(self):
         target_mres = 0.001
         pos_above_res = 0.01


### PR DESCRIPTION
Another attempt at making the system_tests_iocs more stable:
- catch an error while setting up the tests, and then carry on with other tests
- assert that the stress rig conversion factors are not zero as this causes a `ZeroDivisionError`
- add `unstable_test` decorator in various places.