### PR TITLE
Ticket3185 remote mode reliability

### DIFF
--- a/common_tests/kepco.py
+++ b/common_tests/kepco.py
@@ -27,9 +27,14 @@ class UnitFlags(object):
     ON = 1
     OFF = 0
 
+
+IDN_NO_REM = ("KEPCO, BIT 4886 100-2 123456 1.8-", 1.8)
+
+IDN_REM = ("KEPCO, BIT 4886 100-2, 123456, 3.3-", 3.7)
+
 IDN_LIST = [
-    ("KEPCO, BIT 4886 100-2 123456 1.8-", 1.8),
-    ("KEPCO, BIT 4886 100-2, 123456, 3.3-", 3.7),
+    IDN_NO_REM,
+    IDN_REM,
     ("KEPCO,BIT 4886 100-2,123456,", 2.2),
     ("KEPCO,BIT 4886 100-2,123456 ", 1.4),
     # With current and voltage

--- a/common_tests/kepco.py
+++ b/common_tests/kepco.py
@@ -124,6 +124,7 @@ class KepcoTests(object):
     @parameterized.expand(parameterized_list(IDN_LIST))
     def test_GIVEN_idn_set_WHEN_read_THEN_idn_is_as_expected(self, _, idn_no_firmware, firmware):
         expected_idn = self._set_IDN(idn_no_firmware, firmware)
+        self.ca.process_pv("IDN")
         self.ca.assert_that_pv_is("IDN", expected_idn)
 
     @skip_if_recsim("In rec sim you can not diconnect the device")
@@ -137,4 +138,5 @@ class KepcoTests(object):
     @parameterized.expand(parameterized_list(IDN_LIST))
     def test_GIVEN_idn_set_AND_firmware_set_THEN_firmware_pv_correct(self, _, idn_no_firmware, firmware):
         self._set_IDN(idn_no_firmware, firmware)
+        self.ca.process_pv("FIRMWARE")
         self.ca.assert_that_pv_is("FIRMWARE", firmware)

--- a/common_tests/kepco.py
+++ b/common_tests/kepco.py
@@ -54,8 +54,7 @@ class KepcoTests(object):
         self._lewis, self._ioc = get_running_lewis_and_ioc("kepco", DEVICE_PREFIX)
         self.ca = ChannelAccess(default_timeout=30, device_prefix=DEVICE_PREFIX)
         self._lewis.backdoor_run_function_on_device("reset")
-        self._ioc.start_with_original_macros()
-        self.ca.assert_that_pv_exists("VOLTAGE", timeout=60)
+        self.ca.assert_that_pv_exists("VOLTAGE", timeout=30)
 
     def _write_voltage(self, expected_voltage):
         self._lewis.backdoor_set_on_device("voltage", expected_voltage)

--- a/common_tests/kepco.py
+++ b/common_tests/kepco.py
@@ -1,25 +1,9 @@
-import unittest
-
-from parameterized import parameterized
-
 from utils.channel_access import ChannelAccess
-from utils.ioc_launcher import get_default_ioc_dir, ProcServLauncher
 from utils.test_modes import TestModes
-from utils.testing import get_running_lewis_and_ioc, skip_if_recsim, parameterized_list
-from distutils.util import strtobool
+from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
 
 DEVICE_PREFIX = "KEPCO_01"
-
-
-IOCS = [
-    {
-        "name": DEVICE_PREFIX,
-        "directory": get_default_ioc_dir("KEPCO"),
-        "macros": {},
-        "emulator": "kepco",
-        "ioc_launcher_class": ProcServLauncher,
-    },
-]
+emulator_name = "kepco"
 
 
 TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
@@ -42,7 +26,7 @@ class UnitFlags(object):
     OFF = 0
 
 
-class KepcoTests(unittest.TestCase):
+class KepcoTests(object):
     """
     Tests for the KEPCO.
     """
@@ -125,27 +109,3 @@ class KepcoTests(unittest.TestCase):
         self.ca.assert_that_pv_alarm_is("OUTPUTMODE", self.ca.Alarms.INVALID)
         self.ca.assert_that_pv_alarm_is("CURRENT", self.ca.Alarms.INVALID)
         self.ca.assert_that_pv_alarm_is("VOLTAGE", self.ca.Alarms.INVALID)
-
-    @parameterized.expand(parameterized_list([
-        "OUTPUTMODE:SP",
-        "CURRENT:SP",
-        "VOLTAGE:SP",
-        "OUTPUTSTATUS:SP",
-    ]))
-    @skip_if_recsim("Complex behaviour not simulated in recsim")
-    def test_GIVEN_psu_in_local_mode_WHEN_setpoint_is_sent_THEN_power_supply_put_into_remote_first(self, _, setpoint_pv):
-        self._lewis.backdoor_set_on_device("remote_comms_enabled", False)
-        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", False, cast=strtobool)
-
-        self.ca.process_pv(setpoint_pv)
-
-        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
-
-    @skip_if_recsim("No lewis backdoor in recsim")
-    def test_WHEN_ioc_restarted_THEN_set_into_remote_mode(self):
-        self._lewis.backdoor_set_on_device("remote_comms_enabled", False)
-        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", False, cast=strtobool)
-
-        self._ioc.start_ioc()
-
-        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)

--- a/common_tests/kepco.py
+++ b/common_tests/kepco.py
@@ -54,7 +54,8 @@ class KepcoTests(object):
         self._lewis, self._ioc = get_running_lewis_and_ioc("kepco", DEVICE_PREFIX)
         self.ca = ChannelAccess(default_timeout=30, device_prefix=DEVICE_PREFIX)
         self._lewis.backdoor_run_function_on_device("reset")
-        self.ca.assert_that_pv_exists("VOLTAGE", timeout=30)
+        self._ioc.start_with_original_macros()
+        self.ca.assert_that_pv_exists("VOLTAGE", timeout=60)
 
     def _write_voltage(self, expected_voltage):
         self._lewis.backdoor_set_on_device("voltage", expected_voltage)

--- a/tests/kepco.py
+++ b/tests/kepco.py
@@ -41,6 +41,19 @@ class UnitFlags(object):
     OFF = 0
 
 
