### PR TITLE
Fix system tests

### DIFF
--- a/common_tests/danfysik.py
+++ b/common_tests/danfysik.py
@@ -136,6 +136,7 @@ class DanfysikCommon(DanfysikBase):
             self.ca.assert_that_pv_is("{}CURR".format(id_prefix), 0)
             self.ca.assert_that_pv_is("{}VOLT".format(id_prefix), 0)
 
+    @skip_if_condition(lambda: "RKNPS_01" in IOCRegister.RunningIOCs.keys(), "AUTOONOFF not implemented in RKNPS")
     def test_GIVEN_power_on_and_zero_sp_WHEN_enabling_auto_onoff_THEN_device_is_powered_off(self):
         self.ca.set_pv_value("AUTOONOFF", 0)
         self.ca.set_pv_value("POWER:SP", 1)
@@ -146,6 +147,7 @@ class DanfysikCommon(DanfysikBase):
 
         self.ca.assert_that_pv_is("POWER:SP", "Off")
 
+    @skip_if_condition(lambda: "RKNPS_01" in IOCRegister.RunningIOCs.keys(), "AUTOONOFF not implemented in RKNPS")
     def test_GIVEN_power_off_and_non_zero_sp_WHEN_enabling_auto_onoff_THEN_device_is_powered_on(self):
         self.ca.set_pv_value("AUTOONOFF", 0)
         self.ca.set_pv_value("POWER:SP", 0)
@@ -156,6 +158,7 @@ class DanfysikCommon(DanfysikBase):
 
         self.ca.assert_that_pv_is("POWER:SP", "On")
 
+    @skip_if_condition(lambda: "RKNPS_01" in IOCRegister.RunningIOCs.keys(), "AUTOONOFF not implemented in RKNPS")
     def test_GIVEN_power_off_and_zero_sp_WHEN_enabling_auto_onoff_THEN_device_remains_off(self):
         self.ca.set_pv_value("AUTOONOFF", 0)
         self.ca.set_pv_value("POWER:SP", 0)
@@ -166,6 +169,7 @@ class DanfysikCommon(DanfysikBase):
 
         self.ca.assert_that_pv_is("POWER:SP", "Off")
 
+    @skip_if_condition(lambda: "RKNPS_01" in IOCRegister.RunningIOCs.keys(), "AUTOONOFF not implemented in RKNPS")
     def test_GIVEN_power_on_and_non_zero_sp_WHEN_enabling_auto_onoff_THEN_device_remains_on(self):
         self.ca.set_pv_value("AUTOONOFF", 0)
         self.ca.set_pv_value("POWER:SP", 1)
@@ -176,6 +180,7 @@ class DanfysikCommon(DanfysikBase):
 
         self.ca.assert_that_pv_is("POWER:SP", "On")
 
+    @skip_if_condition(lambda: "RKNPS_01" in IOCRegister.RunningIOCs.keys(), "AUTOONOFF not implemented in RKNPS")
     def test_GIVEN_power_on_and_auto_onoff_enabled_WHEN_setting_zero_value_THEN_device_is_powered_off(self):
         self.ca.set_pv_value("POWER:SP", 1)
         self.ca.set_pv_value("CURR:SP", 10)
@@ -186,6 +191,7 @@ class DanfysikCommon(DanfysikBase):
 
         self.ca.assert_that_pv_is("POWER:SP", "Off")
 
+    @skip_if_condition(lambda: "RKNPS_01" in IOCRegister.RunningIOCs.keys(), "AUTOONOFF not implemented in RKNPS")
     def test_GIVEN_power_off_and_auto_onoff_enabled_WHEN_setting_non_zero_value_THEN_device_is_powered_on(self):
         self.ca.set_pv_value("AUTOONOFF", 1)
         self.ca.set_pv_value("POWER:SP", 0)
@@ -196,6 +202,7 @@ class DanfysikCommon(DanfysikBase):
 
         self.ca.assert_that_pv_is("POWER:SP", "On")
 
+    @skip_if_condition(lambda: "RKNPS_01" in IOCRegister.RunningIOCs.keys(), "AUTOONOFF not implemented in RKNPS")
     def test_GIVEN_auto_onoff_disabled_WHEN_sweep_to_zero_and_turn_off_triggered_THEN_actioned_by_enabling_auto_onoff_and_setting_sp_to_zero(self):
         self.ca.set_pv_value("AUTOONOFF", 0)
         self.ca.set_pv_value("POWER:SP", 1)

--- a/tests/ccd100.py
+++ b/tests/ccd100.py
@@ -73,6 +73,9 @@ class CCD100SecondDeviceTests(CCD100Tests):
 class CCD100LogTests(unittest.TestCase):
     """
     Tests for the log messages produced by CCD100.
+
+    In general all we want to test here is that we're not producing excessive messages. Unfortunately some of the
+    messages outputted by autosave etc. are outside our control so we're just testing messages are less than some value.
     """
     NUM_OF_PVS = 3
 
