### PR TITLE
Fix some tests broken in python 3

### DIFF
--- a/tests/flipprps.py
+++ b/tests/flipprps.py
@@ -34,9 +34,9 @@ class FlipprpsTests(unittest.TestCase):
     @skip_if_recsim("Lewis backdoor commands not available in RecSim")
     def test_SET_polarity(self):
         self.ca.set_pv_value("POLARITY", "Down")
-        self._lewis.assert_that_emulator_value_is("polarity", "0")
+        self._lewis.assert_that_emulator_value_is("polarity", 0)
         self.ca.set_pv_value("POLARITY", "Up")
-        self._lewis.assert_that_emulator_value_is("polarity", "1")
+        self._lewis.assert_that_emulator_value_is("polarity", 1)
 
     def test_GET_id(self):
         self.ca.assert_that_pv_is("ID", "Flipper")

--- a/tests/icefrdge.py
+++ b/tests/icefrdge.py
@@ -125,14 +125,14 @@ class IceFridgeTests(unittest.TestCase):
     @skip_if_recsim("Lewis assertion not working in recsim")
     def test_WHEN_Lakeshore_MC_setpoint_is_zero_THEN_scan_correct(self):
         self.ca.set_pv_value("LS:MC:TEMP:SP", 0)
-        self._lewis.assert_that_emulator_value_is("lakeshore_scan", "1", 15)
-        self._lewis.assert_that_emulator_value_is("lakeshore_cmode", "4", 15)
+        self._lewis.assert_that_emulator_value_is("lakeshore_scan", 1, 15)
+        self._lewis.assert_that_emulator_value_is("lakeshore_cmode", 4, 15)
 
     @skip_if_recsim("Lewis assertion not working in recsim")
     def test_WHEN_Lakeshore_MC_setpoint_is_larger_than_zero_THEN_scan_correct(self):
         self.ca.set_pv_value("LS:MC:TEMP:SP", 4)
-        self._lewis.assert_that_emulator_value_is("lakeshore_scan", "0", 15)
-        self._lewis.assert_that_emulator_value_is("lakeshore_cmode", "1", 15)
+        self._lewis.assert_that_emulator_value_is("lakeshore_scan", 0, 15)
+        self._lewis.assert_that_emulator_value_is("lakeshore_cmode", 1, 15)
 
     def test_WHEN_Lakeshore_MC_setpoint_negative_THEN_readback_zero(self):
         self.ca.set_pv_value("LS:MC:TEMP:SP", -1)
@@ -334,62 +334,62 @@ class IceFridgeTests(unittest.TestCase):
 
     @skip_if_recsim("Lewis assertion not working in recsim")
     def test_WHEN_mimic_skip_THEN_skipped(self):
-        self._lewis.assert_that_emulator_value_is("skipped", "False", 15)
+        self._lewis.assert_that_emulator_value_is("skipped", False, 15)
 
         self.ca.set_pv_value("MIMIC:MODE:SP", "SEMI AUTOMATIC")
         # does not matter what value the pv is set to, only that it processes
         self.ca.set_pv_value("MIMIC:SKIP:SP", "SKIP")
 
-        self._lewis.assert_that_emulator_value_is("skipped", "True", 15)
+        self._lewis.assert_that_emulator_value_is("skipped", True, 15)
 
     @skip_if_recsim("Lewis assertion not working in recsim")
     def test_WHEN_mimic_stop_THEN_stopped(self):
-        self._lewis.assert_that_emulator_value_is("stopped", "False", 15)
+        self._lewis.assert_that_emulator_value_is("stopped", False, 15)
 
         self.ca.set_pv_value("MIMIC:MODE:SP", "SEMI AUTOMATIC")
         # does not matter what value the pv is set to, only that it processes
         self.ca.set_pv_value("MIMIC:STOP:SP", "STOP")
 
-        self._lewis.assert_that_emulator_value_is("stopped", "True", 15)
+        self._lewis.assert_that_emulator_value_is("stopped", True, 15)
 
     @skip_if_recsim("Lewis assertion not working in recsim")
     def test_WHEN_mimic_sequence_condense_THEN_condense(self):