+class KepcoStartupTests(unittest.TestCase):
+    """
+    Tests for the startup of a KEPCO.
+    """
+
+    def setUp(self):
+        self._lewis, self._ioc = get_running_lewis_and_ioc("kepco", DEVICE_PREFIX)
+        self.ca = ChannelAccess(default_timeout=30, device_prefix=DEVICE_PREFIX)
+
+    def test_GIVEN_kepco_started_THEN_in_remote_mode(self):
+        self.ca.assert_that_pv_is("REMOTE:GET", "ON")
+
+
 class KepcoTests(unittest.TestCase):
     """
     Tests for the KEPCO.

--- a/tests/kepco_no_rem.py
+++ b/tests/kepco_no_rem.py
@@ -51,7 +51,7 @@ class KepcoNoRemTests(KepcoTests, unittest.TestCase):
             try:
                 self._lewis.assert_that_emulator_value_is(var, set_func(val), cast=int)
             except AssertionError as e:
-                error_message_calls += "\n{}".format(e.message)
+                error_message_calls += "\n{}\n{}".format(var, e.message)
         if error_message_calls != "":
             raise AssertionError("Failed to call sets:{}".format(error_message_calls))
 
@@ -92,7 +92,9 @@ class KepcoNoRemTests(KepcoTests, unittest.TestCase):
         )
 
         # Restart the ioc, initiating a reset and sending of values after 100 microseconds
-        self._ioc.start_with_macros(macros)
+        self._ioc.start_with_macros(macros, wait=True)
+        self.ca.assert_that_pv_exists("VOLTAGE", timeout=60)
+
 
         # Assert reset occurred
         self._lewis.assert_that_emulator_value_is("reset_count", 1, cast=int)

--- a/tests/kepco_no_rem.py
+++ b/tests/kepco_no_rem.py
@@ -107,4 +107,7 @@ class KepcoNoRemTests(KepcoTests, unittest.TestCase):
 
         # Assert autosave has correctly set pvs
         self.ca.assert_dict_of_pvs_have_given_values(pv_values)
-        self._ioc.start_with_original_macros()
+
+        # Reset the macros for subsequent tests
+        self._ioc.start_with_original_macros(wait=True)
+        self.ca.assert_that_pv_exists("VOLTAGE", timeout=60)

--- a/tests/kepco_no_rem.py
+++ b/tests/kepco_no_rem.py
@@ -18,7 +18,6 @@ IOCS = [
         "directory": get_default_ioc_dir("KEPCO"),
         "emulator": emulator_name,
         "ioc_launcher_class": ProcServLauncher,
-        "lewis_protocol": "no_rem",
     },
 ]
 
@@ -58,9 +57,9 @@ class KepcoNoRemTests(KepcoTests, unittest.TestCase):
 
     @parameterized.expand(parameterized_list([
         (IDN_NO_REM[0], IDN_NO_REM[1], {}),
-        (IDN_NO_REM[0], IDN_NO_REM[1], {"ON_START": 0}),
-        (IDN_NO_REM[0], IDN_NO_REM[1], {"ON_START": 1}),
-        (IDN_REM[0], IDN_REM[1], {"ON_START": 1}),
+        (IDN_NO_REM[0], IDN_NO_REM[1], {"RESET_ON_START": 1}),
+        (IDN_NO_REM[0], IDN_NO_REM[1], {"RESET_ON_START": 2}),
+        (IDN_REM[0], IDN_REM[1], {"RESET_ON_START": 2}),
     ]))
     @skip_if_recsim("Lewis not available in recsim")
     def test_GIVEN_kepco_started_THEN_reset_and_params_resent(self, _, idn_no_firmware, firmware, macros):
@@ -103,61 +102,6 @@ class KepcoNoRemTests(KepcoTests, unittest.TestCase):
 
         # Assert correct calls made
         self.assert_lewis_set_counts_incremented(zip(lewis_vars, lewis_vals))
-
-        # Assert autosave has correctly set pvs
-        self.ca.assert_dict_of_pvs_have_given_values(pv_values)
-        self._ioc.start_with_original_macros()
-
-    @parameterized.expand(parameterized_list([
-        (IDN_NO_REM[0], IDN_NO_REM[1], {"ON_START": 2}),
-        (IDN_NO_REM[0], IDN_NO_REM[1], {"ON_START": 3}),
-        (IDN_REM[0], IDN_REM[1], {}),
-        (IDN_REM[0], IDN_REM[1], {"ON_START": 0}),
-        (IDN_REM[0], IDN_REM[1], {"ON_START": 2}),
-        (IDN_REM[0], IDN_REM[1], {"ON_START": 3}),
-    ]))
-    @skip_if_recsim("Lewis not available in recsim")
-    def test_GIVEN_kepco_started_THEN_NOT_reset_and_params_resent(self, _, idn_no_firmware, firmware, macros):
-        # Reset data
-        self._lewis.backdoor_run_function_on_device("reset")
-        # Set firmware
-        self._set_IDN(idn_no_firmware, firmware)
-
-        # Set setpoint pvs to something different to their initial values
-        # Keep dict to check autosave has maintained the sets after reset
-        pv_values = {
-            "CURRENT:SP": float(self._lewis.backdoor_get_from_device("setpoint_current")) + 5.0,
-            "VOLTAGE:SP": float(self._lewis.backdoor_get_from_device("setpoint_voltage")) + 5.0,
-            "OUTPUTMODE:SP": "VOLTAGE" if self.ca.get_pv_value("OUTPUTMODE:SP") == "CURRENT" else "CURRENT",
-            "OUTPUTSTATUS:SP": "OFF" if self.ca.get_pv_value("OUTPUTSTATUS:SP") == "ON" else "ON"
-        }
-        for pv, value in pv_values.items():
-            self.ca.set_pv_value(pv, value)
-            self.ca.assert_that_pv_is(pv, value)
-
-        # Make sure autosave writes the value
-        self._ioc.telnet.write("manual_save(\"KEPCO_01_info_settings.req\")\n")
-        self._ioc.telnet.write("manual_save(\"KEPCO_01_info_positions.req\")\n")
-
-        # Set counts to zero and remote mode to false
-        # We want lewis_vars and lewis_vals separate as they are checked later
-        lewis_vars = ["voltage_set_count", "current_set_count", "output_mode_set_count", "output_status_set_count"]
-        lewis_vals = [0, 0, 0, 0]
-        self.lewis_set_and_assert_list(
-            zip(lewis_vars + ["reset_count", "remote_comms_enabled"], lewis_vals + [0, False])
-        )
-
-        # Restart the ioc, which will not initiate a reset
-        self._ioc.start_with_macros(macros)
-
-        # Assert reset did not occur (and SYST:REM had no effect)
-        self._lewis.assert_that_emulator_value_is("reset_count", 0, cast=int)
-        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", False, cast=strtobool)
-        # Wait for reset to be done as is done in the IOC
-        time.sleep(1)
-
-        # Assert calls to set values not made
-        self.assert_lewis_set_counts_not_incremented(zip(lewis_vars, lewis_vals))
 
         # Assert autosave has correctly set pvs
         self.ca.assert_dict_of_pvs_have_given_values(pv_values)

--- a/tests/kepco_no_rem.py
+++ b/tests/kepco_no_rem.py
@@ -1,0 +1,87 @@
+import unittest
+
+from common_tests.kepco import KepcoTests, DEVICE_PREFIX, emulator_name
+
+from utils.ioc_launcher import get_default_ioc_dir, ProcServLauncher
+from utils.test_modes import TestModes
+from utils.testing import skip_if_recsim
+
+from distutils.util import strtobool
+import time
+
+
+IOCS = [
+    {
+        "name": DEVICE_PREFIX,
+        "directory": get_default_ioc_dir("KEPCO"),
+        "macros": {
+            "ON_START": 1
+        },
+        "emulator": emulator_name,
+        "ioc_launcher_class": ProcServLauncher,
+        "lewis_protocol": "no_rem",
+    },
+]
+
+
+TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
+
+
+class KepcoNoRemTests(KepcoTests, unittest.TestCase):
+    """
+    Tests for the KEPCO that has no SYS:REM command available.
+    """
+
+    def setUp(self):
+        super(KepcoNoRemTests, self).setUp()
+
+    @skip_if_recsim("Lewis not available in recsim")
+    def test_GIVEN_kepco_started_THEN_reset_and_params_resent(self):
+        # Reset data
+        self._lewis.backdoor_run_function_on_device("reset")
+
+        # Set setpoint pvs to something different to their initial values
+        pv_values = {
+            "CURRENT:SP": float(self._lewis.backdoor_get_from_device("setpoint_current")) + 5.0,
+            "VOLTAGE:SP": float(self._lewis.backdoor_get_from_device("setpoint_voltage")) + 5.0,
+            "OUTPUTMODE:SP": "VOLTAGE" if self.ca.get_pv_value("OUTPUTMODE:SP") == "CURRENT" else "CURRENT",
+            "OUTPUTSTATUS:SP": "OFF" if self.ca.get_pv_value("OUTPUTSTATUS:SP") == "ON" else "ON"
+        }
+        for pv, value in pv_values.items():
+            self.ca.set_pv_value(pv, value)
+
+        # Set counts to zero and remote mode to false
+        lewis_vars = ["voltage_set_count", "current_set_count", "output_mode_set_count", "output_status_set_count"]
+        lewis_vals = [0, 0, 0, 0]
+        for var, val in zip(lewis_vars + ["reset_count", "remote_comms_enabled"], lewis_vals + [0, False]):
+            self._lewis.backdoor_set_and_assert_set(var, val)
+
+        # Restart the ioc, initiating a reset and sending of values after 100 microseconds
+        self._ioc.start_ioc()
+
+        # Assert reset occurred
+        self._lewis.assert_that_emulator_value_is("reset_count", 1, cast=int)
+        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
+        # Wait for reset to be done as is done in the IOC
+        time.sleep(1)
+
+        # Assert that correct calls have been made to write to setpoints
+        error_message_calls = ""
+        for var, val in zip(lewis_vars, lewis_vals):
+            try:
+                self._lewis.assert_that_emulator_value_is(var, val + 1, cast=int)
+            except AssertionError as e:
+                error_message_calls += "\n{}".format(e.message)
+        if error_message_calls != "":
+            raise AssertionError("Failed to call sets:{}".format(error_message_calls))
+
+        # Assert that setpoint pv values have been reapplied
+        error_message_setpoints = []
+        for pv, value in pv_values.items():
+            try:
+                self.ca.assert_that_pv_is(pv, value)
+            except AssertionError as e:
+                error_message_setpoints += "\n{}".format(e.message)
+        if error_message_setpoints != "":
+            raise AssertionError("Failed to set setpoints:{}".format(error_message_setpoints))
+

--- a/tests/kepco_no_rem.py
+++ b/tests/kepco_no_rem.py
@@ -92,7 +92,7 @@ class KepcoNoRemTests(KepcoTests, unittest.TestCase):
         )
 
         # Restart the ioc, initiating a reset and sending of values after 100 microseconds
-        self._ioc.start_with_macros(macros, wait=True)
+        self._ioc.start_with_macros(macros)
         self.ca.assert_that_pv_exists("VOLTAGE", timeout=60)
 
 
@@ -109,5 +109,5 @@ class KepcoNoRemTests(KepcoTests, unittest.TestCase):
         self.ca.assert_dict_of_pvs_have_given_values(pv_values)
 
         # Reset the macros for subsequent tests
-        self._ioc.start_with_original_macros(wait=True)
+        self._ioc.start_with_original_macros()
         self.ca.assert_that_pv_exists("VOLTAGE", timeout=60)

--- a/tests/kepco_no_rem.py
+++ b/tests/kepco_no_rem.py
@@ -76,7 +76,7 @@ class KepcoNoRemTests(KepcoTests, unittest.TestCase):
             raise AssertionError("Failed to call sets:{}".format(error_message_calls))
 
         # Assert that setpoint pv values have been reapplied
-        error_message_setpoints = []
+        error_message_setpoints = ""
         for pv, value in pv_values.items():
             try:
                 self.ca.assert_that_pv_is(pv, value)

--- a/tests/kepco_no_rem.py
+++ b/tests/kepco_no_rem.py
@@ -107,7 +107,3 @@ class KepcoNoRemTests(KepcoTests, unittest.TestCase):
 
         # Assert autosave has correctly set pvs
         self.ca.assert_dict_of_pvs_have_given_values(pv_values)
-
-        # Reset the macros for subsequent tests
-        self._ioc.start_with_original_macros()
-        self.ca.assert_that_pv_exists("VOLTAGE", timeout=60)

--- a/tests/kepco_no_rem.py
+++ b/tests/kepco_no_rem.py
@@ -65,6 +65,11 @@ class KepcoNoRemTests(KepcoTests, unittest.TestCase):
         }
         for pv, value in pv_values.items():
             self.ca.set_pv_value(pv, value)
+            self.ca.assert_that_pv_is(pv, value)
+
+        # Make sure autosave writes the value
+        self._ioc.telnet.write("manual_save(\"KEPCO_01_info_settings.req\")\n")
+        self._ioc.telnet.write("manual_save(\"KEPCO_01_info_positions.req\")\n")
 
         # Set counts to zero and remote mode to false
         # We want lewis_vars and lewis_vals separate as they are checked later

--- a/tests/kepco_no_rem.py
+++ b/tests/kepco_no_rem.py
@@ -92,18 +92,15 @@ class KepcoNoRemTests(KepcoTests, unittest.TestCase):
         )
 
         # Restart the ioc, initiating a reset and sending of values after 100 microseconds
-        self._ioc.start_with_macros(macros)
-        self.ca.assert_that_pv_exists("VOLTAGE", timeout=60)
+        with self._ioc.start_with_macros(macros, "VOLTAGE"):
+            # Assert reset occurred
+            self._lewis.assert_that_emulator_value_is("reset_count", 1, cast=int)
+            self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
+            # Wait for reset to be done as is done in the IOC
+            time.sleep(1)
 
+            # Assert correct calls made
+            self.assert_lewis_set_counts_incremented(zip(lewis_vars, lewis_vals))
 
-        # Assert reset occurred
-        self._lewis.assert_that_emulator_value_is("reset_count", 1, cast=int)
-        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
-        # Wait for reset to be done as is done in the IOC
-        time.sleep(1)
-
-        # Assert correct calls made
-        self.assert_lewis_set_counts_incremented(zip(lewis_vars, lewis_vals))
-
-        # Assert autosave has correctly set pvs
-        self.ca.assert_dict_of_pvs_have_given_values(pv_values)
+            # Assert autosave has correctly set pvs
+            self.ca.assert_dict_of_pvs_have_given_values(pv_values)

--- a/tests/kepco_no_rem.py
+++ b/tests/kepco_no_rem.py
@@ -1,10 +1,12 @@
 import unittest
 
-from common_tests.kepco import KepcoTests, DEVICE_PREFIX, emulator_name
+from common_tests.kepco import KepcoTests, DEVICE_PREFIX, emulator_name, IDN_NO_REM, IDN_REM
 
 from utils.ioc_launcher import get_default_ioc_dir, ProcServLauncher
 from utils.test_modes import TestModes
-from utils.testing import skip_if_recsim
+from utils.testing import skip_if_recsim, parameterized_list
+
+from parameterized import parameterized
 
 from distutils.util import strtobool
 import time
@@ -14,9 +16,6 @@ IOCS = [
     {
         "name": DEVICE_PREFIX,
         "directory": get_default_ioc_dir("KEPCO"),
-        "macros": {
-            "ON_START": 1
-        },
         "emulator": emulator_name,
         "ioc_launcher_class": ProcServLauncher,
         "lewis_protocol": "no_rem",
@@ -34,26 +33,40 @@ class KepcoNoRemTests(KepcoTests, unittest.TestCase):
 
     def setUp(self):
         super(KepcoNoRemTests, self).setUp()
+        self._set_IDN(IDN_NO_REM[0], IDN_NO_REM[1])
 
     def lewis_set_and_assert_list(self, lewis_vars_and_vals):
         for var, val in lewis_vars_and_vals:
             self._lewis.backdoor_set_and_assert_set(var, val)
 
     def assert_lewis_set_counts_incremented(self, lewis_vars_and_vals):
+        self.assert_lewis_set_counts_set_correctly(lewis_vars_and_vals, lambda x: x + 1)
+
+    def assert_lewis_set_counts_not_incremented(self, lewis_vars_and_vals):
+        self.assert_lewis_set_counts_set_correctly(lewis_vars_and_vals, lambda x: x)
+
+    def assert_lewis_set_counts_set_correctly(self, lewis_vars_and_vals, set_func):
         # Assert that correct calls have been made to write to setpoints
         error_message_calls = ""
         for var, val in lewis_vars_and_vals:
             try:
-                self._lewis.assert_that_emulator_value_is(var, val + 1, cast=int)
+                self._lewis.assert_that_emulator_value_is(var, set_func(val), cast=int)
             except AssertionError as e:
                 error_message_calls += "\n{}".format(e.message)
         if error_message_calls != "":
             raise AssertionError("Failed to call sets:{}".format(error_message_calls))
 
+    @parameterized.expand(parameterized_list([
+        (IDN_NO_REM[0], IDN_NO_REM[1], {}),
+        (IDN_NO_REM[0], IDN_NO_REM[1], {"ON_START": 0}),
+        (IDN_NO_REM[0], IDN_NO_REM[1], {"ON_START": 1}),
+        (IDN_REM[0], IDN_REM[1], {"ON_START": 1}),
+    ]))
     @skip_if_recsim("Lewis not available in recsim")
-    def test_GIVEN_kepco_started_THEN_reset_and_params_resent(self):
+    def test_GIVEN_kepco_started_THEN_reset_and_params_resent(self, _, idn_no_firmware, firmware, macros):
         # Reset data
         self._lewis.backdoor_run_function_on_device("reset")
+        self._set_IDN(idn_no_firmware, firmware)
 
         # Set setpoint pvs to something different to their initial values
         # Keep dict to check autosave has maintained the sets after reset
@@ -80,7 +93,7 @@ class KepcoNoRemTests(KepcoTests, unittest.TestCase):
         )
 
         # Restart the ioc, initiating a reset and sending of values after 100 microseconds
-        self._ioc.start_ioc()
+        self._ioc.start_with_macros(macros)
 
         # Assert reset occurred
         self._lewis.assert_that_emulator_value_is("reset_count", 1, cast=int)
@@ -93,3 +106,59 @@ class KepcoNoRemTests(KepcoTests, unittest.TestCase):
 
         # Assert autosave has correctly set pvs
         self.ca.assert_dict_of_pvs_have_given_values(pv_values)
+        self._ioc.start_with_original_macros()
+
+    @parameterized.expand(parameterized_list([
+        (IDN_NO_REM[0], IDN_NO_REM[1], {"ON_START": 2}),
+        (IDN_NO_REM[0], IDN_NO_REM[1], {"ON_START": 3}),
+        (IDN_REM[0], IDN_REM[1], {}),
+        (IDN_REM[0], IDN_REM[1], {"ON_START": 0}),
+        (IDN_REM[0], IDN_REM[1], {"ON_START": 2}),
+        (IDN_REM[0], IDN_REM[1], {"ON_START": 3}),
+    ]))
+    @skip_if_recsim("Lewis not available in recsim")
+    def test_GIVEN_kepco_started_THEN_NOT_reset_and_params_resent(self, _, idn_no_firmware, firmware, macros):
+        # Reset data
+        self._lewis.backdoor_run_function_on_device("reset")
+        # Set firmware
+        self._set_IDN(idn_no_firmware, firmware)
+
+        # Set setpoint pvs to something different to their initial values
+        # Keep dict to check autosave has maintained the sets after reset
+        pv_values = {
+            "CURRENT:SP": float(self._lewis.backdoor_get_from_device("setpoint_current")) + 5.0,
+            "VOLTAGE:SP": float(self._lewis.backdoor_get_from_device("setpoint_voltage")) + 5.0,
+            "OUTPUTMODE:SP": "VOLTAGE" if self.ca.get_pv_value("OUTPUTMODE:SP") == "CURRENT" else "CURRENT",
+            "OUTPUTSTATUS:SP": "OFF" if self.ca.get_pv_value("OUTPUTSTATUS:SP") == "ON" else "ON"
+        }
+        for pv, value in pv_values.items():
+            self.ca.set_pv_value(pv, value)
+            self.ca.assert_that_pv_is(pv, value)
+
+        # Make sure autosave writes the value
+        self._ioc.telnet.write("manual_save(\"KEPCO_01_info_settings.req\")\n")
+        self._ioc.telnet.write("manual_save(\"KEPCO_01_info_positions.req\")\n")
+
+        # Set counts to zero and remote mode to false
+        # We want lewis_vars and lewis_vals separate as they are checked later
+        lewis_vars = ["voltage_set_count", "current_set_count", "output_mode_set_count", "output_status_set_count"]
+        lewis_vals = [0, 0, 0, 0]
+        self.lewis_set_and_assert_list(
+            zip(lewis_vars + ["reset_count", "remote_comms_enabled"], lewis_vals + [0, False])
+        )
+
+        # Restart the ioc, which will not initiate a reset
+        self._ioc.start_with_macros(macros)
+
+        # Assert reset did not occur (and SYST:REM had no effect)
+        self._lewis.assert_that_emulator_value_is("reset_count", 0, cast=int)
+        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", False, cast=strtobool)
+        # Wait for reset to be done as is done in the IOC
+        time.sleep(1)
+
+        # Assert calls to set values not made
+        self.assert_lewis_set_counts_not_incremented(zip(lewis_vars, lewis_vals))
+
+        # Assert autosave has correctly set pvs
+        self.ca.assert_dict_of_pvs_have_given_values(pv_values)
+        self._ioc.start_with_original_macros()

--- a/tests/kepco_rem.py
+++ b/tests/kepco_rem.py
@@ -1,6 +1,6 @@
 import unittest
 
-from common_tests.kepco import KepcoTests, DEVICE_PREFIX, emulator_name
+from common_tests.kepco import KepcoTests, DEVICE_PREFIX, emulator_name, IDN_NO_REM, IDN_REM
 
 from utils.ioc_launcher import get_default_ioc_dir, ProcServLauncher
 from utils.test_modes import TestModes
@@ -31,6 +31,7 @@ class KepcoRemTests(KepcoTests, unittest.TestCase):
 
     def setUp(self):
         super(KepcoRemTests, self).setUp()
+        self._set_IDN(IDN_REM[0], IDN_REM[1])
 
     @parameterized.expand(parameterized_list([
         "OUTPUTMODE:SP",
@@ -48,12 +49,19 @@ class KepcoRemTests(KepcoTests, unittest.TestCase):
 
         self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
 
+    @parameterized.expand(parameterized_list([
+        (IDN_REM[0], IDN_REM[1], {}),
+        (IDN_REM[0], IDN_REM[1], {"ON_START": 0}),
+        (IDN_REM[0], IDN_REM[1], {"ON_START": 2}),
+        (IDN_NO_REM[0], IDN_NO_REM[1], {"ON_START": 2}),
+    ]))
     @skip_if_recsim("Lewis not available in recsim")
-    def test_GIVEN_kepco_started_THEN_remote_command_sent(self):
+    def test_GIVEN_kepco_started_THEN_remote_command_sent(self, _, idn_no_firmware, firmware, macros):
+        self._set_IDN(idn_no_firmware, firmware)
         self._lewis.backdoor_set_and_assert_set("reset_count", 0)
         self._lewis.backdoor_set_and_assert_set("remote_comms_enabled", False)
 
-        self._ioc.start_ioc()
+        self._ioc.start_with_macros(macros)
 
         self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
         self._lewis.assert_that_emulator_value_is("reset_count", 0, cast=int)

--- a/tests/kepco_rem.py
+++ b/tests/kepco_rem.py
@@ -1,0 +1,59 @@
+import unittest
+
+from common_tests.kepco import KepcoTests, DEVICE_PREFIX, emulator_name
+
+from utils.ioc_launcher import get_default_ioc_dir, ProcServLauncher
+from utils.test_modes import TestModes
+from utils.testing import skip_if_recsim, parameterized_list
+
+from distutils.util import strtobool
+
+from parameterized import parameterized
+
+IOCS = [
+    {
+        "name": DEVICE_PREFIX,
+        "directory": get_default_ioc_dir("KEPCO"),
+        "macros": {},
+        "emulator": emulator_name,
+        "ioc_launcher_class": ProcServLauncher,
+        "lewis_protocol": "with_rem",
+    },
+]
+
+TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
+
+
+class KepcoRemTests(KepcoTests, unittest.TestCase):
+    """
+    Tests for the KEPCO that has a SYST:REM command available.
+    """
+
+    def setUp(self):
+        super(KepcoRemTests, self).setUp()
+
+    @parameterized.expand(parameterized_list([
+        "OUTPUTMODE:SP",
+        "CURRENT:SP",
+        "VOLTAGE:SP",
+        "OUTPUTSTATUS:SP",
+    ]))
+    @skip_if_recsim("Complex behaviour not simulated in recsim")
+    def test_GIVEN_psu_in_local_mode_WHEN_setpoint_is_sent_THEN_power_supply_put_into_remote_first(self, _,
+                                                                                                   setpoint_pv):
+        self._lewis.backdoor_set_on_device("remote_comms_enabled", False)
+        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", False, cast=strtobool)
+
+        self.ca.process_pv(setpoint_pv)
+
+        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
+
+    @skip_if_recsim("Lewis not available in recsim")
+    def test_GIVEN_kepco_started_THEN_remote_command_sent(self):
+        self._lewis.backdoor_set_and_assert_set("reset_count", 0)
+        self._lewis.backdoor_set_and_assert_set("remote_comms_enabled", False)
+
+        self._ioc.start_ioc()
+
+        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
+        self._lewis.assert_that_emulator_value_is("reset_count", 0, cast=int)

--- a/tests/kepco_rem.py
+++ b/tests/kepco_rem.py
@@ -65,7 +65,7 @@ class KepcoRemTests(KepcoTests, unittest.TestCase):
             self._lewis.assert_that_emulator_value_is("reset_count", 0, cast=int)
 
     @skip_if_recsim("Lewis not available in recsim")
-    def test_GIVEN_kepco_firmware_does_not_support_SYSTREM_WHEN_on_start_is_2_THEN_no_remote_mode_AND_no_reset(self):
+    def test_GIVEN_kepco_firmware_does_not_support_SYSTREM_WHEN_on_start_is_0_THEN_no_remote_mode_AND_no_reset(self):
         idn_no_firmware, firmware, macros = IDN_NO_REM[0], IDN_NO_REM[1], {"RESET_ON_START": 0}
         self._set_IDN(idn_no_firmware, firmware)
         self._lewis.backdoor_set_and_assert_set("reset_count", 0)

--- a/tests/kepco_rem.py
+++ b/tests/kepco_rem.py
@@ -66,10 +66,6 @@ class KepcoRemTests(KepcoTests, unittest.TestCase):
         self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
         self._lewis.assert_that_emulator_value_is("reset_count", 0, cast=int)
 
-        # Reset the macros for subsequent tests
-        self._ioc.start_with_original_macros()
-        self.ca.assert_that_pv_exists("VOLTAGE", timeout=60)
-
     @skip_if_recsim("Lewis not available in recsim")
     def test_GIVEN_kepco_firmware_does_not_support_SYSTREM_WHEN_on_start_is_2_THEN_no_remote_mode_AND_no_reset(self):
         idn_no_firmware, firmware, macros = IDN_NO_REM[0], IDN_NO_REM[1], {"RESET_ON_START": 0}
@@ -82,8 +78,4 @@ class KepcoRemTests(KepcoTests, unittest.TestCase):
 
         self._lewis.assert_that_emulator_value_is("remote_comms_enabled", False, cast=strtobool)
         self._lewis.assert_that_emulator_value_is("reset_count", 0, cast=int)
-
-        # Reset the macros for subsequent tests
-        self._ioc.start_with_original_macros()
-        self.ca.assert_that_pv_exists("VOLTAGE", timeout=60)
 

--- a/tests/kepco_rem.py
+++ b/tests/kepco_rem.py
@@ -60,14 +60,14 @@ class KepcoRemTests(KepcoTests, unittest.TestCase):
         self._lewis.backdoor_set_and_assert_set("reset_count", 0)
         self._lewis.backdoor_set_and_assert_set("remote_comms_enabled", False)
 
-        self._ioc.start_with_macros(macros, wait=True)
+        self._ioc.start_with_macros(macros)
         self.ca.assert_that_pv_exists("VOLTAGE", timeout=60)
 
         self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
         self._lewis.assert_that_emulator_value_is("reset_count", 0, cast=int)
 
         # Reset the macros for subsequent tests
-        self._ioc.start_with_original_macros(wait=True)
+        self._ioc.start_with_original_macros()
         self.ca.assert_that_pv_exists("VOLTAGE", timeout=60)
 
     @skip_if_recsim("Lewis not available in recsim")
@@ -77,13 +77,13 @@ class KepcoRemTests(KepcoTests, unittest.TestCase):
         self._lewis.backdoor_set_and_assert_set("reset_count", 0)
         self._lewis.backdoor_set_and_assert_set("remote_comms_enabled", False)
 
-        self._ioc.start_with_macros(macros, wait=True)
+        self._ioc.start_with_macros(macros)
         self.ca.assert_that_pv_exists("VOLTAGE", timeout=60)
 
         self._lewis.assert_that_emulator_value_is("remote_comms_enabled", False, cast=strtobool)
         self._lewis.assert_that_emulator_value_is("reset_count", 0, cast=int)
 
         # Reset the macros for subsequent tests
-        self._ioc.start_with_original_macros(wait=True)
+        self._ioc.start_with_original_macros()
         self.ca.assert_that_pv_exists("VOLTAGE", timeout=60)
 

--- a/tests/kepco_rem.py
+++ b/tests/kepco_rem.py
@@ -10,8 +10,6 @@ from distutils.util import strtobool
 
 from parameterized import parameterized
 
-import time
-
 IOCS = [
     {
         "name": DEVICE_PREFIX,
@@ -68,6 +66,10 @@ class KepcoRemTests(KepcoTests, unittest.TestCase):
         self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
         self._lewis.assert_that_emulator_value_is("reset_count", 0, cast=int)
 
+        # Reset the macros for subsequent tests
+        self._ioc.start_with_original_macros(wait=True)
+        self.ca.assert_that_pv_exists("VOLTAGE", timeout=60)
+
     @skip_if_recsim("Lewis not available in recsim")
     def test_GIVEN_kepco_firmware_does_not_support_SYSTREM_WHEN_on_start_is_2_THEN_no_remote_mode_AND_no_reset(self):
         idn_no_firmware, firmware, macros = IDN_NO_REM[0], IDN_NO_REM[1], {"RESET_ON_START": 0}
@@ -80,4 +82,8 @@ class KepcoRemTests(KepcoTests, unittest.TestCase):
 
         self._lewis.assert_that_emulator_value_is("remote_comms_enabled", False, cast=strtobool)
         self._lewis.assert_that_emulator_value_is("reset_count", 0, cast=int)
+
+        # Reset the macros for subsequent tests
+        self._ioc.start_with_original_macros(wait=True)
+        self.ca.assert_that_pv_exists("VOLTAGE", timeout=60)
 

--- a/tests/kepco_rem.py
+++ b/tests/kepco_rem.py
@@ -60,11 +60,9 @@ class KepcoRemTests(KepcoTests, unittest.TestCase):
         self._lewis.backdoor_set_and_assert_set("reset_count", 0)
         self._lewis.backdoor_set_and_assert_set("remote_comms_enabled", False)
 
-        self._ioc.start_with_macros(macros)
-        self.ca.assert_that_pv_exists("VOLTAGE", timeout=60)
-
-        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
-        self._lewis.assert_that_emulator_value_is("reset_count", 0, cast=int)
+        with self._ioc.start_with_macros(macros, "VOLTAGE"):
+            self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
+            self._lewis.assert_that_emulator_value_is("reset_count", 0, cast=int)
 
     @skip_if_recsim("Lewis not available in recsim")
     def test_GIVEN_kepco_firmware_does_not_support_SYSTREM_WHEN_on_start_is_2_THEN_no_remote_mode_AND_no_reset(self):
@@ -73,9 +71,7 @@ class KepcoRemTests(KepcoTests, unittest.TestCase):
         self._lewis.backdoor_set_and_assert_set("reset_count", 0)
         self._lewis.backdoor_set_and_assert_set("remote_comms_enabled", False)
 
-        self._ioc.start_with_macros(macros)
-        self.ca.assert_that_pv_exists("VOLTAGE", timeout=60)
-
-        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", False, cast=strtobool)
-        self._lewis.assert_that_emulator_value_is("reset_count", 0, cast=int)
+        with self._ioc.start_with_macros(macros, "VOLTAGE"):
+            self._lewis.assert_that_emulator_value_is("remote_comms_enabled", False, cast=strtobool)
+            self._lewis.assert_that_emulator_value_is("reset_count", 0, cast=int)
 

--- a/tests/kepco_rem.py
+++ b/tests/kepco_rem.py
@@ -34,21 +34,21 @@ class KepcoRemTests(KepcoTests, unittest.TestCase):
         super(KepcoRemTests, self).setUp()
         self._set_IDN(IDN_REM[0], IDN_REM[1])
 
-    # @parameterized.expand(parameterized_list([
-    #     "OUTPUTMODE:SP",
-    #     "CURRENT:SP",
-    #     "VOLTAGE:SP",
-    #     "OUTPUTSTATUS:SP",
-    # ]))
-    # @skip_if_recsim("Complex behaviour not simulated in recsim")
-    # def test_GIVEN_psu_in_local_mode_WHEN_setpoint_is_sent_THEN_power_supply_put_into_remote_first(self, _,
-    #                                                                                                setpoint_pv):
-    #     self._lewis.backdoor_set_on_device("remote_comms_enabled", False)
-    #     self._lewis.assert_that_emulator_value_is("remote_comms_enabled", False, cast=strtobool)
-    #
-    #     self.ca.process_pv(setpoint_pv)
-    #
-    #     self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
+    @parameterized.expand(parameterized_list([
+        "OUTPUTMODE:SP",
+        "CURRENT:SP",
+        "VOLTAGE:SP",
+        "OUTPUTSTATUS:SP",
+    ]))
+    @skip_if_recsim("Complex behaviour not simulated in recsim")
+    def test_GIVEN_psu_in_local_mode_WHEN_setpoint_is_sent_THEN_power_supply_put_into_remote_first(self, _,
+                                                                                                   setpoint_pv):
+        self._lewis.backdoor_set_on_device("remote_comms_enabled", False)
+        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", False, cast=strtobool)
+
+        self.ca.process_pv(setpoint_pv)
+
+        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
 
     @parameterized.expand(parameterized_list([
         (IDN_REM[0], IDN_REM[1], {}),

--- a/utils/channel_access.py
+++ b/utils/channel_access.py
@@ -656,12 +656,11 @@ class ChannelAccess(object):
         Args:
             pvs_and_values_dict: A dictionary with keys as pvs and expected values as the value.
         """
