### PR TITLE
Ticket5057 cryosms basic qsm

### DIFF
--- a/tests/cryosms.py
+++ b/tests/cryosms.py
@@ -83,3 +83,43 @@ class CryoSMSTests(unittest.TestCase):
     @parameterized.expand(["TESLA", "AMPS"])
     def test_GIVEN_outputmode_sp_correct_WHEN_outputmode_sp_written_to_THEN_outputmode_changes(self, units):
         self.ca.assert_setting_setpoint_sets_readback(units, "OUTPUTMODE", "OUTPUTMODE:SP", timeout=10)
+
+    @skip_if_recsim("C++ driver can not correctly initialise in recsim")
+    def test_GIVEN_IOC_not_ramping_WHEN_ramp_started_THEN_simulated_ramp_performed(self):
+        self.ca.set_pv_value("START:SP", 1)
+        self.ca.assert_that_pv_is("QSM:STATE", "RAMPING", msg="Ramping failed to start")
+        self.ca.assert_that_pv_is("QSM:STATE", "HOLDING ON TARGET", timeout=10)
+
+    @skip_if_recsim("C++ driver can not correctly initialise in recsim")
+    def test_GIVEN_IOC_ramping_WHEN_paused_and_unpaused_THEN_ramp_is_paused_resumed_and_completes(self):
+        # GIVEN ramping
+        self.ca.set_pv_value("START:SP", 1)
+        self.ca.assert_that_pv_is("QSM:STATE", "RAMPING")
+        # Pauses when pause set to true
+        self.ca.set_pv_value("PAUSE:SP", 1)
+        self.ca.assert_that_pv_is("QSM:STATE", "HOLDING ON PAUSE", msg="Ramping failed to pause")
+        self.ca.assert_that_pv_is_not("RAMP:STAT", "HOLDING ON TARGET", timeout=10,
+                                      msg="Ramp completed even though it should have paused")
+        # Resumes when pause set to false, completes ramp
+        self.ca.set_pv_value("PAUSE:SP", 0)
+        self.ca.assert_that_pv_is("QSM:STATE", "RAMPING", msg="Ramping failed to resume")
+        self.ca.assert_that_pv_is("QSM:STATE", "HOLDING ON TARGET", timeout=10, msg="Ramping failed to complete")
+
+    @skip_if_recsim("C++ driver can not correctly initialise in recsim")
+    def test_GIVEN_IOC_ramping_WHEN_aborted_THEN_ramp_aborted(self):
+        # Given Ramping
+        self.ca.set_pv_value("START:SP", 1)
+        self.ca.assert_that_pv_is("QSM:STATE", "RAMPING")
+        # Aborts when abort set to true, then hits ready again
+        self.ca.set_pv_value("ABORT:SP", 1)
+        self.ca.assert_that_pv_is("QSM:STATE", "HOLDING ON TARGET")
+
+    @skip_if_recsim("C++ driver can not correctly initialise in recsim")
+    def test_GIVEN_IOC_paused_WHEN_aborted_THEN_ramp_aborted(self):
+        # GIVEN paused
+        self.ca.set_pv_value("START:SP", 1)
+        self.ca.set_pv_value("PAUSE:SP", 1)
+        self.ca.assert_that_pv_is("QSM:STATE", "HOLDING ON PAUSE", msg="Ramping failed to pause")
+        # Aborts when abort set to true, then hits ready again
+        self.ca.set_pv_value("ABORT:SP", 1)
+        self.ca.assert_that_pv_is("QSM:STATE", "HOLDING ON TARGET")

--- a/tests/cryosms.py
+++ b/tests/cryosms.py
@@ -50,6 +50,9 @@ class CryoSMSTests(unittest.TestCase):
             self.ca.assert_that_pv_exists("DISABLE", timeout=30)
         else:
             self.ca.assert_that_pv_is("INIT", "Startup complete",  timeout=30)
+            self.ca.set_pv_value("PAUSE:SP", 0)
+            self.ca.set_pv_value("ABORT:SP", 0)
+            self.ca.assert_that_pv_is("RAMP:STAT", "HOLDING ON TARGET")
 
     @skip_if_recsim("Cannot properly simulate device startup in recsim")
     def test_GIVEN_certain_macros_WHEN_IOC_loads_THEN_correct_values_initialised(self):
@@ -87,39 +90,41 @@ class CryoSMSTests(unittest.TestCase):
     @skip_if_recsim("C++ driver can not correctly initialise in recsim")
     def test_GIVEN_IOC_not_ramping_WHEN_ramp_started_THEN_simulated_ramp_performed(self):
         self.ca.set_pv_value("START:SP", 1)
