### PR TITLE
added timeout for assertion for flowrate

### DIFF
--- a/tests/jsco4180.py
+++ b/tests/jsco4180.py
@@ -108,7 +108,7 @@ class Jsco4180Tests(unittest.TestCase):
         self.ca.set_pv_value("TIME:RUN:SP", 100)
         self.ca.set_pv_value("START:SP", "Start")
 
-        self.ca.assert_that_pv_is("FLOWRATE", expected_value)
+        self.ca.assert_that_pv_is("FLOWRATE", expected_value, timeout=5)
 
     @skip_if_recsim("LeWIS backdoor not supported in RECSIM")
     def test_GIVEN_an_ioc_WHEN_set_flowrate_and_pump_volume_THEN_ioc_uses_rbv_for_calculation_of_remaining_time(self):


### PR DESCRIPTION
In December I had reviewed a ticket fixing a bug for the Jasco https://github.com/ISISComputingGroup/IBEX/issues/4872 .

Apparently, I had forgotten to run all the IOC test for Jasco to make sure they all pass. I remembered this and checked it and found out that test_GIVEN_an_ioc_WHEN_set_flowrate_THEN_flowrate_setpoint_is_correct consistently failed when you run all the IOC tests, but if you run just that one test then it consistently passed. I reverted all commits done before the changes in that ticket and found that this was not an issue before.

I added a timeout so the pv has time to update so the test can pass.