-        # Assert that setpoint pv values have been reapplied
-        error_message_setpoints = ""
+        error_message = ""
         for pv, value in pvs_and_values_dict.items():
             try:
                 self.assert_that_pv_is(pv, value)
             except AssertionError as e:
-                error_message_setpoints += "\n{}".format(e.message)
-        if error_message_setpoints != "":
-            raise AssertionError("Failed to set setpoints:{}".format(error_message_setpoints))
+                error_message += "\n{}".format(e.message)
+        if error_message != "":
+            raise AssertionError("Not all PVs have given values, see errors: {}".format(error_message))

--- a/utils/channel_access.py
+++ b/utils/channel_access.py
@@ -648,3 +648,20 @@ class ChannelAccess(object):
         self.assert_that_pv_value_causes_func_to_return_true(
             pv=pv_with_prefix, func=lambda val: val == time_before, pv_value_source=PvUpdateTimeValueSource(),
             message="PV {} was processed".format(pv))
+
+    def assert_dict_of_pvs_have_given_values(self, pvs_and_values_dict):
+        """
+        Assert that the pvs (keys of the passed dict) have the given values (values of the dict).
+
+        Args:
+            pvs_and_values_dict: A dictionary with keys as pvs and expected values as the value.
+        """
+        # Assert that setpoint pv values have been reapplied
+        error_message_setpoints = ""
+        for pv, value in pvs_and_values_dict.items():
+            try:
+                self.assert_that_pv_is(pv, value)
+            except AssertionError as e:
+                error_message_setpoints += "\n{}".format(e.message)
+        if error_message_setpoints != "":
+            raise AssertionError("Failed to set setpoints:{}".format(error_message_setpoints))