-        self._lewis.assert_that_emulator_value_is("condense", "False", 15)
+        self._lewis.assert_that_emulator_value_is("condense", False, 15)
 
         self.ca.set_pv_value("MIMIC:MODE:SP", "SEMI AUTOMATIC")
         self.ca.set_pv_value("MIMIC:SEQUENCE:SP", "Condense")
         # does not matter what value the pv is set to, only that it processes
         self.ca.set_pv_value("MIMIC:START:SP", "START")
 
-        self._lewis.assert_that_emulator_value_is("condense", "True", 15)
+        self._lewis.assert_that_emulator_value_is("condense", True, 15)
 
     @skip_if_recsim("Lewis assertion not working in recsim")
     def test_WHEN_mimic_sequence_circulate_THEN_circulate(self):
-        self._lewis.assert_that_emulator_value_is("circulate", "False", 15)
+        self._lewis.assert_that_emulator_value_is("circulate", False, 15)
 
         self.ca.set_pv_value("MIMIC:MODE:SP", "SEMI AUTOMATIC")
         self.ca.set_pv_value("MIMIC:SEQUENCE:SP", "Circulate")
         # does not matter what value the pv is set to, only that it processes
         self.ca.set_pv_value("MIMIC:START:SP", "START")
 
-        self._lewis.assert_that_emulator_value_is("circulate", "True", 15)
+        self._lewis.assert_that_emulator_value_is("circulate", True, 15)
 
     @skip_if_recsim("Lewis assertion not working in recsim")
     def test_WHEN_mimic_sequence_condense_and_circulate_THEN_condense_and_circulate(self):
-        self._lewis.assert_that_emulator_value_is("condense", "False", 15)
-        self._lewis.assert_that_emulator_value_is("circulate", "False", 15)
+        self._lewis.assert_that_emulator_value_is("condense", False, 15)
+        self._lewis.assert_that_emulator_value_is("circulate", False, 15)
 
         self.ca.set_pv_value("MIMIC:MODE:SP", "SEMI AUTOMATIC")
         self.ca.set_pv_value("MIMIC:SEQUENCE:SP", "Condense & Circulate")
         # does not matter what value the pv is set to, only that it processes
         self.ca.set_pv_value("MIMIC:START:SP", "START")
 
-        self._lewis.assert_that_emulator_value_is("condense", "True", 15)
-        self._lewis.assert_that_emulator_value_is("circulate", "True", 15)
+        self._lewis.assert_that_emulator_value_is("condense", True, 15)
+        self._lewis.assert_that_emulator_value_is("circulate", True, 15)
 
     @skip_if_recsim("Lewis assertion not working in recsim")
     def test_WHEN_mimic_sequence_temp_control_THEN_readback_identical(self):
-        self._lewis.assert_that_emulator_value_is("temp_control", "0", 15)
+        self._lewis.assert_that_emulator_value_is("temp_control", 0, 15)
 
         self.ca.set_pv_value("MIMIC:MODE:SP", "SEMI AUTOMATIC")
         self.ca.set_pv_value("MIMIC:SEQUENCE:SP", "Temperature Control")
@@ -401,25 +401,25 @@ class IceFridgeTests(unittest.TestCase):
 
     @skip_if_recsim("Lewis assertion not working in recsim")
     def test_WHEN_mimic_sequence_make_safe_THEN_make_safe(self):
-        self._lewis.assert_that_emulator_value_is("make_safe", "False", 15)
+        self._lewis.assert_that_emulator_value_is("make_safe", False, 15)
 
         self.ca.set_pv_value("MIMIC:MODE:SP", "SEMI AUTOMATIC")
         self.ca.set_pv_value("MIMIC:SEQUENCE:SP", "Make Safe")
         # does not matter what value the pv is set to, only that it processes
         self.ca.set_pv_value("MIMIC:START:SP", "START")
 
-        self._lewis.assert_that_emulator_value_is("make_safe", "True", 15)
+        self._lewis.assert_that_emulator_value_is("make_safe", True, 15)
 
     @skip_if_recsim("Lewis assertion not working in recsim")
     def test_WHEN_mimic_sequence_warm_up_THEN_warm_up(self):
