### PR TITLE
fix more tests after lewis backdoor control change

### DIFF
--- a/common_tests/danfysik.py
+++ b/common_tests/danfysik.py
@@ -255,5 +255,5 @@ class DanfysikCommon(DanfysikBase):
         self.ca.assert_that_pv_is("CURR", current)
         self.ca.assert_that_pv_is("POWER", "On" if power_state else "Off")
 
-        self.assertEqual(current, self._lewis.backdoor_get_from_device("absolute_current"))
-        self.assertEqual(power_state, self._lewis.backdoor_get_from_device("power"))
+        self.assertEqual(str(float(current)), self._lewis.backdoor_get_from_device("absolute_current"))
+        self.assertEqual(str(power_state), self._lewis.backdoor_get_from_device("power"))

--- a/tests/rotsc.py
+++ b/tests/rotsc.py
@@ -111,7 +111,7 @@ class RotscTests(unittest.TestCase):
         self.ca.assert_that_pv_alarm_is("ERR_STRING", self.ca.Alarms.MAJOR)
 
         # Confirm we move back to original position
-        self._lewis.assert_that_emulator_value_is("sample_retrieved", False)
+        self._lewis.assert_that_emulator_value_is("sample_retrieved", 'False')
         # Temporarily removed in https://github.com/ISISComputingGroup/IBEX/issues/5342
         # self.ca.assert_that_pv_is("POSN", initial_position)
         self.ca.assert_that_pv_is("CALC_NOT_MOVING", 1)

--- a/tests/sm300.py
+++ b/tests/sm300.py
@@ -1,3 +1,4 @@
+import ast
 import unittest
 from unittest import skipIf
 
@@ -176,7 +177,7 @@ class Sm300Tests(unittest.TestCase):
         self.ioc_ca.assert_that_pv_exists("RESET", 30)
         self.ioc_ca.set_pv_value("RESET", 1)
 
-        reset_codes = eval(self._lewis.backdoor_get_from_device("reset_codes"))
+        reset_codes = ast.literal_eval(self._lewis.backdoor_get_from_device("reset_codes"))
 
         for reset_code in expected_reset_codes:
             assert_that(reset_codes, has_item(reset_code))
@@ -253,7 +254,7 @@ class Sm300Tests(unittest.TestCase):
 
         self.ioc_ca.set_pv_value("RESET_AND_HOME", 1)
 
-        reset_codes = eval(self._lewis.backdoor_get_from_device("reset_codes"))
+        reset_codes = ast.literal_eval(self._lewis.backdoor_get_from_device("reset_codes"))
         for reset_code in expected_reset_codes:
             assert_that(reset_codes, has_item(reset_code))
             self.ioc_ca.assert_that_pv_is("RESET", "Done")

--- a/tests/sm300.py
+++ b/tests/sm300.py
@@ -176,7 +176,7 @@ class Sm300Tests(unittest.TestCase):
         self.ioc_ca.assert_that_pv_exists("RESET", 30)
         self.ioc_ca.set_pv_value("RESET", 1)
 
-        reset_codes = self._lewis.backdoor_get_from_device("reset_codes")
+        reset_codes = eval(self._lewis.backdoor_get_from_device("reset_codes"))
 
         for reset_code in expected_reset_codes:
             assert_that(reset_codes, has_item(reset_code))
@@ -253,7 +253,7 @@ class Sm300Tests(unittest.TestCase):
 
         self.ioc_ca.set_pv_value("RESET_AND_HOME", 1)
 
-        reset_codes = self._lewis.backdoor_get_from_device("reset_codes")
+        reset_codes = eval(self._lewis.backdoor_get_from_device("reset_codes"))
         for reset_code in expected_reset_codes:
             assert_that(reset_codes, has_item(reset_code))
             self.ioc_ca.assert_that_pv_is("RESET", "Done")


### PR DESCRIPTION
fixes danfysik8800,8500 and common tests and rotsc tests which were broken after the lewis backdoor reversion 
