### PR TITLE
Stopped fermi_chopper running in recsim

### DIFF
--- a/tests/fzj_dd_fermi_chopper.py
+++ b/tests/fzj_dd_fermi_chopper.py
@@ -1,10 +1,9 @@
 import unittest
-from unittest import skipIf
 
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import IOCRegister, get_default_ioc_dir
 from utils.test_modes import TestModes
-from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
+from utils.testing import get_running_lewis_and_ioc
 
 chopper_name = "C01"
 
@@ -22,7 +21,7 @@ IOCS = [
     },
 ]
 
-TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
+TEST_MODES = [TestModes.DEVSIM]
 
 OK_NOK = {True: "OK", False: "NOK"}
 ON_OFF = {True: "ON", False: "OFF"}
@@ -89,7 +88,7 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
 
         self._lewis, self._ioc = get_running_lewis_and_ioc("fzj_dd_fermi_chopper", DEVICE_PREFIX)
 
-        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
+        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX, default_wait_time=0.0)
 
         if not IOCRegister.uses_rec_sim:
             self._lewis.backdoor_set_on_device("chopper_name", chopper_name)
@@ -122,7 +121,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self._ioc.set_simulated_value(pv_name, value)
         self._lewis.backdoor_set_on_device(backdoor_parameter, value)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_frequency_setpoint_WHEN_read_all_status_THEN_value_is_as_expected(self):
         expected_value = 100
         self._set_simulated_value("frequency_setpoint", expected_value)
