### PR TITLE
Ticket4918 sans dls

### DIFF
--- a/tests/lsicorr.py
+++ b/tests/lsicorr.py
@@ -117,11 +117,6 @@ class LSITests(unittest.TestCase):
         self.ca.assert_that_pv_is("ERRORMSG", error_message)
         pass
 
-    def test_GIVEN_enum_setting_WHEN_setting_pv_read_THEN_enum_name_is_returned(self):
-        setting_pv = "CORRELATIONTYPE"
-        self.ca.assert_that_pv_exists(setting_pv)
-        self.ca.assert_that_pv_is(setting_pv, "AUTO")
-
     @parameterized.expand([
         ("NORMALIZATION", ("SYMMETRIC", "COMPENSATED")),
         ("SWAPCHANNELS", ("ChA_ChB", "ChB_ChA")),
@@ -131,5 +126,16 @@ class LSITests(unittest.TestCase):
     ])
     def test_GIVEN_enum_setting_WHEN_setting_pv_written_to_THEN_new_value_read_back(self, pv, values):
         for value in values:
-            self.ca.set_pv_value(pv, value)
+            self.ca.set_pv_value(pv, value, sleep_after_set=0.0)
             self.ca.assert_that_pv_is(pv, value)
+
+    @parameterized.expand([
+        ("OVERLOADLIMIT", "Mcps"),
+        ("SCATTERING_ANGLE", "degree"),
+        ("SAMPLE_TEMP", "C"),
+        ("SOLVENT_VISCOSITY", ""),
+        ("SOLVENT_REFRACTIVE_INDEX", "mPas"),
+        ("LASER_WAVELENGTH", "nm")
+    ])
+    def test_GIVEN_pv_with_unit_WHEN_EGU_field_read_from_THEN_unit_returned(self, pv, expected_unit):
+        self.ca.assert_that_pv_is("{pv}.EGU".format(pv=pv), expected_unit)

--- a/tests/lsicorr.py
+++ b/tests/lsicorr.py
@@ -51,7 +51,14 @@ class LSITests(unittest.TestCase):
 
     def test_GIVEN_setting_pv_WHEN_pv_written_to_THEN_new_value_read_back(self):
         pv_name = "MEASUREMENTDURATION"
-        pv_value = 1000.0
+        pv_value = 1000
 
         self.ca.set_pv_value(pv_name, pv_value)
         self.ca.assert_that_pv_is_number(pv_name, pv_value)
+
+    def test_GIVEN_setting_pv_WHEN_pv_written_to_with_invalid_value_THEN_value_not_updated(self):
+        pv_name = "MEASUREMENTDURATION"
+        original_value = self.ca.get_pv_value(pv_name)
+
+        self.ca.set_pv_value(pv_name, -1)
+        self.ca.assert_that_pv_is_number(pv_name, original_value)

--- a/tests/lsicorr.py
+++ b/tests/lsicorr.py
@@ -80,3 +80,8 @@ class LSITests(unittest.TestCase):
 
         self.ca.assert_that_pv_is("ERRORMSG", error_message)
         pass
+
+    def test_GIVEN_enum_setting_WHEN_setting_pv_read_THEN_enum_name_is_returned(self):
+        setting_pv = "CORRELATIONTYPE"
+        self.ca.assert_that_pv_exists(setting_pv)
+        self.ca.assert_that_pv_is(setting_pv, "AUTO")

