### PR TITLE
sans2d fix test

### DIFF
--- a/tests/sans2d_vacuum_tank.py
+++ b/tests/sans2d_vacuum_tank.py
@@ -8,7 +8,6 @@ from parameterized import parameterized
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
 from utils.channel_access import ChannelAccess
-from utils.axis import set_axis_moving, assert_axis_moving, assert_axis_not_moving, stop_axis_moving
 from utils.testing import ManagerMode
 
 test_path = os.path.realpath(
@@ -74,18 +73,15 @@ class Sans2dVacTankTests(unittest.TestCase):
         self.upper_inhibit_bound = 2
 
     def set_axis_SPMG(self, axis, state):
-        self.ca.set_pv_value("{}:MTR.SPMG".format(axis), state)
+        self.ca.set_pv_value("{}:MTR.SPMG".format(axis), state, wait=True)
 
     def reset_axis_to_non_inhibit(self, axis):
-        self.set_axis_SPMG(axis, MOVE)
         self.ca.set_pv_value("{}:SP".format(axis), 0)
-
         self.ca.assert_that_pv_is_number(axis, 0, tolerance=1.9, timeout=10)
-        self.ca.set_pv_value("{}:MTR.STOP".format(axis), 1, wait=True)
 
     def reset_axes_to_non_inhibit(self, axis_one, axis_two):
-        axis_one_val = self.ca.get_pv_value(axis_one)
-        axis_two_val = self.ca.get_pv_value(axis_two)
+        axis_one_val = self.ca.get_pv_value("{}:SP".format(axis_one))
+        axis_two_val = self.ca.get_pv_value("{}:SP".format(axis_two))
         axis_one_inhibiting = axis_one_val < self.lower_inhibit_bound or axis_one_val > self.upper_inhibit_bound
         axis_two_inhibiting = axis_two_val < self.lower_inhibit_bound or axis_two_val > self.upper_inhibit_bound
         if axis_one_inhibiting and axis_two_inhibiting:
@@ -107,31 +103,18 @@ class Sans2dVacTankTests(unittest.TestCase):
             else:
                 raise err
 
-    @parameterized.expand(AXES_TO_STOP)
-    def test_GIVEN_axis_moving_WHEN_stop_all_THEN_axis_stopped_and_appropriate_axis_set_to_pause(self, axis):
-        for _ in range(3):
-            self.set_axis_SPMG(axis, GO)
-            set_axis_moving(axis)
-            assert_axis_moving(axis)
-            self.ca.set_pv_value("SANS2DVAC:STOP_MOTORS:ALL", 1)
-            if axis in AXES_FOR_CA:
-                self.ca.assert_that_pv_is("{}:MTR.SPMG".format(axis), "Pause")
-
-            assert_axis_not_moving(axis)
-        self.reset_axis_to_non_inhibit(axis)
 
     @parameterized.expand([("FRONTBEAMSTOP", "FRONTDETROT"), ("FRONTDETROT", "FRONTBEAMSTOP")])
     def test_GIVEN_axes_in_range_WHEN_axis_goes_out_of_range_THEN_other_axis_inhibited(self, inhibiting_axis, inhibited_axis):
         # Arrange
         self.reset_axes_to_non_inhibit(inhibited_axis, inhibiting_axis)
-        self.set_axis_SPMG(inhibiting_axis, GO)
         try:
             # Act
-            self.ca.set_pv_value("{}:SP".format(inhibiting_axis), -3, wait=True)
+            self.ca.set_pv_value("{}:SP".format(inhibiting_axis), -3)
             self.ca.assert_that_pv_is_number("{}:SP".format(inhibiting_axis), -3)
             start_position = self.ca.get_pv_value(inhibited_axis)
             with self.assertRaises(WriteAccessException, msg="DISP should be set on inhibited axis"):
-                set_axis_moving(inhibited_axis)
+                self.ca.set_pv_value("SANS2DVAC:MOVE_ALL.PROC", 1)
             # Assert
             self.ca.assert_that_pv_is("SANS2DVAC:INHIBIT_{}".format(inhibited_axis), 1)
             end_position = self.ca.get_pv_value(inhibited_axis)
@@ -139,4 +122,3 @@ class Sans2dVacTankTests(unittest.TestCase):
         finally:
             # Rearrange
             self.reset_axes_to_non_inhibit(inhibited_axis, inhibiting_axis)
-            self.ca.set_pv_value("{}:MTR.SPMG".format(inhibiting_axis), PAUSE)


### PR DESCRIPTION
test_GIVEN_axis_moving_WHEN_stop_all_THEN_axis_stopped removed as it is tested in test_GIVEN_some_axes_have_stopped_moving_THEN_stopped_axes_are_set_to_PAUSE.

components inside vacuum tank now does not move immediately and instead waits for move command, so changed the tests accordingly.