@@ -84,25 +87,27 @@ class CCD100LogTests(unittest.TestCase):
         sleep(2)  # Wait for previous errors to get logged
 
     @skip_if_recsim("Cannot check log messages in rec sim")
-    def test_GIVEN_not_in_error_WHEN_put_in_error_THEN_three_log_messages_per_pv_logged_in_five_secs(self):
-        self._set_error_state(False) # Should already be out of error state but doing this again to ingest logs
-        with assert_log_messages(self._ioc, self.NUM_OF_PVS*3, 5) as log:
+    def test_GIVEN_not_in_error_WHEN_put_in_error_THEN_less_than_four_log_messages_per_pv_logged_in_five_secs(self):
+        self._set_error_state(False)  # Should already be out of error state but doing this again to ingest logs
+        # Actually expect 3 messages but checking for 4 as a buffer see comment above
+        with assert_log_messages(self._ioc, self.NUM_OF_PVS*4, 5) as log:
             self._set_error_state(True)
 
     @skip_if_recsim("Cannot check log messages in rec sim")
-    def test_GIVEN_in_error_WHEN_error_cleared_THEN_one_log_message_per_pv_logged(self):
+    def test_GIVEN_in_error_WHEN_error_cleared_THEN_less_than_two_log_message_per_pv_logged(self):
         self._set_error_state(True)
-        with assert_log_messages(self._ioc, self.NUM_OF_PVS*1):
+        # Actually expect 1 message but checking for 2 as a buffer see comment above
+        with assert_log_messages(self._ioc, self.NUM_OF_PVS*2):
             self._set_error_state(False)
 
-    @unstable_test()
     @skip_if_recsim("Cannot check log messages in rec sim")
-    def test_GIVEN_in_error_WHEN_error_string_changed_THEN_three_log_message_per_pv_logged_in_five_secs(self):
+    def test_GIVEN_in_error_WHEN_error_string_changed_THEN_less_than_four_log_message_per_pv_logged_in_five_secs(self):
         self._lewis.backdoor_set_on_device("out_error", "OLD_ERROR")
         self._set_error_state(True)
 
         new_error = "A_NEW_ERROR"
-        with assert_log_messages(self._ioc, self.NUM_OF_PVS*3, 5) as log:
+        # Actually expect 3 messages but checking for 4 as a buffer see comment above
+        with assert_log_messages(self._ioc, self.NUM_OF_PVS*4, 5) as log:
             self._lewis.backdoor_set_on_device("out_error", new_error)
 
         self.assertTrue(new_error in log.messages[-1])

--- a/utils/testing.py
+++ b/utils/testing.py
@@ -57,9 +57,10 @@ class _AssertLogContext(object):
 
         actual_num_of_messages = len(self.messages)
 
-        if self.exp_num_of_messages is not None and actual_num_of_messages != self.exp_num_of_messages:
-            raise AssertionError("Incorrect number of log messages created. Expected {} and found {}"
-                                 .format(self.exp_num_of_messages, actual_num_of_messages))
+        if self.exp_num_of_messages is not None and actual_num_of_messages > self.exp_num_of_messages:
+            raise AssertionError("Incorrect number of log messages created. Expected {} and found {}.\n"
+                                 "Found log messages were: \n{}"
+                                 .format(self.exp_num_of_messages, actual_num_of_messages, "\n".join(self.messages)))
 
         if self.must_contain is not None and not any(self.must_contain in message for message in self.messages):
             raise AssertionError("Expected the generated log messages to contain the string '{}' but they didn't.\n"
@@ -96,7 +97,7 @@ def assert_log_messages(ioc, number_of_messages=None, in_time=1, must_contain=No
     A context object that asserts that the given code produces the given number of ioc log messages in the the given
     amount of time.
 
-    To assert that only 5 messages are produced in 5 seconds::
+    To assert that no more than 5 messages are produced in 5 seconds::
         with assert_log_messages(self._ioc, 5, 5):
             do_something()
 
@@ -108,7 +109,7 @@ def assert_log_messages(ioc, number_of_messages=None, in_time=1, must_contain=No
 
     Args:
         ioc (IocLauncher): The IOC that we are checking the logs for.
-        number_of_messages (int): The number of messages that are expected (None to not check number of messages)
+        number_of_messages (int): The maximum number of messages that are expected (None to not check number of messages)
         in_time (int): The number of seconds to wait for messages
         must_contain (str): a string which must be contained in at least one of the messages (None to not check)
         ignore_log_client_failures (bool): Whether to ignore messages about not being able to connect to logserver


### PR DESCRIPTION
Fixes the IOC system tests by:

* Skipping the `AUTOONOFF` tests for `RKNPS` as they do not use them
* Making the `CCD100` logging test more forgiving