### PR TITLE
Add tests for DMA4500M

### DIFF
--- a/tests/dma4500m.py
+++ b/tests/dma4500m.py
@@ -60,11 +60,11 @@ class DMA4500MTests(unittest.TestCase):
         self._lewis.backdoor_set_on_device("measurement_time", measurement_time * LEWIS_SPEED)
         self.ca.set_pv_value("START", 1)
 
-    def _start_automeasure(self, interval):
+    def _enable_automeasure(self, interval):
         self.ca.set_pv_value("AUTOMEASURE:FREQ:SP", interval)
         self.ca.set_pv_value("AUTOMEASURE:ENABLED", 1)
 
-    def _stop_automeasure(self):
+    def _disable_automeasure(self):
         self.ca.set_pv_value("AUTOMEASURE:ENABLED", 0)
 
     def setUp(self):
@@ -122,16 +122,12 @@ class DMA4500MTests(unittest.TestCase):
         self.ca.assert_that_pv_is("MEASUREMENT", "done", timeout=SCAN_FREQUENCY)
         self._assert_pvs_disabled(self.PVS_ENABLED_OUTSIDE_MEASUREMENT, False)
 
-    def test_WHEN_automeasure_frequency_set_THEN_value_updates(self):
-        self.ca.set_pv_value("AUTOMEASURE:FREQ:SP", 10)
-        self.ca.assert_that_pv_is("AUTOMEASURE:FREQ", 10)
-
     @skip_if_recsim
     @parameterized.expand(parameterized_list([2, 5, 10, 20]))
     def test_WHEN_automeasure_frequency_set_THEN_measurement_repeats(self, _, automeasure_interval):
         measurement_time = 5
         self._lewis.backdoor_set_on_device("measurement_time", measurement_time * LEWIS_SPEED)
-        self._start_automeasure(automeasure_interval)
+        self._enable_automeasure(automeasure_interval)
         sleep(automeasure_interval)
         self.ca.assert_that_pv_is("MEASUREMENT", "measuring", timeout=SCAN_FREQUENCY)
         sleep(measurement_time)
@@ -144,11 +140,11 @@ class DMA4500MTests(unittest.TestCase):
     def test_WHEN_automeasure_frequency_set_then_unset_THEN_measurement_stops(self, _, automeasure_interval):
         measurement_time = 5
         self._lewis.backdoor_set_on_device("measurement_time", measurement_time * LEWIS_SPEED)
-        self._start_automeasure(automeasure_interval)
+        self._enable_automeasure(automeasure_interval)
         sleep(automeasure_interval)
         self.ca.assert_that_pv_is("MEASUREMENT", "measuring", timeout=SCAN_FREQUENCY)
+        self._disable_automeasure()
         sleep(measurement_time)
-        self._stop_automeasure()
         self.ca.assert_that_pv_is("MEASUREMENT", "done", timeout=SCAN_FREQUENCY)
         sleep(automeasure_interval)
         self.ca.assert_that_pv_is("MEASUREMENT", "done", timeout=SCAN_FREQUENCY)

--- a/tests/dma4500m.py
+++ b/tests/dma4500m.py
@@ -138,13 +138,10 @@ class DMA4500MTests(unittest.TestCase):
         measurement_time = 5
         self._lewis.backdoor_set_on_device("measurement_time", measurement_time * LEWIS_SPEED)
         self._enable_automeasure(automeasure_interval)
-        sleep(automeasure_interval)
-        self.ca.assert_that_pv_is("MEASUREMENT", "measuring", timeout=SCAN_FREQUENCY)
+        self.ca.assert_that_pv_is("MEASUREMENT", "measuring", timeout=2*automeasure_interval)
         self._disable_automeasure()
-        sleep(measurement_time)
-        self.ca.assert_that_pv_is("MEASUREMENT", "done", timeout=SCAN_FREQUENCY)
-        sleep(automeasure_interval)
-        self.ca.assert_that_pv_is("MEASUREMENT", "done", timeout=SCAN_FREQUENCY)
+        self.ca.assert_that_pv_is("MEASUREMENT", "done", timeout=2*measurement_time)
+        self.ca.assert_that_pv_is("MEASUREMENT", "done", timeout=2*automeasure_interval)
 
     @skip_if_recsim
     def test_GIVEN_device_not_connected_WHEN_get_status_THEN_alarm(self):