@@ -130,7 +128,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is("FREQ:SP:RBV", expected_value)
         self.ca.assert_that_pv_alarm_is("FREQ:SP:RBV", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_phase_setpoint_WHEN_read_all_status_THEN_value_is_as_expected(self):
         expected_value = 45.2
         self._set_simulated_value("phase_setpoint", expected_value)
@@ -138,7 +135,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is("PHAS:SP:RBV", expected_value)
         self.ca.assert_that_pv_alarm_is("PHAS:SP:RBV", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_phase_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
         for boolean_value, expected_value in OK_NOK.items():
             self._set_simulated_value("phase_status_is_ok", boolean_value)
@@ -146,7 +142,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("PHAS:STAT", expected_value)
             self.ca.assert_that_pv_alarm_is("PHAS:STAT", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_magnetic_bearing_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
         for boolean_value, expected_value in OK_NOK.items():
             self._set_simulated_value("magnetic_bearing_status_is_ok", boolean_value)
@@ -154,7 +149,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("MB:STAT", expected_value)
             self.ca.assert_that_pv_alarm_is("MB:STAT", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_magnetic_bearing_WHEN_read_all_status_THEN_status_is_as_expected(self):
         for boolean_value, expected_value in ON_OFF.items():
             self._set_simulated_value("magnetic_bearing_is_on", boolean_value)
@@ -162,7 +156,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("MB", expected_value)
             self.ca.assert_that_pv_alarm_is("MB", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_WHEN_read_all_status_THEN_status_is_as_expected(self):
         for boolean_value, expected_value in ON_OFF.items():
             self._set_simulated_value("drive_is_on", boolean_value)
@@ -170,7 +163,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("DRIVE", expected_value)
             self.ca.assert_that_pv_alarm_is("DRIVE", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_mode_WHEN_read_all_status_THEN_value_is_as_expected(self):
         for boolean_value, expected_value in START_STOP.items():
             self._set_simulated_value("drive_mode_is_start", boolean_value)
@@ -178,7 +170,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("DRIVE:MODE", expected_value)
             self.ca.assert_that_pv_alarm_is("DRIVE:MODE", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_l1_current_WHEN_read_all_status_THEN_value_is_as_expected(self):
         expected_value = 9.62
         self._set_simulated_value("drive_l1_current", expected_value)
@@ -186,7 +177,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is("DRIVE:L1:CURR", expected_value)
         self.ca.assert_that_pv_alarm_is("DRIVE:L1:CURR", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_l2_current_WHEN_read_all_status_THEN_value_is_as_expected(self):
         expected_value = 2.74
         self._set_simulated_value("drive_l2_current", expected_value)
@@ -194,7 +184,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is("DRIVE:L2:CURR", expected_value)
         self.ca.assert_that_pv_alarm_is("DRIVE:L2:CURR", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_l3_current_WHEN_read_all_status_THEN_value_is_as_expected(self):
         expected_value = 12.48
         self._set_simulated_value("drive_l3_current", expected_value)
@@ -202,7 +191,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is("DRIVE:L3:CURR", expected_value)
         self.ca.assert_that_pv_alarm_is("DRIVE:L3:CURR", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_direction_WHEN_read_all_status_THEN_status_is_as_expected(self):
         for boolean_value, expected_value in CW_CCW.items():
             self._set_simulated_value("drive_direction_is_cw", boolean_value)
@@ -210,7 +198,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("DRIVE:DIR", expected_value)
             self.ca.assert_that_pv_alarm_is("DRIVE:DIR", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_drive_temperature_WHEN_read_all_status_THEN_value_is_as_expected(self):
         expected_value = 86.31
         self._set_simulated_value("drive_temperature", expected_value)
@@ -218,7 +205,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is("DRIVE:TEMP", expected_value)
         self.ca.assert_that_pv_alarm_is("DRIVE:TEMP", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_phase_outage_WHEN_read_all_status_THEN_value_is_as_expected(self):
         expected_value = 354.71
         self._set_simulated_value("phase_outage", expected_value)
@@ -226,7 +212,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is("PHAS:OUTAGE", expected_value)
         self.ca.assert_that_pv_alarm_is("PHAS:OUTAGE", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_logging_WHEN_read_all_status_THEN_status_is_as_expected(self):
         for boolean_value, expected_value in ON_OFF.items():
             self._set_simulated_value("logging_is_on", boolean_value)
@@ -234,7 +219,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("LOGGING", expected_value)
             self.ca.assert_that_pv_alarm_is("LOGGING", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_dsp_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
         for boolean_value, expected_value in OK_NOK.items():
             self._set_simulated_value("dsp_status_is_ok", boolean_value)
@@ -242,7 +226,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("DSP:STAT", expected_value)
             self.ca.assert_that_pv_alarm_is("DSP:STAT", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_er_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
         for boolean_value, expected_value in OK_NOK.items():
             self._set_simulated_value("interlock_er_status_is_ok", boolean_value)
@@ -250,7 +233,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("INTERLOCK:ER:STAT", expected_value)
             self.ca.assert_that_pv_alarm_is("INTERLOCK:ER:STAT", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_vacuum_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
         for boolean_value, expected_value in OK_NOK.items():
             self._set_simulated_value("interlock_vacuum_status_is_ok", boolean_value)
@@ -258,7 +240,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("INTERLOCK:VAC:STAT", expected_value)
             self.ca.assert_that_pv_alarm_is("INTERLOCK:VAC:STAT", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_frequency_monitoring_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
         for boolean_value, expected_value in OK_NOK.items():
             self._set_simulated_value("interlock_frequency_monitoring_status_is_ok", boolean_value)
@@ -266,7 +247,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("INTERLOCK:FREQMON:STAT", expected_value)
             self.ca.assert_that_pv_alarm_is("INTERLOCK:FREQMON:STAT", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_magnetic_bearing_amplifier_temperature_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
         for boolean_value, expected_value in OK_NOK.items():
             self._set_simulated_value("interlock_magnetic_bearing_amplifier_temperature_status_is_ok", boolean_value)
@@ -274,7 +254,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("INTERLOCK:MB:AMP:TEMP:STAT", expected_value)
             self.ca.assert_that_pv_alarm_is("INTERLOCK:MB:AMP:TEMP:STAT", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_magnetic_bearing_amplifier_current_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
         for boolean_value, expected_value in OK_NOK.items():
             self._set_simulated_value("interlock_magnetic_bearing_amplifier_current_status_is_ok", boolean_value)
@@ -282,7 +261,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("INTERLOCK:MB:AMP:CURR:STAT", expected_value)
             self.ca.assert_that_pv_alarm_is("INTERLOCK:MB:AMP:CURR:STAT", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_drive_amplifier_temperature_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
         for boolean_value, expected_value in OK_NOK.items():
             self._set_simulated_value("interlock_drive_amplifier_temperature_status_is_ok", boolean_value)
@@ -290,7 +268,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("INTERLOCK:DRIVE:AMP:TEMP:STAT", expected_value)
             self.ca.assert_that_pv_alarm_is("INTERLOCK:DRIVE:AMP:TEMP:STAT", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_interlock_drive_amplifier_current_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
         for boolean_value, expected_value in OK_NOK.items():
             self._set_simulated_value("interlock_drive_amplifier_current_status_is_ok", boolean_value)
@@ -298,7 +275,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("INTERLOCK:DRIVE:AMP:CURR:STAT", expected_value)
             self.ca.assert_that_pv_alarm_is("INTERLOCK:DRIVE:AMP:CURR:STAT", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set parameter")
     def test_GIVEN_ups_status_WHEN_read_all_status_THEN_status_is_as_expected(self):
         for boolean_value, expected_value in OK_NOK.items():
             self._set_simulated_value("interlock_ups_status_is_ok", boolean_value)
@@ -310,7 +286,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
 
     # Frequency
 
-    @skip_if_recsim("Uses mbbo record - incompatible with RECSIM")
     def test_GIVEN_drive_mode_is_start_WHEN_frequency_setpoint_is_set_THEN_frequency_reaches_setpoint(self):
 
         self.ca.set_pv_value("DRIVE:MODE:SP", START_STOP[True])
@@ -321,7 +296,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is_number("FREQ", frequency, timeout=30)
         self.ca.assert_that_pv_alarm_is("FREQ", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses mbbo record - incompatible with RECSIM")
     def test_GIVEN_drive_mode_is_stop_WHEN_frequency_setpoint_is_set_THEN_frequency_is_zero(self):
 
         self.ca.set_pv_value("DRIVE:MODE:SP", START_STOP[False])
@@ -332,7 +306,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is_number("FREQ", 0, timeout=30)
         self.ca.assert_that_pv_alarm_is("FREQ", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses mbbo record - incompatible with RECSIM")
     def test_GIVEN_frequency_setpoint_is_set_WHEN_drive_mode_is_start_THEN_frequency_reaches_setpoint(self):
 
         frequency = 600
@@ -343,7 +316,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is_number("FREQ", frequency, timeout=30)
         self.ca.assert_that_pv_alarm_is("FREQ", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses mbbo record - incompatible with RECSIM")
     def test_GIVEN_frequency_setpoint_is_set_WHEN_drive_mode_is_stop_THEN_frequency_is_zero(self):
 
         frequency = 600
@@ -354,7 +326,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is_number("FREQ", 0, timeout=30)
         self.ca.assert_that_pv_alarm_is("FREQ", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses mbbo record - incompatible with RECSIM")
     def test_WHEN_frequency_setpoint_is_set_THEN_readback_updates(self):
         frequency = 150
         frequency_as_string = str(frequency)
@@ -365,7 +336,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is("FREQ:SP:RBV", frequency)
         self.ca.assert_that_pv_alarm_is("FREQ:SP:RBV", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set error")
     def test_GIVEN_error_WHEN_set_frequency_THEN_error_is_handled(self):
         frequency = 150
         frequency_as_string = str(frequency)
@@ -376,7 +346,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_alarm_is("FREQ:SP", self.ca.Alarms.INVALID)
         self.ca.assert_that_pv_is("FREQ:SP:ERROR", expected_error)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set error")
     def test_GIVEN_error_then_no_error_WHEN_set_frequency_THEN_error_is_cleared(self):
         frequency = 150
         frequency_as_string = str(frequency)
@@ -393,7 +362,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
 
     #  Phase
 
-    @skip_if_recsim("Uses LeWIS to implement state machine.  Depends on current state.")
     def test_GIVEN_drive_mode_is_start_WHEN_phase_setpoint_is_set_THEN_phase_reaches_setpoint(self):
 
         self.ca.set_pv_value("DRIVE:MODE:SP", START_STOP[True])
@@ -404,7 +372,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is_number("PHAS", phase, timeout=30)
         self.ca.assert_that_pv_alarm_is("PHAS", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS to implement state machine.  Depends on current state.")
     def test_GIVEN_drive_mode_is_stop_WHEN_phase_setpoint_is_set_THEN_phase_is_zero(self):
 
         self.ca.set_pv_value("DRIVE:MODE:SP", START_STOP[False])
@@ -415,7 +382,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is_number("PHAS", 0, timeout=30)
         self.ca.assert_that_pv_alarm_is("PHAS", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS to implement state machine.  Depends on current state.")
     def test_GIVEN_phase_setpoint_is_set_WHEN_drive_mode_is_start_THEN_phase_reaches_setpoint(self):
 
         phase = 65.7
@@ -426,7 +392,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is_number("PHAS", phase, timeout=30)
         self.ca.assert_that_pv_alarm_is("PHAS", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS to implement state machine.  Depends on current state.")
     def test_GIVEN_phase_setpoint_is_set_WHEN_drive_mode_is_stop_THEN_phase_is_zero(self):
 
         phase = 65.7
@@ -437,7 +402,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is_number("PHAS", 0, timeout=30)
         self.ca.assert_that_pv_alarm_is("PHAS", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("PHAS:SP:RBV pushed from protocol")
     def test_WHEN_phase_setpoint_is_set_THEN_readback_updates(self):
         phase = 243.8
         self.ca.set_pv_value("PHAS:SP", phase)
@@ -447,7 +411,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is("PHAS:SP:RBV", phase)
         self.ca.assert_that_pv_alarm_is("PHAS:SP:RBV", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set error")
     def test_GIVEN_error_WHEN_set_phase_THEN_error_is_handled(self):
         phase = 243.8
         expected_error = "09;CxxNOK;SETPOINT_PHASE_OUT_OF_RANGE"
@@ -457,7 +420,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_alarm_is("PHAS:SP", self.ca.Alarms.INVALID)
         self.ca.assert_that_pv_is("PHAS:SP:ERROR", expected_error)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set error")
     def test_GIVEN_error_then_no_error_WHEN_set_phase_THEN_error_is_cleared(self):
         phase = 243.8
         expected_error = "09;CxxNOK;SETPOINT_PHASE_OUT_OF_RANGE"
@@ -473,7 +435,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
 
     # Magnetic Bearing
 
-    @skip_if_recsim("Uses protocol file to push value to PV")
     def test_WHEN_magnetic_bearing_is_set_THEN_readback_updates(self):
         for magnetic_bearing in [ON_OFF[True], ON_OFF[False]]:
             self.ca.set_pv_value("MB:SP", magnetic_bearing)
@@ -483,7 +444,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("MB", magnetic_bearing)
             self.ca.assert_that_pv_alarm_is("MB", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set error")
     def test_GIVEN_error_WHEN_set_magnetic_bearing_is_on_THEN_error_is_handled(self):
         for magnetic_bearing in [ON_OFF[True], ON_OFF[False]]:
             expected_error = "10;CxxNOK;MAGNETIC_BEARING_NOT_OK"
@@ -493,7 +453,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_alarm_is("MB:SP", self.ca.Alarms.INVALID)
             self.ca.assert_that_pv_is("MB:SP:ERROR", expected_error)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set error")
     def test_GIVEN_error_then_no_error_WHEN_set_magnetic_bearing_is_on_THEN_error_is_cleared(self):
         for magnetic_bearing in [ON_OFF[True], ON_OFF[False]]:
             expected_error = "10;CxxNOK;MAGNETIC_BEARING_NOT_OK"
@@ -509,7 +468,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
 
     # Drive
 
-    @skip_if_recsim("Uses protocol file to push value to PV")
     def test_WHEN_drive_mode_is_set_THEN_readback_updates(self):
         for drive_mode in [START_STOP[True], START_STOP[False]]:
             self.ca.set_pv_value("DRIVE:MODE:SP", drive_mode)
@@ -519,7 +477,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_is("DRIVE:MODE", drive_mode)
             self.ca.assert_that_pv_alarm_is("DRIVE:MODE", self.ca.Alarms.NONE)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set error")
     def test_GIVEN_error_WHEN_set_drive_mode_is_start_THEN_error_is_handled(self):
         for drive_mode in [START_STOP[True], START_STOP[False]]:
             expected_error = "10;CxxNOK;MAGNETIC_BEARING_NOT_OK"
@@ -529,7 +486,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
             self.ca.assert_that_pv_alarm_is("DRIVE:MODE:SP", self.ca.Alarms.INVALID)
             self.ca.assert_that_pv_is("DRIVE:MODE:SP:ERROR", expected_error)
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set error")
     def test_GIVEN_error_then_no_error_WHEN_set_drive_mode_is_start_THEN_error_is_cleared(self):
         for drive_mode in [START_STOP[True], START_STOP[False]]:
             expected_error = "10;CxxNOK;MAGNETIC_BEARING_NOT_OK"
@@ -543,7 +499,6 @@ class FzjDigitalDriveFermiChopperTests(unittest.TestCase):
 
             self.ca.assert_that_pv_is("DRIVE:MODE:SP:ERROR", "")
 
-    @skip_if_recsim("Uses LeWIS backdoor command to set disconnected state")
     def test_GIVEN_device_is_not_communicating_WHEN_read_all_status_THEN_values_have_error(self):
         self._lewis.backdoor_set_on_device("disconnected", True)
 


### PR DESCRIPTION
To test:
* Run fermi chopper tests and confirm they all still pass but are now faster (~100s -> ~60s) given that they don't start up a RECSIM IOC and that they are not waiting after every pv set