### PR TITLE
Revert "Re-enable tests post 64bit pointer fix in attocube code"

### DIFF
--- a/tests/attocube.py
+++ b/tests/attocube.py
@@ -57,12 +57,18 @@ class AttocubeTests(unittest.TestCase):
         self.ca.assert_that_pv_value_is_increasing(MOTOR_RBV, 1)
         self.ca.assert_that_pv_is_number(MOTOR_RBV, position_setpoint, timeout=30)
 
+    @unittest.skip("This test is broken and is difficult to fix because the test passes consistently on dev machines, "
+                   "but fails consistently on RENO. On connecting a debugger, it appears that the motor record may be "
+                   "deadlocked, however, this is hard to diagnose with only the remote tools (will be fixed in #5049).")
     def test_GIVEN_device_not_connected_THEN_pv_in_alarm(self):
         self._lewis.backdoor_set_on_device('connected', False)
         self.ca.assert_that_pv_alarm_is(MOTOR_PV, ChannelAccess.Alarms.INVALID, timeout=30)
         self._lewis.backdoor_set_on_device('connected', True)
         self.ca.assert_that_pv_alarm_is(MOTOR_PV, ChannelAccess.Alarms.NONE, timeout=30)
 
+    @unittest.skip("This test is broken and is difficult to fix because the test passes consistently on dev machines, "
+                   "but fails consistently on RENO. On connecting a debugger, it appears that the motor record may be "
+                   "deadlocked, however, this is hard to diagnose with only the remote tools (will be fixed in #5049).")
     def test_GIVEN_device_not_connected_WHEN_motor_val_set_THEN_pv_returns_to_alarm(self):
         self._lewis.backdoor_set_on_device('connected', False)
         self.ca.assert_that_pv_alarm_is(MOTOR_PV, ChannelAccess.Alarms.INVALID, timeout=30)


### PR DESCRIPTION
Reverts https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework/pull/274

The above pull request was merged to see whether the new attocube code would make the tests pass on RENO - the tests have now had time to run, and they are not fixed. Disable the tests again.