--- a/tests/dma4500m.py
+++ b/tests/dma4500m.py
@@ -87,42 +87,35 @@ class DMA4500MTests(unittest.TestCase):
         self._start_instant_measurement()
         self.ca.assert_that_pv_is("TEMPERATURE", 12.34)
 
-    @skip_if_recsim("Lewis backdoor not available in recsim")
     def test_WHEN_density_set_via_backdoor_THEN_it_updates_after_measurement(self):
         self._lewis.backdoor_set_on_device("density", 98.76)
         self._start_instant_measurement()
         self.ca.assert_that_pv_is("DENSITY", 98.76)
 
-    @skip_if_recsim("Lewis backdoor not available in recsim")
     def test_WHEN_condition_set_via_backdoor_THEN_it_updates_after_measurement(self):
         self._lewis.backdoor_set_on_device("condition", "valid")
         self._start_instant_measurement()
         self.ca.assert_that_pv_is("CONDITION", "valid")
 
-    @skip_if_recsim("Lewis backdoor not available in recsim")
     def test_WHEN_measurement_starts_THEN_status_updates(self):
         self._start_measurement(measurement_time=10)
         self.ca.assert_that_pv_is("MEASUREMENT", "measuring", timeout=SCAN_FREQUENCY)
         sleep(10)
         self.ca.assert_that_pv_is("MEASUREMENT", "done", timeout=SCAN_FREQUENCY)
 
-    @skip_if_recsim("Lewis backdoor not available in recsim")
     def test_WHEN_status_is_ready_THEN_correct_records_enabled(self):
         self._assert_pvs_disabled(self.PVS_ENABLED_OUTSIDE_MEASUREMENT, False)
 
-    @skip_if_recsim("Lewis backdoor not available in recsim")
     def test_WHEN_status_is_measuring_THEN_correct_records_disabled(self):
         self._start_measurement(measurement_time=10)
         self.ca.assert_that_pv_is("MEASUREMENT", "measuring", timeout=SCAN_FREQUENCY)
         self._assert_pvs_disabled(self.PVS_DISABLED_DURING_MEASUREMENT, True)
 
-    @skip_if_recsim("Lewis backdoor not available in recsim")
     def test_WHEN_status_is_done_THEN_correct_records_enabled(self):
         self._start_instant_measurement()
         self.ca.assert_that_pv_is("MEASUREMENT", "done", timeout=SCAN_FREQUENCY)
         self._assert_pvs_disabled(self.PVS_ENABLED_OUTSIDE_MEASUREMENT, False)
 
-    @skip_if_recsim
     @parameterized.expand(parameterized_list([2, 5, 10, 20]))
     def test_WHEN_automeasure_frequency_set_THEN_measurement_repeats(self, _, automeasure_interval):
         measurement_time = 5
@@ -132,7 +125,6 @@ class DMA4500MTests(unittest.TestCase):
         self.ca.assert_that_pv_is("MEASUREMENT", "done", timeout=2*measurement_time)
         self.ca.assert_that_pv_is("MEASUREMENT", "measuring", timeout=2*automeasure_interval)
 
-    @skip_if_recsim
     @parameterized.expand(parameterized_list([2, 5, 10, 20]))
     def test_WHEN_automeasure_frequency_set_then_unset_THEN_measurement_stops(self, _, automeasure_interval):
         measurement_time = 5
@@ -143,7 +135,6 @@ class DMA4500MTests(unittest.TestCase):
         self.ca.assert_that_pv_is("MEASUREMENT", "done", timeout=2*measurement_time)
         self.ca.assert_that_pv_is("MEASUREMENT", "done", timeout=2*automeasure_interval)
 
-    @skip_if_recsim
     def test_GIVEN_device_not_connected_WHEN_get_status_THEN_alarm(self):
         self._lewis.backdoor_set_on_device('connected', False)
         self.ca.assert_that_pv_alarm_is('MEASUREMENT', ChannelAccess.Alarms.INVALID)