--- a/utils/ioc_launcher.py
+++ b/utils/ioc_launcher.py
@@ -291,6 +291,7 @@ class ProcServLauncher(BaseLauncher):
 
         self.telnet = None
         self.autorestart = True
+        self.original_macros = ioc.get("macros", {})
 
     def get_environment_vars(self):
         settings = super(ProcServLauncher, self).get_environment_vars()
@@ -431,6 +432,25 @@ class ProcServLauncher(BaseLauncher):
         arguments_match = all([args in process_arguments for args in ioc_start_arguments])
 
         return arguments_match
+
+    def start_with_macros(self, macros):
+        """
+        Restart the ioc with the given macros
+
+        Args
+            macros (dict): A dictionary of macros to restart the ioc with.
+        """
+        self.macros = macros
+        self.create_macros_file()
+        self.start_ioc()
+
+    def start_with_original_macros(self):
+        """
+        Restart the ioc with the macros originally set.
+        """
+        self.macros = self.original_macros
+        self.create_macros_file()
+        self.start_ioc()
 
 
 class IocLauncher(BaseLauncher):

--- a/utils/ioc_launcher.py
+++ b/utils/ioc_launcher.py
@@ -4,6 +4,7 @@ Code that launches an IOC/application under test
 import subprocess
 import os
 import time
