### PR TITLE
Remove EPICS dir at end

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,7 +119,7 @@ pipeline {
 	stage("Clean Up") {
       steps {
 	    bat """
-		  rmdir "C:\\Instrument\\Apps\\EPICS-%MYJOB%"
+		  rmdir /s /q "C:\\Instrument\\Apps\\EPICS-%MYJOB%"
 		  exit /b %ERRCODE%
 		"""
 	  }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,6 +115,15 @@ pipeline {
          }
       }
     }
+	
+	stage("Clean Up") {
+      steps {
+	    bat """
+		  rmdir "C:\\Instrument\\Apps\\EPICS-%MYJOB%"
+		  exit /b %ERRCODE%
+		"""
+	  }
+	}
   }
   
   post {


### PR DESCRIPTION
Having separate EPICS directories is clogging up RENO, this should free up some space.