### PR TITLE
Ticket 5266: Reconnect DAQmx on error

### DIFF
--- a/tests/DAQmx.py
+++ b/tests/DAQmx.py
@@ -1,0 +1,70 @@
+import unittest
+
+from utils.test_modes import TestModes
+from utils.channel_access import ChannelAccess
+from utils.ioc_launcher import EPICS_TOP
+from utils.emulator_launcher import CommandLineEmulatorLauncher, DEVICE_EMULATOR_PATH
+from utils.testing import get_running_lewis_and_ioc
+
+import os
+
+
+class DAQMxEmulatorLauncher(CommandLineEmulatorLauncher):
+    def __init__(self, device, var_dir, port, options):
+        labview_scripts_dir = os.path.join(DEVICE_EMULATOR_PATH, "other_emulators", "DAQmx")
+        self.start_command = os.path.join(labview_scripts_dir, "start_sim.bat")
+        self.stop_command = os.path.join(labview_scripts_dir, "stop_sim.bat")
+        options["emulator_command_line"] = self.start_command
+        options["emulator_wait_to_finish"] = True
+        super(DAQMxEmulatorLauncher, self).__init__(device, var_dir, port, options)
+
+    def _close(self):
+        self.disconnect_device()
+        super(DAQMxEmulatorLauncher, self)._close()
+
+    def disconnect_device(self):
+        self._call_command_line(self.stop_command)
+
+    def reconnect_device(self):
+        self._call_command_line(self.start_command)
+
+
+# Device prefix
+DEVICE_PREFIX = "DAQMXTEST"
+
+IOCS = [
+    {
+        "name": DEVICE_PREFIX,
+        "directory": os.path.join(EPICS_TOP, "support", "DAQmxBase", "master", "iocBoot",  "iocDAQmx"),
+        "emulator": DEVICE_PREFIX,
+        "emulator_launcher_class": DAQMxEmulatorLauncher,
+    },
+]
+
+
+TEST_MODES = [TestModes.DEVSIM]
+
+
+class DAQmxTests(unittest.TestCase):
+    """
+    General tests for the DAQmx.
+    """
+    def setUp(self):
+        self.emulator, self._ioc = get_running_lewis_and_ioc(DEVICE_PREFIX, DEVICE_PREFIX)
+
+        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
+
+    def test_WHEN_acquire_called_THEN_data_gathered_and_is_changing(self):
+        self.ca.set_pv_value("ACQUIRE", 1)
+
+        def non_zero_data(data):
+            return all([d != 0.0 for d in data])
+        self.ca.assert_that_pv_value_causes_func_to_return_true("DATA", non_zero_data, timeout=2)
+        self.ca.assert_that_pv_value_is_changing("DATA", 1)
+
+    def test_WHEN_emulator_disconnected_THEN_data_in_alarm(self):
+        self.ca.assert_that_pv_alarm_is_not("DATA", ChannelAccess.Alarms.INVALID)
+        self.emulator.disconnect_device()
+        self.ca.assert_that_pv_alarm_is("DATA", ChannelAccess.Alarms.INVALID)
+
+

--- a/tests/DAQmx.py
+++ b/tests/DAQmx.py
@@ -38,6 +38,7 @@ IOCS = [
         "directory": os.path.join(EPICS_TOP, "support", "DAQmxBase", "master", "iocBoot",  "iocDAQmx"),
         "emulator": DEVICE_PREFIX,
         "emulator_launcher_class": DAQMxEmulatorLauncher,
+        "pv_for_existence": "ACQUIRE",
     },
 ]
 
@@ -59,12 +60,16 @@ class DAQmxTests(unittest.TestCase):
 
         def non_zero_data(data):
             return all([d != 0.0 for d in data])
-        self.ca.assert_that_pv_value_causes_func_to_return_true("DATA", non_zero_data, timeout=2)
+        self.ca.assert_that_pv_value_causes_func_to_return_true("DATA", non_zero_data)
         self.ca.assert_that_pv_value_is_changing("DATA", 1)
 
-    def test_WHEN_emulator_disconnected_THEN_data_in_alarm(self):
+    def test_WHEN_emulator_disconnected_THEN_data_in_alarm_and_valid_on_reconnect(self):
         self.ca.assert_that_pv_alarm_is_not("DATA", ChannelAccess.Alarms.INVALID)
         self.emulator.disconnect_device()
         self.ca.assert_that_pv_alarm_is("DATA", ChannelAccess.Alarms.INVALID)
+
+        self.emulator.reconnect_device()
+        self.ca.assert_that_pv_alarm_is_not("DATA", ChannelAccess.Alarms.INVALID, timeout=5)
+        self.ca.assert_that_pv_value_is_changing("DATA", 1)
 
 

--- a/utils/emulator_launcher.py
+++ b/utils/emulator_launcher.py
@@ -17,6 +17,8 @@ from utils.formatters import format_value
 
 from utils.emulator_exceptions import UnableToConnectToEmulatorException
 
+DEVICE_EMULATOR_PATH = os.path.join(EPICS_TOP, "support", "DeviceEmulator", "master")
+
 
 class EmulatorRegister(object):
     """
@@ -323,8 +325,7 @@ class LewisLauncher(EmulatorLauncher):
         self._lewis_path = options.get("lewis_path", LewisLauncher._DEFAULT_LEWIS_PATH)
         self._python_path = options.get("python_path", os.path.join(LewisLauncher._DEFAULT_PY_PATH, "python.exe"))
         self._lewis_protocol = options.get("lewis_protocol", "stream")
-        self._lewis_additional_path = options.get("lewis_additional_path",
-                                                  os.path.join(EPICS_TOP, "support", "DeviceEmulator", "master"))
+        self._lewis_additional_path = options.get("lewis_additional_path", DEVICE_EMULATOR_PATH)
         self._lewis_package = options.get("lewis_package", "lewis_emulators")
         self._default_timeout = options.get("default_timeout", 5)
 


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/5266

Added a test for DAQmx driver using the NI MAX simulation.

To test:
* Pull this along with https://github.com/ISISComputingGroup/EPICS-DeviceEmulator/pull/73 and https://github.com/ISISComputingGroup/EPICS-DAQmxBase/pull/6
* Run the tests
* Confirm that they run and pass