### PR TITLE
Add annotations and further notes to some motion tests

### DIFF
--- a/tests/attocube.py
+++ b/tests/attocube.py
@@ -5,7 +5,6 @@ from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
 from utils.testing import get_running_lewis_and_ioc
 
-
 DEVICE_PREFIX = "ATTOCUBE_01"
 EMULATOR = "attocube_anc350"
 
@@ -22,7 +21,6 @@ IOCS = [
     },
 ]
 
-
 TEST_MODES = [TestModes.DEVSIM]
 
 MOTOR_PV = "MTR0101"
@@ -33,39 +31,58 @@ class AttocubeTests(unittest.TestCase):
     """
     Tests for the Attocube IOC.
     """
+
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc(EMULATOR, DEVICE_PREFIX)
         self.ca = self._ioc.ca
-        self._lewis.backdoor_set_on_device('connected', True)
         self.ca.assert_that_pv_exists(MOTOR_RBV)
+        self._lewis.backdoor_set_on_device('connected', True)
+        self.ca.assert_that_pv_alarm_is(MOTOR_PV, ChannelAccess.Alarms.NONE, timeout=30)
 
-    @unittest.skip("Fix in https://github.com/ISISComputingGroup/IBEX/issues/4841")
+        self.ca.set_pv_value(MOTOR_PV + ".RTRY", 0)
+        self.ca.set_pv_value(MOTOR_PV + ".VBAS", 20)
+        self.ca.set_pv_value(MOTOR_PV + ".VMAX", 20)
+        self.ca.set_pv_value(MOTOR_PV + ".VELO", 20)
+
+        self.ca.set_pv_value(MOTOR_PV, 0)
+        self.ca.assert_that_pv_is(MOTOR_PV + ".RBV", 0, timeout=30)
+        self.ca.assert_that_pv_is(MOTOR_PV + ".DMOV", 1, timeout=30)
+
+        self._lewis.backdoor_set_on_device('axis_on', True)
+        self._lewis.assert_that_emulator_value_is('axis_on', "True")
+
     def test_WHEN_moved_to_position_THEN_position_reached(self):
-        position_setpoint = 20
+        position_setpoint = 2
         self.ca.set_pv_value(MOTOR_PV, position_setpoint)
         self.ca.assert_that_pv_value_is_increasing(MOTOR_RBV, 1)
-        self.ca.assert_that_pv_is_number(MOTOR_RBV, position_setpoint, timeout=20)
+        self.ca.assert_that_pv_is_number(MOTOR_RBV, position_setpoint, timeout=30)
 
-    @unittest.skip("Fix in https://github.com/ISISComputingGroup/IBEX/issues/4841")
+    @unittest.skip("This test is broken and is difficult to fix because the test passes consistently on dev machines, "
+                   "but fails consistently on RENO. On connecting a debugger, it appears that the motor record may be "
+                   "deadlocked, however, this is hard to diagnose with only the remote tools.")
     def test_GIVEN_device_not_connected_THEN_pv_in_alarm(self):
         self._lewis.backdoor_set_on_device('connected', False)
         self.ca.assert_that_pv_alarm_is(MOTOR_PV, ChannelAccess.Alarms.INVALID, timeout=30)
         self._lewis.backdoor_set_on_device('connected', True)
+        self.ca.assert_that_pv_alarm_is(MOTOR_PV, ChannelAccess.Alarms.NONE, timeout=30)
 
-    @unittest.skip("Fix in https://github.com/ISISComputingGroup/IBEX/issues/4841")
+    @unittest.skip("This test is broken and is difficult to fix because the test passes consistently on dev machines, "
+                   "but fails consistently on RENO. On connecting a debugger, it appears that the motor record may be "
+                   "deadlocked, however, this is hard to diagnose with only the remote tools.")
     def test_GIVEN_device_not_connected_WHEN_motor_val_set_THEN_pv_returns_to_alarm(self):
         self._lewis.backdoor_set_on_device('connected', False)
-        self.ca.assert_that_pv_alarm_is(MOTOR_PV, ChannelAccess.Alarms.INVALID, timeout=10)
-        position_setpoint = 5
+        self.ca.assert_that_pv_alarm_is(MOTOR_PV, ChannelAccess.Alarms.INVALID, timeout=30)
+        position_setpoint = 4
         self.ca.set_pv_value(MOTOR_PV, position_setpoint)
         self.ca.assert_that_pv_alarm_is(MOTOR_PV, ChannelAccess.Alarms.INVALID, timeout=30)
         self._lewis.backdoor_set_on_device('connected', True)
+        self.ca.assert_that_pv_alarm_is(MOTOR_PV, ChannelAccess.Alarms.NONE, timeout=30)
 
     def test_GIVEN_axis_not_on_WHEN_motor_moved_THEN_axis_turned_on_and_moves(self):
         self._lewis.backdoor_set_on_device('axis_on', False)
-        position_setpoint = 5
+        position_setpoint = 6
         self.ca.set_pv_value(MOTOR_PV, position_setpoint)
         self.ca.assert_that_pv_value_is_increasing(MOTOR_RBV, 1)
-        self.ca.assert_that_pv_is_number(MOTOR_RBV, position_setpoint, timeout=20)
+        self.ca.assert_that_pv_is_number(MOTOR_RBV, position_setpoint, timeout=30)
 
-        self.assertTrue(self._lewis.backdoor_get_from_device('axis_on'))
+        self._lewis.assert_that_emulator_value_is('axis_on', "True")

--- a/tests/nimrod_jaws_manager.py
+++ b/tests/nimrod_jaws_manager.py
@@ -3,7 +3,7 @@ import unittest
 from utils.ioc_launcher import get_default_ioc_dir
 import os
 from parameterized.parameterized import parameterized
-from utils.testing import parameterized_list
+from utils.testing import parameterized_list, unstable_test
 from common_tests.jaws_manager_utils import JawsManagerBase, MOD_GAP
 
 # IP address of device
@@ -43,7 +43,7 @@ class NimrodJawsManagerTests(JawsManagerBase, unittest.TestCase):
         (70, 40, [60.2, 57.7, 51.6, 46.5, 43.7, 40]),
         (130, 5, [89, 78.8, 53.4, 31.9, 20.6, 5]),
     ]))
-    @unittest.skip("Fix in https://github.com/ISISComputingGroup/IBEX/issues/4841")
+    @unstable_test(max_retries=10)
     def test_WHEN_sample_gap_set_THEN_other_jaws_as_expected(self, _, mod_gap, sample_gap, expected):
         self.ca.set_pv_value(MOD_GAP.format("V"), mod_gap)
         self._test_WHEN_sample_gap_set_THEN_other_jaws_as_expected("V", sample_gap, expected)


### PR DESCRIPTION
Fixes one test in the attocube test suite, and retries (rather than skipping) a test in the jaws manager test suite.

After several hours of investigation between myself, @ChrisColeExpControl and @John-Holt-Tessella we think there is a problem somewhere in the motor record, where it sometimes gets into a deadlocked/frozen state and fails to respond in a correct way. We haven't been able to diagnose this problem - I will create a ticket.