### PR TITLE
Refl init velocities

### DIFF
--- a/tests/refl.py
+++ b/tests/refl.py
@@ -55,11 +55,15 @@ IOCS = [
         },
         "inits": {
             "MTR0102.VMAX": INITIAL_VELOCITY,
+            "MTR0102.VELO": INITIAL_VELOCITY,
             "MTR0103.VMAX": MEDIUM_VELOCITY,  # Remove s4 as a speed limiting factor
             "MTR0103.VELO": MEDIUM_VELOCITY,  # Remove s4 as a speed limiting factor
             "MTR0104.VMAX": INITIAL_VELOCITY,
+            "MTR0104.VELO": INITIAL_VELOCITY,
             "MTR0105.VMAX": FAST_VELOCITY,  # Remove angle as a speed limiting factor
-            "MTR0107.VMAX": FAST_VELOCITY,
+            "MTR0105.VELO": FAST_VELOCITY,
+            "MTR0107.VMAX": FAST_VELOCITY,  # Speed up parking / unparking supermirror
+            "MTR0107.VELO": FAST_VELOCITY,
             "MTR0104.LLM": SOFT_LIMIT_LO,
             "MTR0104.HLM": SOFT_LIMIT_HI,
             "MTR0105.LLM": SOFT_LIMIT_LO,
@@ -750,6 +754,7 @@ class ReflTests(unittest.TestCase):
         self.ca.assert_that_pv_is(param_pv, "Test String")
 
     def test_GIVEN_PNR_mode_with_SM_angle_WHEN_move_in_disable_mode_and_into_PNR_THEN_beamline_is_updated_on_mode_change_and_value_of_pd_offsets_correct(self):
+        # input("hit it ...")
         self.ca.set_pv_value("BL:MODE:SP", "POLARISED")
         self.ca.set_pv_value("PARAM:SMANGLE:SP_NO_ACTION", 0.2)
         self.ca.set_pv_value("BL:MOVE", 1)

--- a/tests/refl.py
+++ b/tests/refl.py
@@ -754,7 +754,6 @@ class ReflTests(unittest.TestCase):
         self.ca.assert_that_pv_is(param_pv, "Test String")
 
     def test_GIVEN_PNR_mode_with_SM_angle_WHEN_move_in_disable_mode_and_into_PNR_THEN_beamline_is_updated_on_mode_change_and_value_of_pd_offsets_correct(self):
-        # input("hit it ...")
         self.ca.set_pv_value("BL:MODE:SP", "POLARISED")
         self.ca.set_pv_value("PARAM:SMANGLE:SP_NO_ACTION", 0.2)
         self.ca.set_pv_value("BL:MOVE", 1)


### PR DESCRIPTION
Ensure velocities set on simulated Galils for Reflectometry tests are consistent