-        self._lewis.assert_that_emulator_value_is("warm_up", "False", 15)
+        self._lewis.assert_that_emulator_value_is("warm_up", False, 15)
 
         self.ca.set_pv_value("MIMIC:MODE:SP", "SEMI AUTOMATIC")
         self.ca.set_pv_value("MIMIC:SEQUENCE:SP", "Warm Up")
         # does not matter what value the pv is set to, only that it processes
         self.ca.set_pv_value("MIMIC:START:SP", "START")
 
-        self._lewis.assert_that_emulator_value_is("warm_up", "True", 15)
+        self._lewis.assert_that_emulator_value_is("warm_up", True, 15)
 
     @skip_if_recsim("Lewis backdoor not working in recsim")
     def test_WHEN_mimic_info_THEN_ioc_read_correctly(self):

--- a/tests/ips.py
+++ b/tests/ips.py
@@ -162,7 +162,7 @@ class IpsTests(unittest.TestCase):
         persistent_field = float(self.ca.get_pv_value("MAGNET:FIELD:PERSISTENT"))
 
         # Set the new field. This will cause all of the following events based on the state machine.
-        self.ca.set_pv_value("FIELD:SP", val, sleep_after_set=1.0)
+        self.ca.set_pv_value("FIELD:SP", val)
 
         # PSU should be ramped to match the persistent field inside the magnet (if there was one)
         self._assert_field_is(persistent_field)

--- a/tests/ips.py
+++ b/tests/ips.py
@@ -88,7 +88,7 @@ class IpsTests(unittest.TestCase):
         # Wait for statemachine to reach "at field" state after every test.
         self.ca.assert_that_pv_is("STATEMACHINE", "At field")
 
-        self.assertEqual(self._lewis.backdoor_get_from_device("quenched"), "False")
+        self.assertEqual(self._lewis.backdoor_get_from_device("quenched"), False)
 
     def test_WHEN_ioc_is_started_THEN_ioc_is_not_disabled(self):
         self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")
@@ -162,7 +162,7 @@ class IpsTests(unittest.TestCase):
         persistent_field = float(self.ca.get_pv_value("MAGNET:FIELD:PERSISTENT"))
 
         # Set the new field. This will cause all of the following events based on the state machine.
-        self.ca.set_pv_value("FIELD:SP", val)
+        self.ca.set_pv_value("FIELD:SP", val, sleep_after_set=1.0)
 
         # PSU should be ramped to match the persistent field inside the magnet (if there was one)
         self._assert_field_is(persistent_field)

--- a/tests/kepco_no_rem.py
+++ b/tests/kepco_no_rem.py
@@ -49,7 +49,7 @@ class KepcoNoRemTests(KepcoTests, unittest.TestCase):
         error_message_calls = ""
         for var, val in lewis_vars_and_vals:
             try:
-                self._lewis.assert_that_emulator_value_is(var, set_func(val), cast=int)
+                self._lewis.assert_that_emulator_value_is(var, set_func(val))
             except AssertionError as e:
                 error_message_calls += "\n{}\n{}".format(var, e.message)
         if error_message_calls != "":
@@ -93,8 +93,8 @@ class KepcoNoRemTests(KepcoTests, unittest.TestCase):
         # Restart the ioc, initiating a reset and sending of values after 100 microseconds
         with self._ioc.start_with_macros(macros, "VOLTAGE"):
             # Assert reset occurred
-            self._lewis.assert_that_emulator_value_is("reset_count", 1, cast=int)
-            self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
+            self._lewis.assert_that_emulator_value_is("reset_count", 1)
+            self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True)
             # Wait for reset to be done as is done in the IOC
             time.sleep(1)
 

--- a/tests/kepco_rem.py
+++ b/tests/kepco_rem.py
@@ -42,11 +42,11 @@ class KepcoRemTests(KepcoTests, unittest.TestCase):
     def test_GIVEN_psu_in_local_mode_WHEN_setpoint_is_sent_THEN_power_supply_put_into_remote_first(self, _,
                                                                                                    setpoint_pv):
         self._lewis.backdoor_set_on_device("remote_comms_enabled", False)
-        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", False, cast=strtobool)
+        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", False)
 
         self.ca.process_pv(setpoint_pv)
 