+from contextlib import contextmanager
 
 import psutil
 from time import sleep
@@ -435,7 +436,25 @@ class ProcServLauncher(BaseLauncher):
 
         return arguments_match
 
-    def start_with_macros(self, macros, wait=True):
+    @contextmanager
+    def start_with_macros(self, macros, pv_to_wait_for):
+        """
+        A context manager to start the ioc with the given macros and then at the end start
+        the ioc again with the original macros.
+
+        Args:
+             macros (dict): A dictionary of macros to restart the ioc with.
+             pv_to_wait_for (str): A pv to wait for 60 seconds to appear after starting the ioc.
+        """
+        try:
+            self._start_with_macros(macros)
+            self.ca.assert_that_pv_exists(pv_to_wait_for, timeout=60)
+            yield
+        finally:
+            self._start_with_original_macros()
+            self.ca.assert_that_pv_exists(pv_to_wait_for, timeout=60)
+
+    def _start_with_macros(self, macros, wait=True):
         """
         Restart the ioc with the given macros
 
@@ -446,7 +465,7 @@ class ProcServLauncher(BaseLauncher):
         self.create_macros_file()
         self.start_ioc(wait)
 
-    def start_with_original_macros(self, wait=True):
+    def _start_with_original_macros(self, wait=True):
         """
         Restart the ioc with the macros originally set.
         """

--- a/utils/ioc_launcher.py
+++ b/utils/ioc_launcher.py
@@ -435,7 +435,7 @@ class ProcServLauncher(BaseLauncher):
 
         return arguments_match
 
-    def start_with_macros(self, macros, wait=False):
+    def start_with_macros(self, macros, wait=True):
         """
         Restart the ioc with the given macros
 