-        self.ca.assert_that_pv_is("QSM:STATE", "RAMPING", msg="Ramping failed to start")
-        self.ca.assert_that_pv_is("QSM:STATE", "HOLDING ON TARGET", timeout=10)
+        self.ca.assert_that_pv_is("RAMP:STAT", "RAMPING", msg="Ramping failed to start")
+        self.ca.assert_that_pv_is("RAMP:STAT", "HOLDING ON TARGET", timeout=10)
 
     @skip_if_recsim("C++ driver can not correctly initialise in recsim")
     def test_GIVEN_IOC_ramping_WHEN_paused_and_unpaused_THEN_ramp_is_paused_resumed_and_completes(self):
         # GIVEN ramping
         self.ca.set_pv_value("START:SP", 1)
-        self.ca.assert_that_pv_is("QSM:STATE", "RAMPING")
+        self.ca.assert_that_pv_is("RAMP:STAT", "RAMPING")
         # Pauses when pause set to true
         self.ca.set_pv_value("PAUSE:SP", 1)
-        self.ca.assert_that_pv_is("QSM:STATE", "HOLDING ON PAUSE", msg="Ramping failed to pause")
-        self.ca.assert_that_pv_is_not("RAMP:STAT", "HOLDING ON TARGET", timeout=10,
+        self.ca.assert_that_pv_is("RAMP:STAT", "HOLDING ON PAUSE", msg="Ramping failed to pause")
+        self.ca.assert_that_pv_is_not("RAMP:STAT", "HOLDING ON TARGET", timeout=5,
                                       msg="Ramp completed even though it should have paused")
         # Resumes when pause set to false, completes ramp
         self.ca.set_pv_value("PAUSE:SP", 0)
-        self.ca.assert_that_pv_is("QSM:STATE", "RAMPING", msg="Ramping failed to resume")
-        self.ca.assert_that_pv_is("QSM:STATE", "HOLDING ON TARGET", timeout=10, msg="Ramping failed to complete")
+        self.ca.assert_that_pv_is("RAMP:STAT", "RAMPING", msg="Ramping failed to resume")
+        self.ca.assert_that_pv_is("RAMP:STAT", "HOLDING ON TARGET", timeout=10, msg="Ramping failed to complete")
 
     @skip_if_recsim("C++ driver can not correctly initialise in recsim")
     def test_GIVEN_IOC_ramping_WHEN_aborted_THEN_ramp_aborted(self):
         # Given Ramping
         self.ca.set_pv_value("START:SP", 1)
-        self.ca.assert_that_pv_is("QSM:STATE", "RAMPING")
+        self.ca.assert_that_pv_is("RAMP:STAT", "RAMPING")
         # Aborts when abort set to true, then hits ready again
         self.ca.set_pv_value("ABORT:SP", 1)
-        self.ca.assert_that_pv_is("QSM:STATE", "HOLDING ON TARGET")
+        self.ca.assert_that_pv_is("RAMP:STAT", "HOLDING ON TARGET", timeout=10)
 
     @skip_if_recsim("C++ driver can not correctly initialise in recsim")
     def test_GIVEN_IOC_paused_WHEN_aborted_THEN_ramp_aborted(self):
         # GIVEN paused
         self.ca.set_pv_value("START:SP", 1)
         self.ca.set_pv_value("PAUSE:SP", 1)
-        self.ca.assert_that_pv_is("QSM:STATE", "HOLDING ON PAUSE", msg="Ramping failed to pause")
+        rampTarget = self.ca.get_pv_value("MID")
+        self.ca.assert_that_pv_is("RAMP:STAT", "HOLDING ON PAUSE", msg="Ramping failed to pause")
         # Aborts when abort set to true, then hits ready again
         self.ca.set_pv_value("ABORT:SP", 1)
-        self.ca.assert_that_pv_is("QSM:STATE", "HOLDING ON TARGET")
+        self.ca.assert_that_pv_is("RAMP:STAT", "HOLDING ON TARGET", timeout=10)
+        self.ca.assert_that_pv_is_not("MID", rampTarget)


### PR DESCRIPTION
### Description of Work
Added tests for the new QSM in the CRYOSMS IOC.

### To test
https://github.com/ISISComputingGroup/IBEX/issues/5057

### Acceptance criteria
New tests have been added which effectively test:
 - [x] Ramping all the way to the ramp target
 - [x] Ramping to the target, pausing/unpausing in the middle
 - [x] Ramping part of the way to a target before aborting
 - [x] Ramping part of the way to a target, pausing, then aborting
---
 - [x] These tests should not interfere with each other, so state machine should be reset before each test