-        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
+        self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True)
 
     @parameterized.expand(parameterized_list([
         (IDN_REM[0], IDN_REM[1], {}),
@@ -61,8 +61,8 @@ class KepcoRemTests(KepcoTests, unittest.TestCase):
         self._lewis.backdoor_set_and_assert_set("remote_comms_enabled", False)
 
         with self._ioc.start_with_macros(macros, "VOLTAGE"):
-            self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True, cast=strtobool)
-            self._lewis.assert_that_emulator_value_is("reset_count", 0, cast=int)
+            self._lewis.assert_that_emulator_value_is("remote_comms_enabled", True)
+            self._lewis.assert_that_emulator_value_is("reset_count", 0)
 
     @parameterized.expand(parameterized_list([
         (IDN_NO_REM[0], IDN_NO_REM[1], {}),
@@ -76,6 +76,6 @@ class KepcoRemTests(KepcoTests, unittest.TestCase):
         self._lewis.backdoor_set_and_assert_set("remote_comms_enabled", False)
 
         with self._ioc.start_with_macros(macros, "VOLTAGE"):
-            self._lewis.assert_that_emulator_value_is("remote_comms_enabled", False, cast=strtobool)
-            self._lewis.assert_that_emulator_value_is("reset_count", 0, cast=int)
+            self._lewis.assert_that_emulator_value_is("remote_comms_enabled", False)
+            self._lewis.assert_that_emulator_value_is("reset_count", 0)
 

--- a/tests/linmot.py
+++ b/tests/linmot.py
@@ -104,14 +104,14 @@ class LinmotTests(unittest.TestCase):
         # Driver converts the input velocity units mm (from the motor record) into a value the device uses.
         # See SET_VELOCITY in the devLinMot.cc driver for more information
         target_velocity_value = "0.2"
-        expected_value = "104"
+        expected_value = 104
         self.ca_linmot.set_pv_value(MTR_VELOCITY, target_velocity_value)
         self.ca_linmot.set_pv_value(MTR_SETPOINT, 10)
 
         self._lewis.assert_that_emulator_value_is("velocity", expected_value, timeout=5)
 
     def test_GIVEN_start_up_WHEN_get_motor_warn_status_THEN_it_is_correct(self):
-        expected_value = "256"
+        expected_value = 256
         device_value = self._lewis.backdoor_get_from_device("motor_warn_status_int")
         self.assertEqual(device_value, expected_value)
 

--- a/tests/rkndio.py
+++ b/tests/rkndio.py
@@ -105,13 +105,13 @@ class RkndioVersionTests(unittest.TestCase):
         # Given
         pv = "PIN:{}".format(pin)
         self.ca.set_pv_value(pv, "FALSE")
-        reset_check = self._lewis.backdoor_run_function_on_device("get_output_state_via_the_backdoor", [pin])[0]
+        reset_check = self._lewis.backdoor_run_function_on_device("get_output_state_via_the_backdoor", [pin])
         self.assertEqual(reset_check, "FALSE")
 
         # When:
         self.ca.set_pv_value(pv, "TRUE")
 
         # Then:
-        result = self._lewis.backdoor_run_function_on_device("get_output_state_via_the_backdoor", [pin])[0]
+        result = self._lewis.backdoor_run_function_on_device("get_output_state_via_the_backdoor", [pin])
         self.assertEqual(result, "TRUE")
 

--- a/utils/emulator_launcher.py
+++ b/utils/emulator_launcher.py
@@ -193,7 +193,7 @@ class EmulatorLauncher(object):
             UnableToConnectToPVException: if emulator property does not exist within timeout
         """
         self.backdoor_set_on_device(variable, value)
-        self.assert_that_emulator_value_is(variable, str(value))
+        self.assert_that_emulator_value_is(variable, value)
 
     def assert_that_emulator_value_is(self, emulator_property, expected_value, timeout=None, message=None,
                                       cast=lambda val: val):


### PR DESCRIPTION
Fixes a number of tests.

To test run the following and confirm they pass:
* `flipprps`
* `icefrdge`
* `ips`
* `kepco`
* `kepco_no_rem`
* `linmot`
* `rkndio`