### PR TITLE
Added option to add delay after IOC startup

### DIFF
--- a/tests/refl.py
+++ b/tests/refl.py
@@ -70,7 +70,8 @@ IOCS = [
             "MTR0105.HLM": SOFT_LIMIT_HI,
             "MTR0107.ERES": 0.001,
             "MTR0107.MRES": 0.001,
-        }
+        },
+        "delay_after_startup": 5
     },
     {
         "name": GALIL_PREFIX_JAWS,
@@ -85,7 +86,8 @@ IOCS = [
         "inits": {
             "MTR0208.ERES": 0.001,
             "MTR0208.MRES": 0.001
-        }
+        },
+        "delay_after_startup": 5
     },
     {
         "name": "INSTETC",

--- a/utils/ioc_launcher.py
+++ b/utils/ioc_launcher.py
@@ -137,6 +137,7 @@ class BaseLauncher(object):
         self.emulator_port = int(self.macros['EMULATOR_PORT'])
         self._extra_environment_vars = ioc_config.get("environment_vars", {})
         self._init_values = ioc_config.get('inits', {})
+        self._delay_after_startup = ioc_config.get('delay_after_startup', 0)
         self._var_dir = var_dir
         self._test_name = test_name
         self.ca = None
@@ -193,6 +194,8 @@ class BaseLauncher(object):
                 self.ca.set_pv_value(key, value)
 
         IOCRegister.add_ioc(self._device, self)
+
+        sleep(self._delay_after_startup)
 
     def _command_line(self):
         """


### PR DESCRIPTION
One of the reflectometry tests is currently failing. I believe this is because the simulated Galils need a bit of extra time to properly initialise before starting to run the tests or else seem to fail to complete their moves. haven't been able to work out what exactly the underlying issue is, but this should fix the failing test at least. This should be good enough as I don't think this is an issue outside of the IOC tests.

Added a parameter to IOC launcher that lets you specify a delay duration to give IOCs a bit of extra time to start up.