### PR TITLE
add retry when stopping motors in refl tests

### DIFF
--- a/tests/refl.py
+++ b/tests/refl.py
@@ -403,7 +403,7 @@ class ReflTests(unittest.TestCase):
         value = value
 
         self.ca.set_pv_value("PARAM:{}:SP".format(param), value)
-        self.ca_cs.set_pv_value("MOT:STOP:ALL", 1)
+        stop_motors_with_retry(self.ca_cs, 5)
 
         self.ca.assert_that_pv_is("PARAM:{}:CHANGING".format(param), expected_value)
 
@@ -414,7 +414,7 @@ class ReflTests(unittest.TestCase):
         value = value
 
         self.ca.set_pv_value("PARAM:{}:SP".format(param), value)
-        self.ca_cs.set_pv_value("MOT:STOP:ALL", 1)
+        stop_motors_with_retry(self.ca_cs, 5)
 
         self.ca.assert_that_pv_is("PARAM:{}:RBV:AT_SP".format(param), expected_value)
 
@@ -425,7 +425,7 @@ class ReflTests(unittest.TestCase):
         value = value
 
         self.ca.set_pv_value("PARAM:{}:SP".format(param), value)
-        self.ca_cs.set_pv_value("MOT:STOP:ALL", 1)
+        stop_motors_with_retry(self.ca_cs, 5)
 
         self.ca.assert_that_pv_is("PARAM:{}:RBV:AT_SP".format(param), expected_value)
 

--- a/tests/refl.py
+++ b/tests/refl.py
@@ -142,7 +142,7 @@ def stop_motors_with_retry(channel_access, n_retry):
     """
     for _ in range(n_retry):
         channel_access.set_pv_value("MOT:STOP:ALL", 1, wait=True)
-        if channel_access.get_pv_value("MOT:MOVING") != 0.0:
+        if channel_access.get_pv_value("MOT:MOVING") == 0.0:
             break
         time.sleep(1)
     self.ca_cs.assert_that_pv_is("MOT:MOVING", 0, timeout=5)


### PR DESCRIPTION
`MOT:STOP:ALL` sometimes fails to stop all axes when on simulated motors. This PR adds a retry to try to make this less likely to break our tests.