@@ -446,7 +446,7 @@ class ProcServLauncher(BaseLauncher):
         self.create_macros_file()
         self.start_ioc(wait)
 
-    def start_with_original_macros(self, wait=False):
+    def start_with_original_macros(self, wait=True):
         """
         Restart the ioc with the macros originally set.
         """

--- a/utils/ioc_launcher.py
+++ b/utils/ioc_launcher.py
@@ -225,10 +225,9 @@ class BaseLauncher(object):
         full_dir = os.path.join(self._var_dir, "tmp")
         if not os.path.exists(full_dir):
             os.makedirs(full_dir)
-        with open(os.path.join(full_dir, "test_config.txt"), mode="w") as f:
+        with open(os.path.join(full_dir, "test_macros.txt"), mode="w") as f:
             for macro, value in self.macros.items():
-                f.write('epicsEnvSet("{macro}", "{value}")\n'
-                        .format(macro=macro.replace('"', '\\"'), value=str(value).replace('"', '\\"')))
+                f.write('{ioc_name}__{macro}={value}\n'.format(ioc_name=self._device, macro=macro, value=value))
 
     def get_environment_vars(self):
         """
@@ -463,6 +462,7 @@ class ProcServLauncher(BaseLauncher):
         """
         self.macros = macros
         self.create_macros_file()
