### PR TITLE
Fix refl system tests

### DIFF
--- a/tests/refl.py
+++ b/tests/refl.py
@@ -145,7 +145,7 @@ def stop_motors_with_retry(channel_access, n_retry):
         if channel_access.get_pv_value("MOT:MOVING") == 0.0:
             break
         time.sleep(1)
-    self.ca_cs.assert_that_pv_is("MOT:MOVING", 0, timeout=5)
+    channel_access.assert_that_pv_is("MOT:MOVING", 0, timeout=5)
 
 
 class ReflTests(unittest.TestCase):


### PR DESCRIPTION
Silly copy paste error. Method should use channel access object passed to method