### PR TITLE
Rename waveguide instance from comment with guides

### DIFF
--- a/tests/sans2d_apertures_guides.py
+++ b/tests/sans2d_apertures_guides.py
@@ -54,7 +54,7 @@ AXES_TO_STOP = ["APERTURE_{}".format(i) for i in range(1, 6)] + ["GUIDE_{}".form
 
 class Sans2dAperturesGuidesTests(unittest.TestCase):
     """
-    Tests for the sans2d waveguides and apertures tank motor extensions.
+    Tests for the sans2d guides and apertures tank motor extensions.
     """
 
     def setUp(self):


### PR DESCRIPTION
## Work Done

Rename references to "waveguides" in relation to SANS2D to "guides"

"Waveguides" is the incorrect term and should be referred to as "guides" going forward

### Issue
 - [6428](https://github.com/ISISComputingGroup/IBEX/issues/6428)

### Acceptance Criteria
- All references to "waveguides" have been renamed to "guides"
- Where instances of "waveguides" have been updated to "guides", corresponding unit tests where applicable pass.