--- a/tests/dma4500m.py
+++ b/tests/dma4500m.py
@@ -128,12 +128,9 @@ class DMA4500MTests(unittest.TestCase):
         measurement_time = 5
         self._lewis.backdoor_set_on_device("measurement_time", measurement_time * LEWIS_SPEED)
         self._enable_automeasure(automeasure_interval)
-        sleep(automeasure_interval)
-        self.ca.assert_that_pv_is("MEASUREMENT", "measuring", timeout=SCAN_FREQUENCY)
-        sleep(measurement_time)
-        self.ca.assert_that_pv_is("MEASUREMENT", "done", timeout=SCAN_FREQUENCY)
-        sleep(automeasure_interval)
-        self.ca.assert_that_pv_is("MEASUREMENT", "measuring", timeout=SCAN_FREQUENCY)
+        self.ca.assert_that_pv_is("MEASUREMENT", "measuring", timeout=2*automeasure_interval)
+        self.ca.assert_that_pv_is("MEASUREMENT", "done", timeout=2*measurement_time)
+        self.ca.assert_that_pv_is("MEASUREMENT", "measuring", timeout=2*automeasure_interval)
 
     @skip_if_recsim
     @parameterized.expand(parameterized_list([2, 5, 10, 20]))

--- a/tests/dma4500m.py
+++ b/tests/dma4500m.py
@@ -1,0 +1,95 @@
+from __future__ import division
+
+import unittest
+from time import sleep
+
+from utils.channel_access import ChannelAccess
+from utils.ioc_launcher import get_default_ioc_dir
+from utils.test_modes import TestModes
+from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
+
+DEVICE_PREFIX = "DMA4500M_01"
+_EMULATOR_NAME = "dma4500m"
+
+LEWIS_SPEED = 100
+SCAN_FREQUENCY = 2
+
+IOCS = [
+    {
+        "name": DEVICE_PREFIX,
+        "directory": get_default_ioc_dir("DMA4500M"),
+        "emulator": _EMULATOR_NAME,
+    },
+]
+
+
+TEST_MODES = [TestModes.DEVSIM]
+
+
+class DMA4500MTests(unittest.TestCase):
+    """
+    Tests for the DMA4500M density meter
+    """
+    def setUp(self):
+        self._lewis, self._ioc = get_running_lewis_and_ioc(_EMULATOR_NAME, DEVICE_PREFIX)
+        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX, default_timeout=15)
+        self._lewis.backdoor_run_function_on_device("reset")
+        self.ca.set_pv_value("MEASUREMENT", "ready")
+        self.ca.set_pv_value("AUTOMEASURE:FREQ:SP", 0)
+
+    def test_WHEN_temperature_set_THEN_setpoint_readback_updates(self):
+        self.ca.set_pv_value("TEMPERATURE:SP", 12.34)
+        self.ca.assert_that_pv_is("TEMPERATURE:SP:RBV", 12.34)
+
+    def test_WHEN_temperature_set_THEN_status_is_ready(self):
+        self.ca.set_pv_value("TEMPERATURE:SP", 12.34)
+        self.ca.assert_that_pv_is("MEASUREMENT", "ready")
+
+    def test_WHEN_temperature_set_THEN_it_updates_after_measurement(self):
+        self.ca.set_pv_value("TEMPERATURE:SP", 12.34)
+        self.ca.set_pv_value("START", 1)
+        self.ca.assert_that_pv_is("TEMPERATURE", 12.34)
+
+    @skip_if_recsim("Lewis backdoor not available in recsim")
+    def test_WHEN_density_set_via_backdoor_THEN_it_updates_after_measurement(self):
+        self._lewis.backdoor_set_on_device("density", 98.76)
+        self.ca.set_pv_value("START", 1)
+        self.ca.assert_that_pv_is("DENSITY", 98.76)
+
+    @skip_if_recsim("Lewis backdoor not available in recsim")
+    def test_WHEN_condition_set_via_backdoor_THEN_it_updates_after_measurement(self):
+        self._lewis.backdoor_set_on_device("condition", "valid")
+        self.ca.set_pv_value("START", 1)
+        self.ca.assert_that_pv_is("CONDITION", "valid")
+
+    @skip_if_recsim("Lewis backdoor not available in recsim")
+    def test_WHEN_measurement_starts_THEN_status_updates(self):
+        measurement_time = 10
+        self._lewis.backdoor_set_on_device("measurement_time", measurement_time * LEWIS_SPEED)
+        self.ca.assert_that_pv_is("MEASUREMENT", "ready")
+        self.ca.set_pv_value("START", 1)
+        self.ca.assert_that_pv_is("MEASUREMENT", "measuring")
+        sleep(measurement_time + SCAN_FREQUENCY)
+        self.ca.assert_that_pv_is("MEASUREMENT", "done")
+
+    def test_WHEN_automeasure_frequency_set_THEN_value_updates(self):
+        self.ca.set_pv_value("AUTOMEASURE:FREQ:SP", 10)
+        self.ca.assert_that_pv_is("AUTOMEASURE:FREQ", 10)
+
+    @skip_if_recsim
+    def test_WHEN_automeasure_frequency_set_THEN_measurement_starts(self):
+        interval = 2
+        measurement_time = 10
+        self._lewis.backdoor_set_on_device("measurement_time", measurement_time * LEWIS_SPEED)
+        self.ca.set_pv_value("AUTOMEASURE:FREQ:SP", interval)
+        sleep(interval + SCAN_FREQUENCY)
+        self.ca.assert_that_pv_is("MEASUREMENT", "measuring")
+
+    @skip_if_recsim
+    def test_GIVEN_device_not_connected_WHEN_get_status_THEN_alarm(self):
+        self._lewis.backdoor_set_on_device('connected', False)
+        self.ca.assert_that_pv_alarm_is('MEASUREMENT', ChannelAccess.Alarms.INVALID)
+        self.ca.assert_that_pv_alarm_is('TEMPERATURE:SP:RBV', ChannelAccess.Alarms.INVALID)
+        self.ca.assert_that_pv_alarm_is('TEMPERATURE', ChannelAccess.Alarms.INVALID)
+        self.ca.assert_that_pv_alarm_is('DENSITY', ChannelAccess.Alarms.INVALID)
+        self.ca.assert_that_pv_alarm_is('CONDITION', ChannelAccess.Alarms.INVALID)

