### PR TITLE
Switch assertion orders, fix wm323 test names

### DIFF
--- a/tests/instron_stress_rig.py
+++ b/tests/instron_stress_rig.py
@@ -618,11 +618,12 @@ class InstronStressRigTests(unittest.TestCase):
             float(self.ca.get_pv_value("STRESS:SCALE"))/float(self.ca.get_pv_value("STRESS:AREA")),
             float(self.ca.get_pv_value("STRAIN:SCALE"))*100000*float(self.ca.get_pv_value("STRAIN:LENGTH"))
         ]
-        expected_values = [input_values[i]/conversion_factors[i] for i in range(NUMBER_OF_CHANNELS)]
-        assert len(expected_values) == len(conversion_factors) == len(input_values) == NUMBER_OF_CHANNELS
 
         for i in range(len(conversion_factors)):
             self.assertNotEqual(0, conversion_factors[i], "Factor {} was zero".format(i))
+
+        expected_values = [input_values[i]/conversion_factors[i] for i in range(NUMBER_OF_CHANNELS)]
+        assert len(expected_values) == len(conversion_factors) == len(input_values) == NUMBER_OF_CHANNELS
 
         # Do this as two separate loops so that we can verify that all 3 channel values are stored independently
         for device_channel in range(NUMBER_OF_CHANNELS):

--- a/tests/keithley_2700.py
+++ b/tests/keithley_2700.py
@@ -4,8 +4,7 @@ import unittest
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
-from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
-
+from utils.testing import get_running_lewis_and_ioc, skip_if_recsim, unstable_test
 
 DEVICE_PREFIX = "KHLY2700_01"
 
@@ -300,6 +299,7 @@ class ChannelTests(unittest.TestCase):
         self.ca.set_pv_value("BUFF:CLEAR:SP", "")
         self.ca.assert_that_pv_is("BUFF:AUTOCLEAR", "ON")
 
+    @unstable_test()
     @skip_if_recsim("Cannot use lewis backdoor in recsim")
     def test_GIVEN_empty_buffer_WHEN_reading_inserted_THEN_channel_PVs_get_correct_values(self):
         _reset_drift_channels(self)

--- a/tests/wm323.py
+++ b/tests/wm323.py
@@ -25,7 +25,7 @@ SPEED_LOW_LIMIT = 3
 SPEED_HIGH_LIMIT = 400
 
 
-class Itc503Tests(unittest.TestCase):
+class Wm323Tests(unittest.TestCase):
     """
     Tests for the wm323 IOC.
     """


### PR DESCRIPTION
Fix assertion order