### PR TITLE
Fix sans2daperturesguidestest

### DIFF
--- a/tests/sans2d_apertures_guides.py
+++ b/tests/sans2d_apertures_guides.py
@@ -30,7 +30,7 @@ IOCS = [
         "macros": {
             "MTRCTRL1": "01",
             "GALILADDR1": GALIL_ADDR1,
-            "MTRCTRL": "02",
+            "MTRCTRL2": "02",
             "GALILADDR2": GALIL_ADDR2,
             "GALILCONFIGDIR": galil_settings_path.replace("\\", "/"),
         }


### PR DESCRIPTION
Jenkins IOC tests were failing because the axes of the guide weren't available to call stop on. They are on motor 2 and weren't in the test config, added as MTRCTRL2 and GALILADDR2 and corrected the IP addresses.