### PR TITLE
Use 0208 instead of 0108 for smangle

### DIFF
--- a/test_config/good_for_refl/refl/config.py
+++ b/test_config/good_for_refl/refl/config.py
@@ -42,7 +42,7 @@ def get_beamline(macros):
     add_parameter(InBeamParameter("SMInBeam", sm_comp), modes=[nr, polarised], mode_inits=[(polarised, True)])
     add_driver(
         IocDriver(sm_comp, ChangeAxis.POSITION, MotorPVWrapper("MOT:MTR0107"), out_of_beam_positions=[SM_OUT_POS]))
-    add_driver(IocDriver(sm_comp, ChangeAxis.ANGLE, MotorPVWrapper("MOT:MTR0108")))
+    add_driver(IocDriver(sm_comp, ChangeAxis.ANGLE, MotorPVWrapper("MOT:MTR0208")))
 
     # THETA
     theta = add_component(ThetaComponent("ThetaComp", PositionAndAngle(0.0, 2 * SPACING, 90)))

--- a/tests/refl.py
+++ b/tests/refl.py
@@ -54,6 +54,8 @@ IOCS = [
         },
         "inits": {
             "MTR0102.VMAX": INITIAL_VELOCITY,
+            "MTR0103.VMAX": MEDIUM_VELOCITY,  # Remove s4 as a speed limiting factor
+            "MTR0103.VELO": MEDIUM_VELOCITY,  # Remove s4 as a speed limiting factor
             "MTR0104.VMAX": INITIAL_VELOCITY,
             "MTR0105.VMAX": FAST_VELOCITY,  # Remove angle as a speed limiting factor
             "MTR0107.VMAX": FAST_VELOCITY,
@@ -63,8 +65,6 @@ IOCS = [
             "MTR0105.HLM": SOFT_LIMIT_HI,
             "MTR0107.ERES": 0.001,
             "MTR0107.MRES": 0.001,
-            "MTR0108.ERES": 0.001,
-            "MTR0108.MRES": 0.001
         }
     },
     {
@@ -78,8 +78,8 @@ IOCS = [
             "GALILCONFIGDIR": test_config_path.replace("\\", "/"),
         },
         "inits": {
-            "MTR0103.VMAX": MEDIUM_VELOCITY,  # Remove s4 as a speed limiting factor
-            "MTR0103.VELO": MEDIUM_VELOCITY,  # Remove s4 as a speed limiting factor
+            "MTR0208.ERES": 0.001,
+            "MTR0208.MRES": 0.001
         }
     },
     {


### PR DESCRIPTION
Tests have been failing because one of the axes occasionally does not move to its setpoint. This change helps us understand whether it is failing due to an issue with that particular motor axis. (it doesn't seem to be an issue of the reflectometry IOC itself)