### PR TITLE
Ticket4571 sans2d apertures guides stop

### DIFF
--- a/tests/sans2d_apertures_guides.py
+++ b/tests/sans2d_apertures_guides.py
@@ -66,7 +66,7 @@ class Sans2dAperturesGuidesTests(unittest.TestCase):
             set_axis_moving(axis)
             assert_axis_moving(axis)
             self.ca.set_pv_value("MOT:SANS2DAPWV:STOP_MOTORS:ALL", 1)
-            assert_axis_not_moving(axis)
+            assert_axis_not_moving(axis, retry_count=3)
 
     @parameterized.expand(AXES_TO_STOP)
     def test_GIVEN_move_disabled_axis_moving_WHEN_stop_all_THEN_axis_stopped(self, axis):
@@ -77,4 +77,4 @@ class Sans2dAperturesGuidesTests(unittest.TestCase):
             set_axis_moving(axis)
             assert_axis_moving(axis)
             self.ca.set_pv_value("MOT:SANS2DAPWV:STOP_MOTORS:ALL", 1)
-            assert_axis_moving(axis)
+            assert_axis_moving(axis, retry_count=3)

--- a/tests/sans2d_apertures_guides.py
+++ b/tests/sans2d_apertures_guides.py
@@ -6,6 +6,7 @@ from utils.ioc_launcher import get_default_ioc_dir, EPICS_TOP
 from utils.test_modes import TestModes
 from utils.channel_access import ChannelAccess
 from utils.axis import set_axis_moving, assert_axis_not_moving, assert_axis_moving
