### PR TITLE
Fix ioc system tests refl

### DIFF
--- a/test_config/good_for_refl/refl/config.py
+++ b/test_config/good_for_refl/refl/config.py
@@ -54,9 +54,8 @@ def get_beamline():
                   detector_angle, not_in_mode_pos, hgap_param, vgap_param, hcentre_param, vcentre_param, slit4_pos, slit5_pos]
     params_polerised = [slit1_pos, sm_in_beam, sm_pos, sm_angle, s3_enabled, theta_ang, slit3_pos, detector_position,
                   detector_angle, hgap_param, vgap_param, hcentre_param, vcentre_param, slit4_pos, slit5_pos]
-    params_nr = [slit1_pos, s3_enabled, theta_ang, slit3_pos, detector_position, detector_angle, not_in_mode_pos,
+    params_nr = [slit1_pos, s3_enabled, theta_ang, slit3_pos, detector_position, detector_angle,
                  hgap_param, vgap_param, hcentre_param, vcentre_param, slit4_pos, slit5_pos]
-    params_default = [slit1_pos, s3_enabled, theta_ang, slit3_pos, detector_position, detector_angle, slit4_pos, slit5_pos]
 
     params_for_mode_testing = [slit1_pos, theta_ang, slit3_pos, slit4_pos, slit5_pos, detector_position, s3_enabled]
     params_for_mode_disabled = [detector_position, detector_angle]

--- a/tests/refl.py
+++ b/tests/refl.py
@@ -133,7 +133,7 @@ class ReflTests(unittest.TestCase):
         self.ca_galil.set_pv_value("MTR0104.VELO", velocity)
         self.ca_galil.set_pv_value("MTR0105.VELO", FAST_VELOCITY)  # Remove angle as a speed limiting factor
 
-    def _check_param(self, param_name, expected_value):
+    def _check_param_pvs(self, param_name, expected_value):
         self.ca.assert_that_pv_is_number("PARAM:%s" % param_name, expected_value, 0.01)
         self.ca.assert_that_pv_is_number("PARAM:%s:SP" % param_name, expected_value, 0.01)
         self.ca.assert_that_pv_is_number("PARAM:%s:SP:RBV" % param_name, expected_value, 0.01)


### PR DESCRIPTION
Two errors fixed:

1. Accidentally renamed method
1. "Not in mode" parameter got add to the mode

Tests should now run without error