### PR TITLE
Fix macro value type for refl_init tests

### DIFF
--- a/tests/refl_init.py
+++ b/tests/refl_init.py
@@ -21,8 +21,8 @@ test_config_path = os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(
 test_var_path = os.path.join(test_config_path, "var_init")
 
 REFL_MACROS = json.dumps({"CONFIG_FILE": "config_init.py",  # tested implicitly by entire suite
-                          "OPTIONAL_1": True,
-                          "OPTIONAL_2": False, })
+                          "OPTIONAL_1": "True",
+                          "OPTIONAL_2": "False", })
 
 IOCS = [
     {


### PR DESCRIPTION
Reflectometry server code previously expected boolean macro values, but they are actually strings. Recent fix to the server to reflect this broke the ioc tests, this change now should fix them.