### PR TITLE
Ticket4711 remove separator stability units

### DIFF
--- a/tests/separator.py
+++ b/tests/separator.py
@@ -627,13 +627,6 @@ class StabilityTests(unittest.TestCase):
         # THEN
         self.ca.assert_that_pv_alarm_is("STABILITY", ChannelAccess.Alarms.NONE)
 
-    def test_GIVEN_separator_stability_THEN_separator_stability_pv_has_no_units(self):
-        # GIVEN
-        units = self.ca.get_pv_value("STABILITY.EGU")
-
-        # THEN
-        self.assertEqual(units, "")
-
     def test_GIVEN_separator_stable_THEN_separator_stability_text_label_is_stable(self):
         # GIVEN
         # asserted in setup that separator is stable

--- a/tests/separator.py
+++ b/tests/separator.py
@@ -129,7 +129,7 @@ def stability_set_up(ca):
 
     ca.assert_that_pv_is_number("UNSTABLETIME", 0.0)
 
-    ca.assert_that_pv_is_number("STABILITY", 1.0, tolerance=1e-3)
+    ca.assert_that_pv_is("STABILITY", "stable")
 
 
 def shared_setup(ca):
@@ -605,7 +605,7 @@ class StabilityTests(unittest.TestCase):
 
         self.ca.set_pv_value("_ADDCOUNTS", testvalue / SAMPLETIME, wait=True, sleep_after_set=0.0)
 
-        self.ca.assert_that_pv_is_number("STABILITY", 0, tolerance=0.1)
+        self.ca.assert_that_pv_is("STABILITY", "unstable")
 
         # THEN
         self.ca.assert_that_pv_alarm_is("STABILITY", ChannelAccess.Alarms.MAJOR)
@@ -622,7 +622,7 @@ class StabilityTests(unittest.TestCase):
 
         self.ca.set_pv_value("_ADDCOUNTS", testvalue / SAMPLETIME, wait=True, sleep_after_set=0.0)
 
-        self.ca.assert_that_pv_is_number("STABILITY", 0, tolerance=0.1)
+        self.ca.assert_that_pv_is("STABILITY", "unstable")
 
         # THEN
         self.ca.assert_that_pv_alarm_is("STABILITY", ChannelAccess.Alarms.NONE)
@@ -633,3 +633,10 @@ class StabilityTests(unittest.TestCase):
 
         # THEN
         self.assertEqual(units, "")
+
+    def test_GIVEN_separator_stable_THEN_separator_stability_text_label_is_stable(self):
+        # GIVEN
+        # asserted in setup that separator is stable
+
+        # THEN
+        self.ca.assert_that_pv_is("STABILITY", "stable")

--- a/tests/separator.py
+++ b/tests/separator.py
@@ -129,7 +129,7 @@ def stability_set_up(ca):
 
     ca.assert_that_pv_is_number("UNSTABLETIME", 0.0)
 
-    ca.assert_that_pv_is("STABILITY", "stable")
+    ca.assert_that_pv_is("STABILITY", "Stable")
 
 
 def shared_setup(ca):
@@ -605,7 +605,7 @@ class StabilityTests(unittest.TestCase):
 
         self.ca.set_pv_value("_ADDCOUNTS", testvalue / SAMPLETIME, wait=True, sleep_after_set=0.0)
 
-        self.ca.assert_that_pv_is("STABILITY", "unstable")
+        self.ca.assert_that_pv_is("STABILITY", "Unstable")
 
         # THEN
         self.ca.assert_that_pv_alarm_is("STABILITY", ChannelAccess.Alarms.MAJOR)
@@ -622,7 +622,7 @@ class StabilityTests(unittest.TestCase):
 
         self.ca.set_pv_value("_ADDCOUNTS", testvalue / SAMPLETIME, wait=True, sleep_after_set=0.0)
 
-        self.ca.assert_that_pv_is("STABILITY", "unstable")
+        self.ca.assert_that_pv_is("STABILITY", "Unstable")
 
         # THEN
         self.ca.assert_that_pv_alarm_is("STABILITY", ChannelAccess.Alarms.NONE)
@@ -632,4 +632,4 @@ class StabilityTests(unittest.TestCase):
         # asserted in setup that separator is stable
 
         # THEN
-        self.ca.assert_that_pv_is("STABILITY", "stable")
+        self.ca.assert_that_pv_is("STABILITY", "Stable")

--- a/tests/separator.py
+++ b/tests/separator.py
@@ -626,3 +626,10 @@ class StabilityTests(unittest.TestCase):
 
         # THEN
         self.ca.assert_that_pv_alarm_is("STABILITY", ChannelAccess.Alarms.NONE)
+
+    def test_GIVEN_separator_stability_THEN_separator_stability_pv_has_no_units(self):
+        # GIVEN
+        units = self.ca.get_pv_value("STABILITY.EGU")
+
+        # THEN
+        self.assertEqual(units, "")


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/4711

* adjusted tests to work with the changes to the STABILITY record in https://github.com/ISISComputingGroup/EPICS-SEPRTR/pull/8