+        time.sleep(1)
         self.start_ioc(wait)
 
     def _start_with_original_macros(self, wait=True):
@@ -471,6 +471,7 @@ class ProcServLauncher(BaseLauncher):
         """
         self.macros = self.original_macros
         self.create_macros_file()
+        time.sleep(1)
         self.start_ioc(wait)
 
 

--- a/utils/ioc_launcher.py
+++ b/utils/ioc_launcher.py
@@ -357,13 +357,15 @@ class ProcServLauncher(BaseLauncher):
         if "Welcome to procServ" not in init_output:
             raise OSError("Cannot connect to procServ over telnet")
 
-    def start_ioc(self):
+    def start_ioc(self, wait=False):
         """
         Sends the start/restart IOC command to procserv. (^X)
 
         """
         start_command = "\x18"
         self.telnet.write("{cmd}\n".format(cmd=start_command))
+        if wait:
+            self.log_file_manager.wait_for_console(MAX_TIME_TO_WAIT_FOR_IOC_TO_START, self._ioc_started_text)
 
     def quit_ioc(self):
         """
@@ -433,7 +435,7 @@ class ProcServLauncher(BaseLauncher):
 
         return arguments_match
 
-    def start_with_macros(self, macros):
+    def start_with_macros(self, macros, wait=False):
         """
         Restart the ioc with the given macros
 
@@ -442,15 +444,15 @@ class ProcServLauncher(BaseLauncher):
         """
         self.macros = macros
         self.create_macros_file()