+import time
 
 galil_settings_path = os.path.realpath(
     os.path.join(os.getenv("EPICS_KIT_ROOT"), "support", "motorExtensions", "master", "settings", "sans2d")
@@ -64,5 +65,16 @@ class Sans2dAperturesGuidesTests(unittest.TestCase):
         for _ in range(3):
             set_axis_moving(axis)
             assert_axis_moving(axis)
-            self.ca.set_pv_value("MOT:SANS2DAPWV:STOP_MOTORS:_ALL", 1)
+            self.ca.set_pv_value("MOT:SANS2DAPWV:STOP_MOTORS:ALL", 1)
             assert_axis_not_moving(axis)
+
+    @parameterized.expand(AXES_TO_STOP)
+    def test_GIVEN_move_disabled_axis_moving_WHEN_stop_all_THEN_axis_stopped(self, axis):
+        # Set interlock to disabled
+        self.ca.set_pv_value("FINS_VAC:SIM:ADDR:1001", 0)
+        self.ca.assert_that_pv_is("FINS_VAC:GALIL_INTERLOCK", "CANNOT MOVE")
+        for _ in range(3):
+            set_axis_moving(axis)
+            assert_axis_moving(axis)
+            self.ca.set_pv_value("MOT:SANS2DAPWV:STOP_MOTORS:ALL", 1)
+            assert_axis_moving(axis)

--- a/tests/sans2d_apertures_guides.py
+++ b/tests/sans2d_apertures_guides.py
@@ -1,0 +1,68 @@
+import unittest
+import os
+from parameterized import parameterized
+
+from utils.ioc_launcher import get_default_ioc_dir, EPICS_TOP
+from utils.test_modes import TestModes
+from utils.channel_access import ChannelAccess
+from utils.axis import set_axis_moving, assert_axis_not_moving, assert_axis_moving
+
+galil_settings_path = os.path.realpath(
+    os.path.join(os.getenv("EPICS_KIT_ROOT"), "support", "motorExtensions", "master", "settings", "sans2d")
+)
+
+GALIL_ADDR = "128.0.0.0"
+
+ioc_name = "FINS"
+fins_settings_path = os.path.join(EPICS_TOP, "ioc", "master", ioc_name, "exampleSettings", "SANS2D_vacuum")
+ioc_prefix = "FINS_VAC"
+
+# Create GALIL_01 and GALIL_02
+IOCS = [
+    {
+        "name": "GALIL_0{}".format(i),
+        "directory": get_default_ioc_dir("GALIL", i),
+        "custom_prefix": "MOT",
+        "pv_for_existence": "MTR0{}01".format(i),
+        "macros": {
+            "GALILADDR": GALIL_ADDR,
+            "MTRCTRL": "0{}".format(i),
+            "GALILCONFIGDIR": galil_settings_path.replace("\\", "/"),
+        }
+    } for i in [1, 2]
+] + [
+    {
+        "name": "FINS_01",
+        "directory": get_default_ioc_dir(ioc_name),
+        "custom_prefix": ioc_prefix,
+        "pv_for_existence": "HEARTBEAT",
+        "macros": {
+            "FINSCONFIGDIR": fins_settings_path.replace("\\", "/"),
+            "PLCIP": "127.0.0.1"
+        },
+    }
+]
+
+TEST_MODES = [TestModes.RECSIM]
+
+AXES_TO_STOP = ["APERTURE_{}".format(i) for i in range(1, 6)] + ["GUIDE_{}".format(j) for j in range(1, 6)]
+
+
+class Sans2dAperturesGuidesTests(unittest.TestCase):
+    """
+    Tests for the sans2d waveguides and apertures tank motor extensions.
+    """
+
+    def setUp(self):
+        self.ca = ChannelAccess()
+
+    @parameterized.expand(AXES_TO_STOP)
+    def test_GIVEN_move_enabled_axis_moving_WHEN_stop_all_THEN_axis_stopped(self, axis):
+        # Set interlock to enabled
+        self.ca.set_pv_value("FINS_VAC:SIM:ADDR:1001", 64)
+        self.ca.assert_that_pv_is("FINS_VAC:GALIL_INTERLOCK", "CAN MOVE")
+        for _ in range(3):
+            set_axis_moving(axis)
+            assert_axis_moving(axis)
+            self.ca.set_pv_value("MOT:SANS2DAPWV:STOP_MOTORS:_ALL", 1)
+            assert_axis_not_moving(axis)

--- a/tests/sans2d_apertures_guides.py
+++ b/tests/sans2d_apertures_guides.py
@@ -5,33 +5,33 @@ from parameterized import parameterized
 from utils.ioc_launcher import get_default_ioc_dir, EPICS_TOP
 from utils.test_modes import TestModes
 from utils.channel_access import ChannelAccess
-from utils.axis import set_axis_moving, assert_axis_not_moving, assert_axis_moving
-import time
+from utils.axis import set_axis_moving, assert_axis_not_moving, assert_axis_moving, stop_axis_moving
 
 galil_settings_path = os.path.realpath(
-    os.path.join(os.getenv("EPICS_KIT_ROOT"), "support", "motorExtensions", "master", "settings", "sans2d")
+    os.path.join(
+        os.getenv("EPICS_KIT_ROOT"), "support", "motorExtensions",
+        "master", "settings", "sans2d_apertures_guides"
+    )
 )
 
-GALIL_ADDR = "128.0.0.0"
+GALIL_ADDR = "127.0.0.1"
 
 ioc_name = "FINS"
 fins_settings_path = os.path.join(EPICS_TOP, "ioc", "master", ioc_name, "exampleSettings", "SANS2D_vacuum")
 ioc_prefix = "FINS_VAC"
 
-# Create GALIL_01 and GALIL_02
 IOCS = [
     {
-        "name": "GALIL_0{}".format(i),
-        "directory": get_default_ioc_dir("GALIL", i),
+        "name": "GALILMUL_01",
+        "directory": get_default_ioc_dir("GALILMUL"),
         "custom_prefix": "MOT",
-        "pv_for_existence": "MTR0{}01".format(i),
+        "pv_for_existence": "MTR0101",
         "macros": {
-            "GALILADDR": GALIL_ADDR,
-            "MTRCTRL": "0{}".format(i),
+            "MTRCTRL1": "01",
+            "GALILADDR1": GALIL_ADDR,
             "GALILCONFIGDIR": galil_settings_path.replace("\\", "/"),
         }
-    } for i in [1, 2]
-] + [
+    },
     {
         "name": "FINS_01",
         "directory": get_default_ioc_dir(ioc_name),
@@ -62,6 +62,10 @@ class Sans2dAperturesGuidesTests(unittest.TestCase):
         # Set interlock to enabled
         self.ca.set_pv_value("FINS_VAC:SIM:ADDR:1001", 64)
         self.ca.assert_that_pv_is("FINS_VAC:GALIL_INTERLOCK", "CAN MOVE")
+        # Stop axis to prevent test instability (other tests may have left it moving)
+        stop_axis_moving(axis)
+        assert_axis_not_moving(axis)
+        # Execute test
         for _ in range(3):
             set_axis_moving(axis)
             assert_axis_moving(axis)
@@ -69,10 +73,11 @@ class Sans2dAperturesGuidesTests(unittest.TestCase):
             assert_axis_not_moving(axis)
 
     @parameterized.expand(AXES_TO_STOP)
-    def test_GIVEN_move_disabled_axis_moving_WHEN_stop_all_THEN_axis_stopped(self, axis):
+    def test_GIVEN_move_disabled_axis_moving_WHEN_stop_all_THEN_axis_not_stopped(self, axis):
         # Set interlock to disabled
         self.ca.set_pv_value("FINS_VAC:SIM:ADDR:1001", 0)
         self.ca.assert_that_pv_is("FINS_VAC:GALIL_INTERLOCK", "CANNOT MOVE")
+        # Execute test
         for _ in range(3):
             set_axis_moving(axis)
             assert_axis_moving(axis)

--- a/tests/sans2d_apertures_guides.py
+++ b/tests/sans2d_apertures_guides.py
@@ -66,7 +66,7 @@ class Sans2dAperturesGuidesTests(unittest.TestCase):
             set_axis_moving(axis)
             assert_axis_moving(axis)
             self.ca.set_pv_value("MOT:SANS2DAPWV:STOP_MOTORS:ALL", 1)
-            assert_axis_not_moving(axis, retry_count=3)
+            assert_axis_not_moving(axis)
 
     @parameterized.expand(AXES_TO_STOP)
     def test_GIVEN_move_disabled_axis_moving_WHEN_stop_all_THEN_axis_stopped(self, axis):
@@ -77,4 +77,4 @@ class Sans2dAperturesGuidesTests(unittest.TestCase):
             set_axis_moving(axis)
             assert_axis_moving(axis)
             self.ca.set_pv_value("MOT:SANS2DAPWV:STOP_MOTORS:ALL", 1)
-            assert_axis_moving(axis, retry_count=3)
+            assert_axis_moving(axis)

--- a/tests/sans2d_vacuum_tank.py
+++ b/tests/sans2d_vacuum_tank.py
@@ -8,7 +8,7 @@ from utils.channel_access import ChannelAccess
 from utils.axis import set_axis_moving, assert_axis_moving, assert_axis_not_moving
 
 test_path = os.path.realpath(
-    os.path.join(os.getenv("EPICS_KIT_ROOT"), "support", "motorExtensions", "master", "settings", "sans2d")
+    os.path.join(os.getenv("EPICS_KIT_ROOT"), "support", "motorExtensions", "master", "settings", "sans2d_vacuum_tank")
 )
 
 GALIL_ADDR = "127.0.0.1"

--- a/utils/axis.py
+++ b/utils/axis.py
@@ -12,11 +12,25 @@ def set_axis_moving(axis):
         ca_motors.set_pv_value(axis + ":SP", low_limit)
 
 
-def assert_axis_moving(axis):
+def assert_axis_moving(axis, retry_count=1):
     ca_motors = ChannelAccess(device_prefix="MOT")
-    ca_motors.assert_that_pv_is(axis + ":MTR.MOVN", 1)
+    for i in range(retry_count):
+        try:
+            ca_motors.assert_that_pv_is(axis + ":MTR.MOVN", 1)
+            break
+        except AssertionError:
+            continue
+    else:
+        raise AssertionError("Axis {}:MTR.MOVN is 0 i.e. not moving. Retry count was {} times".format(axis, retry_count))
 
 
-def assert_axis_not_moving(axis):
+def assert_axis_not_moving(axis, retry_count=1):
     ca_motors = ChannelAccess(device_prefix="MOT")
-    ca_motors.assert_that_pv_is(axis + ":MTR.MOVN", 0)
+    for i in range(retry_count):
+        try:
+            ca_motors.assert_that_pv_is(axis + ":MTR.MOVN", 0)
+            break
+        except AssertionError:
+            continue
+    else:
+        raise AssertionError("Axis {}:MTR.MOVN is 1 i.e. moving. Retry count was {} times".format(axis, retry_count))

--- a/utils/axis.py
+++ b/utils/axis.py
@@ -12,25 +12,11 @@ def set_axis_moving(axis):
         ca_motors.set_pv_value(axis + ":SP", low_limit)
 
 
-def assert_axis_moving(axis, retry_count=1):
+def assert_axis_moving(axis):
     ca_motors = ChannelAccess(device_prefix="MOT")
-    for i in range(retry_count):
-        try:
-            ca_motors.assert_that_pv_is(axis + ":MTR.MOVN", 1)
-            break
-        except AssertionError:
-            continue
-    else:
-        raise AssertionError("Axis {}:MTR.MOVN is 0 i.e. not moving. Retry count was {} times".format(axis, retry_count))
+    ca_motors.assert_that_pv_is(axis + ":MTR.MOVN", 1, timeout=1)
 
 
-def assert_axis_not_moving(axis, retry_count=1):
+def assert_axis_not_moving(axis):
     ca_motors = ChannelAccess(device_prefix="MOT")
-    for i in range(retry_count):
-        try:
-            ca_motors.assert_that_pv_is(axis + ":MTR.MOVN", 0)
-            break
-        except AssertionError:
-            continue
-    else:
-        raise AssertionError("Axis {}:MTR.MOVN is 1 i.e. moving. Retry count was {} times".format(axis, retry_count))
+    ca_motors.assert_that_pv_is(axis + ":MTR.MOVN", 0, timeout=1)

--- a/utils/axis.py
+++ b/utils/axis.py
@@ -12,6 +12,11 @@ def set_axis_moving(axis):
         ca_motors.set_pv_value(axis + ":SP", low_limit)
 
 
+def stop_axis_moving(axis):
+    ca_motors = ChannelAccess(device_prefix="MOT")
+    ca_motors.set_pv_value(axis + ":MTR.STOP", 1)
+
+
 def assert_axis_moving(axis, timeout=1):
     ca_motors = ChannelAccess(device_prefix="MOT")
     ca_motors.assert_that_pv_is(axis + ":MTR.MOVN", 1, timeout=timeout)

--- a/utils/axis.py
+++ b/utils/axis.py
@@ -1,0 +1,22 @@
+from utils.channel_access import ChannelAccess
+
+
+def set_axis_moving(axis):
+    ca_motors = ChannelAccess(device_prefix="MOT")
+    current_position = ca_motors.get_pv_value(axis)
+    low_limit = ca_motors.get_pv_value(axis + ":MTR.LLM")
+    high_limit = ca_motors.get_pv_value(axis + ":MTR.HLM")
+    if current_position - low_limit < high_limit - current_position:
+        ca_motors.set_pv_value(axis + ":SP", high_limit)
+    else:
+        ca_motors.set_pv_value(axis + ":SP", low_limit)
+
+
+def assert_axis_moving(axis):
+    ca_motors = ChannelAccess(device_prefix="MOT")
+    ca_motors.assert_that_pv_is(axis + ":MTR.MOVN", 1)
+
+
+def assert_axis_not_moving(axis):
+    ca_motors = ChannelAccess(device_prefix="MOT")
+    ca_motors.assert_that_pv_is(axis + ":MTR.MOVN", 0)


### PR DESCRIPTION
Test motorExtension pv for galil on sans2d to stop motion for apertures and waveguides

Ticket: https://github.com/ISISComputingGroup/IBEX/issues/4571

## Acceptance criteria

1. The IBEX GUI provides a clear, visible STOP button on the SANS2D apertures and waveguides OPI
1. On pressing the STOP button:
   1. if motion is enabled, all motors driving the SANS2D apertures and waveguides are halted immediately.
   1. if motion is disabled, IBEX ignores the button push.
1. The STOP button should appear on both the "user" and "advanced" tabs.
1. IOC Tests