### PR TITLE
Add tests for alarms at reflectometry parameter level

### DIFF
--- a/tests/refl.py
+++ b/tests/refl.py
@@ -484,7 +484,6 @@ class ReflTests(unittest.TestCase):
         self.ca.assert_that_pv_is("PARAM:DET_ANG.STAT", no_alarm_code)
         self.ca.assert_that_pv_is("PARAM:DET_ANG.SEVR", no_alarm_code)
 
-
     def test_GIVEN_motor_axis_is_displacement_WHEN_motor_alarm_status_is_updated_THEN_alarms_propagate_to_correct_parameters_on_component(self):
         expected_severity_code = "MINOR"
         expected_status_code = "HIGH"

--- a/tests/refl.py
+++ b/tests/refl.py
@@ -16,6 +16,8 @@ DEVICE_PREFIX = "REFL"
 INITIAL_VELOCITY = 0.5
 MEDIUM_VELOCITY = 2
 FAST_VELOCITY = 100
+SOFT_LIMIT_HI = 10000
+SOFT_LIMIT_LO = -10000
 
 REFL_PATH = os.path.join(EPICS_TOP, "ISIS", "inst_servers", "master")
 GALIL_PREFIX = "GALIL_01"
@@ -36,6 +38,10 @@ IOCS = [
             "MTR0102.VMAX": INITIAL_VELOCITY,
             "MTR0104.VMAX": INITIAL_VELOCITY,
             "MTR0105.VMAX": FAST_VELOCITY,  # Remove angle as a speed limiting factor
+            "MTR0104.LLM": SOFT_LIMIT_LO,
+            "MTR0104.HLM": SOFT_LIMIT_HI,
+            "MTR0105.LLM": SOFT_LIMIT_LO,
+            "MTR0105.HLM": SOFT_LIMIT_HI,
         }
     },
     {
@@ -456,3 +462,51 @@ class ReflTests(unittest.TestCase):
         # when the movement finishes it should still be the same
         self.ca_galil.assert_that_pv_is("MTR0103.DMOV", 1, timeout=10)
         self.ca_galil.assert_that_pv_is("MTR0103.VELO", MEDIUM_VELOCITY)
+
+    def test_GIVEN_motor_axis_is_angle_WHEN_motor_alarm_status_is_updated_THEN_alarms_propagate_to_correct_parameters_on_component(self):
+        expected_severity_code = "MINOR"
+        expected_status_code = "HIGH"
+        no_alarm_code = "NO_ALARM"
+
+        # Setting High Limit = Low limit produces alarm on 0105 (detector angle)
+        self.ca_galil.set_pv_value("MTR0105.HLM", SOFT_LIMIT_LO)
+
+        # detector angle should be in alarm
+        self.ca.assert_that_pv_is("PARAM:DET_ANG.STAT", expected_status_code)
+        self.ca.assert_that_pv_is("PARAM:DET_ANG.SEVR", expected_severity_code)
+        # detector offset is independent and should not be in alarm
+        self.ca.assert_that_pv_is("PARAM:DET_POS.STAT", no_alarm_code)
+        self.ca.assert_that_pv_is("PARAM:DET_POS.SEVR", no_alarm_code)
+
+        # Setting High Limit back clears alarm
+        self.ca_galil.set_pv_value("MTR0105.HLM", SOFT_LIMIT_HI)
+
+        self.ca.assert_that_pv_is("PARAM:DET_ANG.STAT", no_alarm_code)
+        self.ca.assert_that_pv_is("PARAM:DET_ANG.SEVR", no_alarm_code)
+
+
+    def test_GIVEN_motor_axis_is_displacement_WHEN_motor_alarm_status_is_updated_THEN_alarms_propagate_to_correct_parameters_on_component(self):
+        expected_severity_code = "MINOR"
+        expected_status_code = "HIGH"
+        no_alarm_code = "NO_ALARM"
+
+        # Setting High Limit = Low limit produces alarm on 0104 (detector height)
+        self.ca_galil.set_pv_value("MTR0104.HLM", SOFT_LIMIT_LO)
+
+        # detector offset should be in alarm
+        self.ca.assert_that_pv_is("PARAM:DET_POS.STAT", expected_status_code)
+        self.ca.assert_that_pv_is("PARAM:DET_POS.SEVR", expected_severity_code)
+        # theta is derived from detector offset and should be in alarm
+        self.ca.assert_that_pv_is("PARAM:THETA.STAT", expected_status_code)
+        self.ca.assert_that_pv_is("PARAM:THETA.SEVR", expected_severity_code)
+        # detector angle is independent and should not be in alarm
+        self.ca.assert_that_pv_is("PARAM:DET_ANG.STAT", no_alarm_code)
+        self.ca.assert_that_pv_is("PARAM:DET_ANG.SEVR", no_alarm_code)
+
+        # Setting High Limit back clears alarm
+        self.ca_galil.set_pv_value("MTR0104.HLM", SOFT_LIMIT_HI)
+
+        self.ca.assert_that_pv_is("PARAM:DET_POS.STAT", no_alarm_code)
+        self.ca.assert_that_pv_is("PARAM:DET_POS.SEVR", no_alarm_code)
+        self.ca.assert_that_pv_is("PARAM:THETA.STAT", no_alarm_code)
+        self.ca.assert_that_pv_is("PARAM:THETA.SEVR", no_alarm_code)


### PR DESCRIPTION
Added tests for checking alarms on low-level motor axes are reflected appropriately on reflectometry beamline parameters.

Issue: 
https://github.com/ISISComputingGroup/IBEX/issues/3892

Related PRs:
https://github.com/ISISComputingGroup/EPICS-inst_servers/pull/244
https://github.com/ISISComputingGroup/ibex_gui/pull/987