--- a/tests/lsicorr.py
+++ b/tests/lsicorr.py
@@ -17,7 +17,7 @@ IOCS = [
     {
         "ioc_launcher_class": ProcServLauncher,
         "name": DEVICE_PREFIX,
-        "directory": get_default_ioc_dir("LSICORR"),
+        "directory": get_default_ioc_dir("LSICORR", iocnum=ioc_number),
         "started_text": "IOC started",
         "macros": {
         }

--- a/tests/lsicorr.py
+++ b/tests/lsicorr.py
@@ -43,12 +43,6 @@ class LSITests(unittest.TestCase):
         self._ioc = IOCRegister.get_running("LSI")
         self.ca = ChannelAccess(default_timeout=30, device_prefix=DEVICE_PREFIX)
 
-    def test_GIVEN_setting_pv_WHEN_pv_read_THEN_value_returned(self):
-        pv_name = "MEASUREMENTDURATION"
-
-        self.ca.assert_that_pv_exists(pv_name)
-        self.ca.assert_that_pv_is_number(pv_name, 300)
-
     def test_GIVEN_setting_pv_WHEN_pv_written_to_THEN_new_value_read_back(self):
         pv_name = "MEASUREMENTDURATION"
         pv_value = 1000
@@ -62,3 +56,10 @@ class LSITests(unittest.TestCase):
 
         self.ca.set_pv_value(pv_name, -1)
         self.ca.assert_that_pv_is_number(pv_name, original_value)
+
+    def test_GIVEN_integer_device_setting_WHEN_pv_written_to_with_a_float_THEN_value_is_rounded_before_setting(self):
+        pv_name = "MEASUREMENTDURATION"
+        new_value = 12.3
+
+        self.ca.set_pv_value(pv_name, new_value)
+        self.ca.assert_that_pv_is_number(pv_name, 12)

--- a/tests/lsicorr.py
+++ b/tests/lsicorr.py
@@ -5,7 +5,7 @@ import time
 from parameterized import parameterized
 
 from utils.channel_access import ChannelAccess
-from utils.ioc_launcher import IOCRegister, get_default_ioc_dir, EPICS_TOP, PythonIOCLauncher
+from utils.ioc_launcher import IOCRegister, get_default_ioc_dir, EPICS_TOP, ProcServLauncher
 from utils.test_modes import TestModes
 from utils.testing import parameterized_list, ManagerMode, unstable_test
 
@@ -15,12 +15,10 @@ DEVICE_PREFIX = "LSICORR_{:02d}".format(ioc_number)
 LSICORR_PATH = os.path.join(EPICS_TOP, "support", "lsicorr", "master")
 IOCS = [
     {
-        "ioc_launcher_class": PythonIOCLauncher,
+        "ioc_launcher_class": ProcServLauncher,
         "name": DEVICE_PREFIX,
-        "directory": LSICORR_PATH,
-        "python_script_commandline": [os.path.join(LSICORR_PATH, "LSi_Correlator.py"), "--pv_prefix", "TE:NDW1836:", "--ioc_number", "{}".format(ioc_number)],
+        "directory": get_default_ioc_dir("LSICORR"),
         "started_text": "IOC started",
-        "python_version": 3,
         "macros": {
         }
     }
@@ -136,7 +134,7 @@ class LSITests(unittest.TestCase):
     @parameterized.expand([
         ("OVERLOADLIMIT", "Mcps"),
         ("SCATTERING_ANGLE", "degree"),
-        ("SAMPLE_TEMP", "C"),
+        ("SAMPLE_TEMP", "K"),
         ("SOLVENT_VISCOSITY", "mPas"),
         ("SOLVENT_REFRACTIVE_INDEX", ""),
         ("LASER_WAVELENGTH", "nm")

--- a/tests/lsicorr.py
+++ b/tests/lsicorr.py
@@ -1,0 +1,49 @@
+import os
+import unittest
+import time
+from contextlib import contextmanager
+from math import tan, radians, cos
+
+from parameterized import parameterized
+
+from utils.channel_access import ChannelAccess
+from utils.ioc_launcher import IOCRegister, get_default_ioc_dir, EPICS_TOP, PythonIOCLauncher
+from utils.test_modes import TestModes
+from utils.testing import ManagerMode
+from utils.testing import unstable_test
+
+DEVICE_PREFIX = "LSI"
+
+LSICORR_PATH = os.path.join(EPICS_TOP, "support", "lsicorr", "master")
+IOCS = [
+    {
+        "ioc_launcher_class": PythonIOCLauncher,
+        "name": DEVICE_PREFIX,
+        "directory": LSICORR_PATH,
+        "python_script_commandline": [os.path.join(LSICORR_PATH, "LSi_Correlator.py"), "--pv_prefix", "TE:NDW1836:"],
+        "started_text": "IOC started",
+        "pv_for_existence": "MEASUREMENTDURATION",
+        "python_version": 3,
+        "macros": {
+        }
+    }
+
+]
+
+
+TEST_MODES = [TestModes.DEVSIM]
+
+class LSITests(unittest.TestCase):
+    """
+    Tests for LSi Correlator
+    """
+
+    def setUp(self):
+        self._ioc = IOCRegister.get_running("LSI")
+        self.ca = ChannelAccess(default_timeout=30, device_prefix=DEVICE_PREFIX)
+
+    def test_GIVEN_setting_pv_WHEN_pv_read_THEN_value_returned(self):
+        pv_name = "MEASUREMENTDURATION"
+
+        self.ca.assert_that_pv_exists(pv_name)
+        self.ca.assert_that_pv_is_number(pv_name, 300)

--- a/tests/lsicorr.py
+++ b/tests/lsicorr.py
@@ -63,3 +63,20 @@ class LSITests(unittest.TestCase):
 
         self.ca.set_pv_value(pv_name, new_value)
         self.ca.assert_that_pv_is_number(pv_name, 12)
+
+    @unittest.skip('Monitors arent working yet')
+    def test_GIVEN_monitor_on_setting_pv_WHEN_pv_changed_THEN_monitor_gets_updated(self):
+        pv_name = "MEASUREMENTDURATION"
+        self.ca.set_pv_value(pv_name, 10.0)
+        new_value = 12.3
+
+        with self.ca.assert_that_pv_monitor_is_number(pv_name, 12.0):
+            self.ca.set_pv_value(pv_name, new_value)
+
+    def test_GIVEN_invalid_value_for_setting_WHEN_setting_pv_written_THEN_status_pv_updates_with_error(self):
+        setting_pv = "MEASUREMENTDURATION"
+        self.ca.set_pv_value(setting_pv, -1)
+        error_message = "LSI --- wrong value assigned to MeasurementDuration"
+
+        self.ca.assert_that_pv_is("ERRORMSG", error_message)
+        pass

--- a/tests/lsicorr.py
+++ b/tests/lsicorr.py
@@ -139,3 +139,10 @@ class LSITests(unittest.TestCase):
     ])
     def test_GIVEN_pv_with_unit_WHEN_EGU_field_read_from_THEN_unit_returned(self, pv, expected_unit):
         self.ca.assert_that_pv_is("{pv}.EGU".format(pv=pv), expected_unit)
+
+    @parameterized.expand([
+        ("CORRELATION_FUNCTION", 400),
+        ("LAGS", 400),
+    ])
+    def test_GIVEN_array_pv_WHEN_NELM_field_read_THEN_length_of_array_returned(self, pv, expected_length):
+        self.ca.assert_that_pv_is_number("{pv}.NELM".format(pv=pv), expected_length)

--- a/tests/lsicorr.py
+++ b/tests/lsicorr.py
@@ -7,8 +7,7 @@ from parameterized import parameterized
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import IOCRegister, get_default_ioc_dir, EPICS_TOP, PythonIOCLauncher
 from utils.test_modes import TestModes
-from utils.testing import ManagerMode
-from utils.testing import unstable_test
+from utils.testing import parameterized_list, ManagerMode, unstable_test
 
 DEVICE_PREFIX = "LSI"
 
@@ -146,3 +145,29 @@ class LSITests(unittest.TestCase):
     ])
     def test_GIVEN_array_pv_WHEN_NELM_field_read_THEN_length_of_array_returned(self, pv, expected_length):
         self.ca.assert_that_pv_is_number("{pv}.NELM".format(pv=pv), expected_length)
+
+    @parameterized.expand(parameterized_list(["CORRELATIONTYPE",
+                                              "NORMALIZATION",
+                                              "MEASUREMENTDURATION",
+                                              "SWAPCHANNELS",
+                                              "SAMPLINGTIMEMULTIT",
+                                              "TRANSFERRATE",
+                                              "OVERLOADLIMIT",
+                                              "OVERLOADINTERVAL",
+                                              "ERRORMSG",
+                                              "FILEPATH",
+                                              "FILENAME",
+                                              "TAKEDATA",
+                                              "CORRELATION_FUNCTION",
+                                              "LAGS",
+                                              "REPETITIONS",
+                                              "CURRENT_REPETITION",
+                                              "RUNNING",
+                                              "CONNECTED",
+                                              "SCATTERING_ANGLE",
+                                              "SAMPLE_TEMP",
+                                              "SOLVENT_VISCOSITY",
+                                              "SOLVENT_REFRACTIVE_INDEX",
+                                              "LASER_WAVELENGTH"]))
+    def test_GIVEN_pv_WHEN_pv_read_THEN_pv_has_no_alarms(self, _, pv):
+        self.ca.assert_that_pv_alarm_is(pv, self.ca.Alarms.NONE)

--- a/tests/lsicorr.py
+++ b/tests/lsicorr.py
@@ -130,9 +130,6 @@ class LSITests(unittest.TestCase):
         ("SAMPLINGTIMEMULTIT", ("ns12_5", "ns200", "ns400", "ns800", "ns1600", "ns3200"))
     ])
     def test_GIVEN_enum_setting_WHEN_setting_pv_written_to_THEN_new_value_read_back(self, pv, values):
