### PR TITLE
Fix ioc tests

### DIFF
--- a/tests/danfysik_local_calib.py
+++ b/tests/danfysik_local_calib.py
@@ -30,7 +30,7 @@ class DanfysikLocalCalibTests(DanfysikBase, unittest.TestCase):
     """
     def test_GIVEN_local_calib_macro_set_to_no_THEN_calib_base_dir_is_common_dir(self):
         g.set_instrument(None)
-        inst = os.environ.get("INSTRUMENT", g.get_instrument())
+        inst = os.environ.get("INSTRUMENT", g.adv.get_instrument())
         for pv in ["FIELD:CALIB", "FIELD:SP:CALIB"]:
             self.ca.assert_that_pv_is("{}.TDIR".format(pv), r"calib/magnets")
             self.ca.assert_that_pv_is("{}.BDIR".format(pv), r"C:/Instrument/Settings/config/{}".format(inst))

--- a/utils/emulator_launcher.py
+++ b/utils/emulator_launcher.py
@@ -345,6 +345,7 @@ class LewisLauncher(EmulatorLauncher):
         super(LewisLauncher, self).__init__(test_name, device, var_dir, port, options)
 
         self._lewis_path = options.get("lewis_path", LewisLauncher._DEFAULT_LEWIS_PATH)
+        self._python_path = options.get("python_path", os.path.join(LewisLauncher._DEFAULT_PY_PATH, "python.exe"))
         self._lewis_protocol = options.get("lewis_protocol", "stream")
         self._lewis_additional_path = options.get("lewis_additional_path", DEVICE_EMULATOR_PATH)
         self._lewis_package = options.get("lewis_package", "lewis_emulators")
@@ -375,7 +376,7 @@ class LewisLauncher(EmulatorLauncher):
         """
 
         self._control_port = str(get_free_ports(1)[0])
-        lewis_command_line = [os.path.join(self._lewis_path, "lewis.exe"),
+        lewis_command_line = [self._python_path, os.path.join(self._lewis_path, "lewis.exe"),
                               "-r", "127.0.0.1:{control_port}".format(control_port=self._control_port)]
         lewis_command_line.extend(["-p", "{protocol}: {{bind_address: 127.0.0.1, port: {port}}}"
                                   .format(protocol=self._lewis_protocol, port=self._port)])
@@ -458,7 +459,7 @@ class LewisLauncher(EmulatorLauncher):
         :param lewis_command: array of command line arguments to send
         :return: lines from the command output
         """
-        lewis_command_line = [os.path.join(self._lewis_path, "lewis-control.exe"),
+        lewis_command_line = [self._python_path, os.path.join(self._lewis_path, "lewis-control.exe"),
                               "-r", "127.0.0.1:{control_port}".format(control_port=self._control_port)]
         lewis_command_line.extend(lewis_command)
         time_stamp = datetime.datetime.fromtimestamp(time()).strftime('%Y-%m-%d %H:%M:%S')

--- a/utils/emulator_launcher.py
+++ b/utils/emulator_launcher.py
@@ -376,7 +376,7 @@ class LewisLauncher(EmulatorLauncher):
         """
 
         self._control_port = str(get_free_ports(1)[0])
-        lewis_command_line = [self._python_path, os.path.join(self._lewis_path, "lewis.exe"),
+        lewis_command_line = [self._python_path, "-m", "lewis",
                               "-r", "127.0.0.1:{control_port}".format(control_port=self._control_port)]
         lewis_command_line.extend(["-p", "{protocol}: {{bind_address: 127.0.0.1, port: {port}}}"
                                   .format(protocol=self._lewis_protocol, port=self._port)])


### PR DESCRIPTION
- Reverts https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework/commit/2b0c1542cce6c1aacc5b6211341cd6539f327299 because the build server fails unless we use an explicit path to python in the startup command
- `g.get_instrument()` -> `g.adv.get_instrument()`