### PR TITLE
Make tp flag fail better

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -231,10 +231,11 @@ if __name__ == '__main__':
     arguments = parser.parse_args()
 
     if os.path.dirname(arguments.tests_path):
-        tests_module_path = os.path.abspath(os.path.dirname(arguments.tests_path))
-        if not os.path.isdir(tests_module_path):
-            print("Test path {} not found".format(tests_module_path))
+        full_path = os.path.abspath(arguments.tests_path)
+        if not os.path.isdir(full_path):
+            print("Test path {} not found".format(full_path))
             sys.exit(-1)
+        tests_module_path = os.path.dirname(full_path)
         sys.path.insert(0, tests_module_path)
         arguments.tests_path = os.path.basename(arguments.tests_path)
 


### PR DESCRIPTION
When giving the tp flag to `run_tests.py` if you give a non-existent folder the script should fail.

**To test**

Create a folder called `new_folder` with an `__init__.py` and one of the IOC tests in it

On master:
- Run `run_tests.py -tp .\\new_folder -l` confirm that the single IOC test is listed
- Run `run_tests.py -tp .\\non_existent_folder -l` confirm that all IOC tests are listed (we don't want this)

On branch:
- Run `run_tests.py -tp .\\new_folder -l` confirm that the single IOC test is listed
- Run `run_tests.py -tp .\\non_existent_folder -l` confirm that an error message is given
- Run `run_tests.py -l` confirm all IOC tests are listed