-        self.start_ioc()
+        self.start_ioc(wait)
 
-    def start_with_original_macros(self):
+    def start_with_original_macros(self, wait=False):
         """
         Restart the ioc with the macros originally set.
         """
         self.macros = self.original_macros
         self.create_macros_file()
-        self.start_ioc()
+        self.start_ioc(wait)
 
 
 class IocLauncher(BaseLauncher):


### PR DESCRIPTION
### Description of work

- Split tests out into kepco versions with SYST:REM command available and without (by setting the firmware at the start of each test which is the condition the device emulator checks)
- Test firmware and IDN are retrieved correctly with multiple versions
- Test when kepco IOC restarted and the firmware version and macro satisfy the conditions to do so then a reset is sent and parameters are also resent
- Test when kepco IOC restarted and the firmware version and macros satisfy the conditions to do so then a remote command is sent
- Add ability to start an IOC with a given set of macros and the ability to start again with the original macros resetting them to the expected 
- Add ability to start an IOC and wait for the given startup text
- Add assertion that a dictionary with keys as PVs and values as expected values have the given expected values

### To test

https://github.com/ISISComputingGroup/IBEX/issues/3185

### Acceptance criteria

*List the acceptance criteria for the PR*

---

#### Code Review

- [ ] A copy of the manual has been placed on the shared drive
- [ ] Pertitent information has been stored in the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Specific-Device-IOC)
- [ ] Does the IOC conform to IBEX standards?
    - [PV naming](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/PV-Naming).
    - [Disable records](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Disable-records)
    - [Record simulation](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Record-Simulation)
    - [Finishing touches](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Finishing-Touches)
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)?
- [ ] Do the IOC and support module conform to the new [build guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reducing-Build-Dependencies)
- [ ] Have the changes been recorded appropriately in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?
- [ ] Is the device's flow control setting correct? [For most devices flow control should be OFF](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Flow-control).

### Functional Tests

- IOC responds correctly in:
    - [ ] Devsim mode
    - [ ] Recsim mode
    - [ ] Real device, if available
- [ ] Supplementary IOCs (`..._0n` where `n>1`) run correctly
- [ ] Log files do not report undefined macros (serach for `macLib: macro` to find instances of `macLib: macro [macro name] is undefined...`

### Final steps

- [ ] Update the IOC submodule in the main EPICS repo. See [Git workflow](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Git-workflow) page for details.
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