--- a/tests/dma4500m.py
+++ b/tests/dma4500m.py
@@ -30,18 +30,27 @@ class DMA4500MTests(unittest.TestCase):
     """
     Tests for the DMA4500M density meter
     """
+
+    def _reset_ioc(self):
+        self.ca.set_pv_value("MEASUREMENT", "ready")
+        self.ca.set_pv_value("TEMPERATURE", 0)
+        self.ca.set_pv_value("TEMPERATURE:SP", 0)
+        self.ca.set_pv_value("DENSITY", 0)
+        self.ca.set_pv_value("CONDITION", "0.00000")
+        self.ca.set_pv_value("AUTOMEASURE:FREQ:SP", 0)
+
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc(_EMULATOR_NAME, DEVICE_PREFIX)
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX, default_timeout=15)
         self._lewis.backdoor_run_function_on_device("reset")
-        self.ca.set_pv_value("MEASUREMENT", "ready")
-        self.ca.set_pv_value("AUTOMEASURE:FREQ:SP", 0)
+        self._reset_ioc()
 
     def test_WHEN_temperature_set_THEN_setpoint_readback_updates(self):
         self.ca.set_pv_value("TEMPERATURE:SP", 12.34)
         self.ca.assert_that_pv_is("TEMPERATURE:SP:RBV", 12.34)
 
-    def test_WHEN_temperature_set_THEN_status_is_ready(self):
+    def test_WHEN_status_is_done_and_temperature_set_THEN_status_is_ready(self):
+        self.ca.set_pv_value("MEASUREMENT", "done")
         self.ca.set_pv_value("TEMPERATURE:SP", 12.34)
         self.ca.assert_that_pv_is("MEASUREMENT", "ready")
 

--- a/tests/dma4500m.py
+++ b/tests/dma4500m.py
@@ -2,11 +2,12 @@ from __future__ import division
 
 import unittest
 from time import sleep
+from parameterized import parameterized
 
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
-from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
+from utils.testing import get_running_lewis_and_ioc, skip_if_recsim, parameterized_list
 
 DEVICE_PREFIX = "DMA4500M_01"
 _EMULATOR_NAME = "dma4500m"
