### PR TITLE
Fix tests now getting all commands back as a list from lewis

### DIFF
--- a/tests/rotsc.py
+++ b/tests/rotsc.py
@@ -111,7 +111,7 @@ class RotscTests(unittest.TestCase):
         self.ca.assert_that_pv_alarm_is("ERR_STRING", self.ca.Alarms.MAJOR)
 
         # Confirm we move back to original position
-        self._lewis.assert_that_emulator_value_is("sample_retrieved", str(False))
+        self._lewis.assert_that_emulator_value_is("sample_retrieved", False)
         # Temporarily removed in https://github.com/ISISComputingGroup/IBEX/issues/5342
         # self.ca.assert_that_pv_is("POSN", initial_position)
         self.ca.assert_that_pv_is("CALC_NOT_MOVING", 1)

--- a/tests/sm300.py
+++ b/tests/sm300.py
@@ -20,11 +20,11 @@ expected_reset_codes = [
     "PXG0", "PYG0",
     "PXH+57000", "PYH+64000",
     "PXI-50", "PYI-20",
-    "PXJ2500", "PYJ25000",
+    "PXJ25000", "PYJ25000",
     "PXK-2500", "PYK-7500",
     "PXL100", "PYL100",
     "PXM5", "PYM5",
-    "PXN100", "PYN5000",
+    "PXN1000", "PYN5000",
     "PXO0", "PYO0",
     "PXP0", "PYP0",
     "BF15000"
@@ -179,7 +179,7 @@ class Sm300Tests(unittest.TestCase):
         reset_codes = self._lewis.backdoor_get_from_device("reset_codes")
 
         for reset_code in expected_reset_codes:
-            assert_that(reset_codes, contains_string(reset_code))
+            assert_that(reset_codes, has_item(reset_code))
         self.ioc_ca.assert_that_pv_is("RESET", "Done")
 
     @skip_if_recsim("Sim doesn't return until move is finished")
@@ -255,7 +255,7 @@ class Sm300Tests(unittest.TestCase):
 
         reset_codes = self._lewis.backdoor_get_from_device("reset_codes")
         for reset_code in expected_reset_codes:
-            assert_that(reset_codes, contains_string(reset_code))
+            assert_that(reset_codes, has_item(reset_code))
             self.ioc_ca.assert_that_pv_is("RESET", "Done")
         self.ca.assert_that_pv_is("MTR0101.RBV", expected_home)
         self.ca.assert_that_pv_is("MTR0102.RBV", expected_home)


### PR DESCRIPTION
# ROTSC 

Just raw type being handed back

# SMC300

Also found some values were wrong. Here is the original labview table:

![image](https://user-images.githubusercontent.com/7570055/110452840-75e44300-80bd-11eb-9181-4428b1ffe481.png)

Previous test wasn't failing because it checked string contain not just whole items and these were factor of 10 out