-        setting_pv = "CORRELATIONTYPE"
         for value in values:
-        #self.ca.assert_that_pv_is(pv, "AUTO")
-
             self.ca.set_pv_value(pv, value)
             self.ca.assert_that_pv_is(pv, value)

--- a/tests/lsicorr.py
+++ b/tests/lsicorr.py
@@ -33,6 +33,7 @@ IOCS = [
 
 TEST_MODES = [TestModes.DEVSIM]
 
+
 class LSITests(unittest.TestCase):
     """
     Tests for LSi Correlator
@@ -47,3 +48,10 @@ class LSITests(unittest.TestCase):
 
         self.ca.assert_that_pv_exists(pv_name)
         self.ca.assert_that_pv_is_number(pv_name, 300)
+
+    def test_GIVEN_setting_pv_WHEN_pv_written_to_THEN_new_value_read_back(self):
+        pv_name = "MEASUREMENTDURATION"
+        pv_value = 1000.0
+
+        self.ca.set_pv_value(pv_name, pv_value)
+        self.ca.assert_that_pv_is_number(pv_name, pv_value)

--- a/tests/lsicorr.py
+++ b/tests/lsicorr.py
@@ -1,8 +1,6 @@
 import os
 import unittest
 import time
-from contextlib import contextmanager
-from math import tan, radians, cos
 
 from parameterized import parameterized
 
@@ -32,6 +30,44 @@ IOCS = [
 
 
 TEST_MODES = [TestModes.DEVSIM]
+
+
+NORMALISATION = (
+    "SYMMETRIC",
+    "COMPENSATED"
+)
+
+SWAPCHANNELS = (
+    "ChA_ChB",
+    "ChB_ChA"
+)
+
+
+CORRELATIONTYPE = (
+    "AUTO",
+    "CROSS"
+)
+
+TRANSFERRATE = (
+    "ms100",
+    "ms150",
+    "ms200",
+    "ms250",
+    "ms300",
+    "ms400",
+    "ms500",
+    "ms600",
+    "ms700"
+)
+
+SAMPLINGTIMEMULTIT = (
+    "ns12_5",
+    "ns200",
+    "ns400",
+    "ns800",
+    "ns1600",
+    "ns3200"
+)
 
 
 class LSITests(unittest.TestCase):
@@ -86,9 +122,17 @@ class LSITests(unittest.TestCase):
         self.ca.assert_that_pv_exists(setting_pv)
         self.ca.assert_that_pv_is(setting_pv, "AUTO")
 
-    def test_GIVEN_enum_setting_WHEN_setting_pv_written_to_THEN_new_value_read_back(self):
+    @parameterized.expand([
+        ("NORMALIZATION", ("SYMMETRIC", "COMPENSATED")),
+        ("SWAPCHANNELS", ("ChA_ChB", "ChB_ChA")),
+        ("CORRELATIONTYPE", ("AUTO", "CROSS")),
+        ("TRANSFERRATE", ("ms100", "ms150", "ms200", "ms250", "ms300", "ms400", "ms500", "ms600", "ms700")),
+        ("SAMPLINGTIMEMULTIT", ("ns12_5", "ns200", "ns400", "ns800", "ns1600", "ns3200"))
+    ])
+    def test_GIVEN_enum_setting_WHEN_setting_pv_written_to_THEN_new_value_read_back(self, pv, values):
         setting_pv = "CORRELATIONTYPE"
-        self.ca.assert_that_pv_is(setting_pv, "AUTO")
+        for value in values:
+        #self.ca.assert_that_pv_is(pv, "AUTO")
 
-        self.ca.set_pv_value(setting_pv, "CROSS")
-        self.ca.assert_that_pv_is(setting_pv, "CROSS")
+            self.ca.set_pv_value(pv, value)
+            self.ca.assert_that_pv_is(pv, value)

--- a/tests/lsicorr.py
+++ b/tests/lsicorr.py
@@ -105,7 +105,6 @@ class LSITests(unittest.TestCase):
         self.ca.set_pv_value(pv_name, new_value)
         self.ca.assert_that_pv_is_number(pv_name, 12)
 
-    @unittest.skip('Monitors arent working yet')
     def test_GIVEN_monitor_on_setting_pv_WHEN_pv_changed_THEN_monitor_gets_updated(self):
         pv_name = "MEASUREMENTDURATION"
         self.ca.set_pv_value(pv_name, 10.0)
@@ -113,10 +112,7 @@ class LSITests(unittest.TestCase):
         expected_value = 12.0
 
         with self.ca.assert_that_pv_monitor_is(pv_name, expected_value):
-            from time import sleep
-            sleep(1.0)
-            print('setting with monitor')
-            self.ca.set_pv_value(pv_name, new_value)
+            self.ca.set_pv_value(pv_name + ":SP", new_value)
 
     def test_GIVEN_invalid_value_for_setting_WHEN_setting_pv_written_THEN_status_pv_updates_with_error(self):
         setting_pv = "MEASUREMENTDURATION"

--- a/tests/lsicorr.py
+++ b/tests/lsicorr.py
@@ -19,7 +19,6 @@ IOCS = [
         "directory": LSICORR_PATH,
         "python_script_commandline": [os.path.join(LSICORR_PATH, "LSi_Correlator.py"), "--pv_prefix", "TE:NDW1836:"],
         "started_text": "IOC started",
-        "pv_for_existence": "MEASUREMENTDURATION",
         "python_version": 3,
         "macros": {
         }
@@ -157,7 +156,8 @@ class LSITests(unittest.TestCase):
                                               "ERRORMSG",
                                               "FILEPATH",
                                               "FILENAME",
-                                              "TAKEDATA",
+                                              "START",
+                                              "STOP",
                                               "CORRELATION_FUNCTION",
                                               "LAGS",
                                               "REPETITIONS",

--- a/tests/lsicorr.py
+++ b/tests/lsicorr.py
@@ -85,3 +85,10 @@ class LSITests(unittest.TestCase):
         setting_pv = "CORRELATIONTYPE"
         self.ca.assert_that_pv_exists(setting_pv)
         self.ca.assert_that_pv_is(setting_pv, "AUTO")
+
+    def test_GIVEN_enum_setting_WHEN_setting_pv_written_to_THEN_new_value_read_back(self):
+        setting_pv = "CORRELATIONTYPE"
+        self.ca.assert_that_pv_is(setting_pv, "AUTO")
+
+        self.ca.set_pv_value(setting_pv, "CROSS")
+        self.ca.assert_that_pv_is(setting_pv, "CROSS")

--- a/utils/channel_access.py
+++ b/utils/channel_access.py
@@ -530,7 +530,7 @@ class ChannelAccess(object):
         """
         Assert that a pv has a given value set by a monitor event
         Args:
-            pv: the pv name
+            pv: the pv name. Must not be the same PV which is written to in the test.
             expected_value: the expected value
         Raises:
             AssertionError: if the value of the pv did not satisfy the comparator
@@ -546,7 +546,7 @@ class ChannelAccess(object):
         """
         Assert that a pv value is set by a monitor event and is within a tolerance
         Args:
-            pv: the pv name
+            pv: the pv name. Must not be the same PV which is written to in the test.
             expected_value: the expected value
             tolerance: tolerance
 

--- a/utils/ioc_launcher.py
+++ b/utils/ioc_launcher.py
@@ -19,6 +19,7 @@ from signal import SIGTERM
 APPS_BASE = os.path.join("C:\\", "Instrument", "Apps")
 EPICS_TOP = os.environ.get("KIT_ROOT", os.path.join(APPS_BASE, "EPICS"))
 PYTHON = os.environ.get("PYTHON", os.path.join(APPS_BASE, "Python", "python.exe"))
+PYTHON3 = os.environ.get("PYTHON3", os.path.join(APPS_BASE, "Python3", "python.exe"))
 
 MAX_TIME_TO_WAIT_FOR_IOC_TO_START = 120
 
@@ -528,12 +529,13 @@ class PythonIOCLauncher(IocLauncher):
     def __init__(self, ioc, test_mode, var_dir):
         super(PythonIOCLauncher, self).__init__(ioc, test_mode, var_dir)
         self._python_script_commandline = ioc.get("python_script_commandline", None)
+        self._python_version = ioc.get("python_version", 2)
 
     def _command_line(self):
         run_ioc_path = self._python_script_commandline[0]
         if not os.path.isfile(run_ioc_path):
             print("Command first argument path not found: '{0}'".format(run_ioc_path))
-        command_line = [PYTHON]
+        command_line = [PYTHON] if self._python_version == 2 else [PYTHON3]
         command_line.extend(self._python_script_commandline)
         return command_line
 


### PR DESCRIPTION
Description of work:
Adds tests which do not rely on an emulator/mocking out parts of the device. These include writing to/reading from PVs.

Ticket:
https://github.com/ISISComputingGroup/IBEX/issues/4918

Acceptance criteria:
 - [ ] PCASpy elements of IOC are tested (PVs can be written to/read)