### PR TITLE
Be more defensive about checking that necessary PVs exist

### DIFF
--- a/tests/simple.py
+++ b/tests/simple.py
@@ -54,6 +54,10 @@ class SimpleTests(unittest.TestCase):
 
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX, default_timeout=30)
 
+        # Some of the ca test PVs seem to take a while to appear on build server.
+        for protection, record in itertools.product(PROTECTION_TYPES, RECORD_TYPES):
+            self.ca.assert_that_pv_exists("CATEST:{}:{}".format(record, protection), timeout=120)
+
         self.set_auto_restart_to_true()
 
     def set_auto_restart_to_true(self):


### PR DESCRIPTION
Be more defensive about checking that certain PVs exist in simpleioc's ioc tests.