### PR TITLE
Fix tests

### DIFF
--- a/common_tests/danfysik.py
+++ b/common_tests/danfysik.py
@@ -255,5 +255,5 @@ class DanfysikCommon(DanfysikBase):
         self.ca.assert_that_pv_is("CURR", current)
         self.ca.assert_that_pv_is("POWER", "On" if power_state else "Off")
 
-        self.assertEqual(str(current), self._lewis.backdoor_get_from_device("absolute_current"))
-        self.assertEqual(str(power_state), self._lewis.backdoor_get_from_device("power"))
+        self.assertEqual(current, self._lewis.backdoor_get_from_device("absolute_current"))
+        self.assertEqual(power_state, self._lewis.backdoor_get_from_device("power"))

--- a/common_tests/fermichopper.py
+++ b/common_tests/fermichopper.py
@@ -65,7 +65,7 @@ class FermichopperBase(object):
         if IOCRegister.uses_rec_sim:
             return False  # In recsim, assume device is always ok
         else:
-            return self._lewis.backdoor_get_from_device("is_broken") != "False"
+            return self._lewis.backdoor_get_from_device("is_broken")
 
     def tearDown(self):
         self.assertFalse(self.is_device_broken(), "Device was broken.")

--- a/utils/emulator_launcher.py
+++ b/utils/emulator_launcher.py
@@ -465,7 +465,7 @@ class LewisLauncher(EmulatorLauncher):
         :return: lines from the command output
         """
         try:
-            return str(call_method(self.remote, lewis_command[0], lewis_command[1], lewis_command[2:]))
+            return call_method(self.remote, lewis_command[0], lewis_command[1], lewis_command[2:])
         except Exception as e:
             sys.stderr.write(f"Error using backdoor: {e}\n")
 

--- a/utils/emulator_launcher.py
+++ b/utils/emulator_launcher.py
@@ -493,7 +493,7 @@ class LewisLauncher(EmulatorLauncher):
         """
         Return the string of a value on a device from lewis.
         :param variable_name: name of the variable
-        :return: the variables value, as a string
+        :return: the variables value
         """
         # backdoor_command returns a list of bytes and join takes str so convert them here
         return self.backdoor_command(["device", str(variable_name)])


### PR DESCRIPTION
Fixes the danfysik IOC system tests. Note that not converting the Lewis return value to a string may break other tests but we should use the type properly now that we can, I suggest we merge and see what fails on the build server.

To test:
* Run the danfysik tests and confirm they pass