@@ -40,6 +41,7 @@ class DMA4500MTests(unittest.TestCase):
         self.ca.set_pv_value("TEMPERATURE:SP", 0)
         self.ca.set_pv_value("DENSITY", 0)
         self.ca.set_pv_value("CONDITION", "0.00000")
+        self.ca.set_pv_value("AUTOMEASURE:ENABLED", 0)
         self.ca.set_pv_value("AUTOMEASURE:FREQ:SP", 0)
 
     def _assert_pvs_disabled(self, pvs, disabled):
@@ -57,6 +59,13 @@ class DMA4500MTests(unittest.TestCase):
         measurement_time = measurement_time
         self._lewis.backdoor_set_on_device("measurement_time", measurement_time * LEWIS_SPEED)
         self.ca.set_pv_value("START", 1)
+
+    def _start_automeasure(self, interval):
+        self.ca.set_pv_value("AUTOMEASURE:FREQ:SP", interval)
+        self.ca.set_pv_value("AUTOMEASURE:ENABLED", 1)
+
+    def _stop_automeasure(self):
+        self.ca.set_pv_value("AUTOMEASURE:ENABLED", 0)
 
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc(_EMULATOR_NAME, DEVICE_PREFIX)
@@ -118,13 +127,31 @@ class DMA4500MTests(unittest.TestCase):
         self.ca.assert_that_pv_is("AUTOMEASURE:FREQ", 10)
 
     @skip_if_recsim
-    def test_WHEN_automeasure_frequency_set_THEN_measurement_starts(self):
-        interval = 2
-        measurement_time = 10
+    @parameterized.expand(parameterized_list([2, 5, 10, 20]))
+    def test_WHEN_automeasure_frequency_set_THEN_measurement_repeats(self, _, automeasure_interval):
+        measurement_time = 5
         self._lewis.backdoor_set_on_device("measurement_time", measurement_time * LEWIS_SPEED)
-        self.ca.set_pv_value("AUTOMEASURE:FREQ:SP", interval)
-        sleep(interval + SCAN_FREQUENCY)
-        self.ca.assert_that_pv_is("MEASUREMENT", "measuring")
+        self._start_automeasure(automeasure_interval)
+        sleep(automeasure_interval)
+        self.ca.assert_that_pv_is("MEASUREMENT", "measuring", timeout=SCAN_FREQUENCY)
+        sleep(measurement_time)
+        self.ca.assert_that_pv_is("MEASUREMENT", "done", timeout=SCAN_FREQUENCY)
+        sleep(automeasure_interval)
+        self.ca.assert_that_pv_is("MEASUREMENT", "measuring", timeout=SCAN_FREQUENCY)
+
+    @skip_if_recsim
+    @parameterized.expand(parameterized_list([2, 5, 10, 20]))
+    def test_WHEN_automeasure_frequency_set_then_unset_THEN_measurement_stops(self, _, automeasure_interval):
+        measurement_time = 5
+        self._lewis.backdoor_set_on_device("measurement_time", measurement_time * LEWIS_SPEED)
+        self._start_automeasure(automeasure_interval)
+        sleep(automeasure_interval)
+        self.ca.assert_that_pv_is("MEASUREMENT", "measuring", timeout=SCAN_FREQUENCY)
+        sleep(measurement_time)
+        self._stop_automeasure()
+        self.ca.assert_that_pv_is("MEASUREMENT", "done", timeout=SCAN_FREQUENCY)
+        sleep(automeasure_interval)
+        self.ca.assert_that_pv_is("MEASUREMENT", "done", timeout=SCAN_FREQUENCY)
 
     @skip_if_recsim
     def test_GIVEN_device_not_connected_WHEN_get_status_THEN_alarm(self):


### PR DESCRIPTION
### Description of work
Adds a few tests for the DMA4500M IOC. Due to how the IOC is structured (some records are pushed from the protocal file and there is a pretty important MBBI record), RECSIM has not been implemented for this device.

### Ticket
https://github.com/ISISComputingGroup/IBEX/issues/4948
https://github.com/ISISComputingGroup/IBEX/issues/3922

### Acceptance criteria
- The tests cover all reasonable test cases for the device
- All tests pass

