### PR TITLE
Fix Reflectometry redefine slit tests

### DIFF
--- a/test_config/good_for_refl/refl/config.py
+++ b/test_config/good_for_refl/refl/config.py
@@ -31,7 +31,7 @@ def get_beamline():
     s1_comp = add_component(Component("s1", PositionAndAngle(0.0, z_s1, 90)))
     add_parameter(TrackingPosition("S1", s1_comp), modes=[nr, polarised, testing])
     add_driver(DisplacementDriver(s1_comp, MotorPVWrapper("MOT:MTR0101")))
-    add_slit_parameters(1, modes=[nr, polarised])
+    add_slit_parameters(1, modes=[nr, polarised], include_centres=True)
 
     # SM
     sm_comp = add_component(ReflectingComponent("SM", PositionAndAngle(0.0, 2*SPACING, 90)))


### PR DESCRIPTION
As part of rework of https://github.com/ISISComputingGroup/IBEX/issues/4289, behaviour of refl IOC was changed so that slit centre params have to be created explicitly (rather than by default). 

Missed in review that test config was not updated accordingly. This is the PR to fix that.