### PR TITLE
Fix system test io cs

### DIFF
--- a/common_tests/kepco.py
+++ b/common_tests/kepco.py
@@ -135,21 +135,6 @@ class KepcoTests(object):
         self.ca.assert_that_pv_alarm_is("CURRENT", self.ca.Alarms.INVALID)
         self.ca.assert_that_pv_alarm_is("VOLTAGE", self.ca.Alarms.INVALID)
 
-    @parameterized.expand(parameterized_list([
-        "OUTPUTMODE:SP",
-        "CURRENT:SP",
-        "VOLTAGE:SP",
-        "OUTPUTSTATUS:SP",
-    ]))
-    @skip_if_recsim("Complex behaviour not simulated in recsim")
-    def test_GIVEN_psu_in_local_mode_WHEN_setpoint_is_sent_THEN_power_supply_put_into_remote_first(self, _, setpoint_pv):
-        self._lewis.backdoor_set_on_device("remote_comms_enabled", False)
-        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", False, cast=strtobool)
-
-        self.ca.process_pv(setpoint_pv)
-
-        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
-
     def _test_ramp_to_target(self, start_current, target_current, ramp_rate, step_number, wait_between_changes):
         self.ca.set_pv_value("CURRENT:SP", start_current)
         self.ca.assert_that_pv_is("CURRENT:SP:RBV", start_current)

--- a/tests/kepco_no_rem.py
+++ b/tests/kepco_no_rem.py
@@ -56,7 +56,6 @@ class KepcoNoRemTests(KepcoTests, unittest.TestCase):
             raise AssertionError("Failed to call sets:{}".format(error_message_calls))
 
     @parameterized.expand(parameterized_list([
-        (IDN_NO_REM[0], IDN_NO_REM[1], {}),
         (IDN_NO_REM[0], IDN_NO_REM[1], {"RESET_ON_START": 1}),
         (IDN_NO_REM[0], IDN_NO_REM[1], {"RESET_ON_START": 2}),
         (IDN_REM[0], IDN_REM[1], {"RESET_ON_START": 2}),

--- a/tests/kepco_rem.py
+++ b/tests/kepco_rem.py
@@ -64,9 +64,13 @@ class KepcoRemTests(KepcoTests, unittest.TestCase):
             self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
             self._lewis.assert_that_emulator_value_is("reset_count", 0, cast=int)
 
+    @parameterized.expand(parameterized_list([
+        (IDN_NO_REM[0], IDN_NO_REM[1], {}),
+        (IDN_NO_REM[0], IDN_NO_REM[1], {"RESET_ON_START": 0})
+    ]))
     @skip_if_recsim("Lewis not available in recsim")
-    def test_GIVEN_kepco_firmware_does_not_support_SYSTREM_WHEN_on_start_is_0_THEN_no_remote_mode_AND_no_reset(self):
-        idn_no_firmware, firmware, macros = IDN_NO_REM[0], IDN_NO_REM[1], {"RESET_ON_START": 0}
+    def test_GIVEN_kepco_firmware_does_not_support_SYSTREM_WHEN_on_start_is_0_THEN_no_remote_mode_AND_no_reset(
+            self, _, idn_no_firmware, firmware, macros):
         self._set_IDN(idn_no_firmware, firmware)
         self._lewis.backdoor_set_and_assert_set("reset_count", 0)
         self._lewis.backdoor_set_and_assert_set("remote_comms_enabled", False)


### PR DESCRIPTION
Tests were failing on kepco_no_rem because:
- The default value of RESET_ON_START has changed so but it's expected behaviour in tests had not
- We do not expect a kepco with no remote command available to be set to remote mode when setting a setpoint