### PR TITLE
Extend Eurotherm System Tests to Allow for Testing of up to Ten Channels

### DIFF
--- a/tests/eurotherm.py
+++ b/tests/eurotherm.py
@@ -10,7 +10,7 @@ from utils.ioc_launcher import get_default_ioc_dir, IOCRegister, EPICS_TOP, Proc
 from utils.calibration_utils import reset_calibration_file, use_calibration_file
 
 # Internal Address of device (must be 2 characters)
-ADDRESS = "A010"
+ADDRESS = "A01"
 # Numerical address of the device
 ADDR_1 = 1 # Leave this value as 1 when changing the ADDRESS value above - hard coded in LEWIS emulator
 DEVICE = "EUROTHRM_01"
@@ -27,7 +27,7 @@ IOCS = [
         "directory": get_default_ioc_dir("EUROTHRM"),
         "macros": {
             "ADDR": ADDRESS,
-            "ADDR_1": "",
+            "ADDR_1": ADDR_1,
             "ADDR_2": "",
             "ADDR_3": "",
             "ADDR_4": "",
@@ -36,7 +36,7 @@ IOCS = [
             "ADDR_7": "",
             "ADDR_8": "",
             "ADDR_9": "",
-            "ADDR_10": ADDR_1
+            "ADDR_10": ""
         },
         "emulator": EMULATOR_DEVICE,
         "ioc_launcher_class": ProcServLauncher,

--- a/tests/eurotherm.py
+++ b/tests/eurotherm.py
@@ -25,6 +25,7 @@ IOCS = [
     {
         "name": DEVICE,
         "directory": get_default_ioc_dir("EUROTHRM"),
+        "ioc_launcher_class": ProcServLauncher,
         "macros": {
             "ADDR": ADDRESS,
             "ADDR_1": ADDR_1,
@@ -39,7 +40,6 @@ IOCS = [
             "ADDR_10": ""
         },
         "emulator": EMULATOR_DEVICE,
-        "ioc_launcher_class": ProcServLauncher,
     },
 ]
 

--- a/tests/eurotherm.py
+++ b/tests/eurotherm.py
@@ -10,9 +10,9 @@ from utils.ioc_launcher import get_default_ioc_dir, IOCRegister, EPICS_TOP
 from utils.calibration_utils import reset_calibration_file, use_calibration_file
 
 # Internal Address of device (must be 2 characters)
-ADDRESS = "A01"
+ADDRESS = "A08"
 # Numerical address of the device
-ADDR_1 = 1
+ADDR_1 = 1 # Leave this value as 1 when changing the ADDRESS value above - hard coded in LEWIS emulator
 DEVICE = "EUROTHRM_01"
 PREFIX = "{}:{}".format(DEVICE, ADDRESS)
 
@@ -27,14 +27,14 @@ IOCS = [
         "directory": get_default_ioc_dir("EUROTHRM"),
         "macros": {
             "ADDR": ADDRESS,
-            "ADDR_1": ADDR_1,
+            "ADDR_1": "",
             "ADDR_2": "",
             "ADDR_3": "",
             "ADDR_4": "",
             "ADDR_5": "",
             "ADDR_6": "",
             "ADDR_7": "",
-            "ADDR_8": ""
+            "ADDR_8": ADDR_1
         },
         "emulator": EMULATOR_DEVICE,
     },

--- a/tests/eurotherm.py
+++ b/tests/eurotherm.py
@@ -6,11 +6,11 @@ import time
 from utils.channel_access import ChannelAccess
 from utils.test_modes import TestModes
 from utils.testing import get_running_lewis_and_ioc
-from utils.ioc_launcher import get_default_ioc_dir, IOCRegister, EPICS_TOP
+from utils.ioc_launcher import get_default_ioc_dir, IOCRegister, EPICS_TOP, ProcServLauncher
 from utils.calibration_utils import reset_calibration_file, use_calibration_file
 
 # Internal Address of device (must be 2 characters)
-ADDRESS = "A08"
+ADDRESS = "A010"
 # Numerical address of the device
 ADDR_1 = 1 # Leave this value as 1 when changing the ADDRESS value above - hard coded in LEWIS emulator
 DEVICE = "EUROTHRM_01"
@@ -34,9 +34,12 @@ IOCS = [
             "ADDR_5": "",
             "ADDR_6": "",
             "ADDR_7": "",
-            "ADDR_8": ADDR_1
+            "ADDR_8": "",
+            "ADDR_9": "",
+            "ADDR_10": ADDR_1
         },
         "emulator": EMULATOR_DEVICE,
+        "ioc_launcher_class": ProcServLauncher,
     },
 ]
 


### PR DESCRIPTION
# PR Justification
This PR was created as part of work described in [#7026](https://github.com/ISISComputingGroup/IBEX/issues/7026).

The changes extend the number of channels which can be tested for the [Eurotherm IOC](https://github.com/ISISComputingGroup/EPICS-ioc/tree/master/EUROTHRM).

For more information on the Eurotherm IOC, please see the [WIKI](https://github.com/ISISComputingGroup/IBEX/wiki/Eurotherms)

By default, the system tests will test channel one of the eurotherm. To test other channels, the address can be manually changed. Below is an example of the changes required to test channel ten:

```python
# Internal Address of device (must be 2 characters)
ADDRESS = "A010" # Change this to the channel you want to test
# Numerical address of the device
ADDR_1 = 1 # Leave this value as 1 when changing the ADDRESS value above - hard coded in LEWIS emulator
DEVICE = "EUROTHRM_01"
PREFIX = "{}:{}".format(DEVICE, ADDRESS)

# PV names
RBV_PV = "RBV"

EMULATOR_DEVICE = "eurotherm"

IOCS = [
    {
        "name": DEVICE,
        "directory": get_default_ioc_dir("EUROTHRM"),
        "ioc_launcher_class": ProcServLauncher,
        "macros": {
            "ADDR": ADDRESS,
            "ADDR_1": "",
            "ADDR_2": "",
            "ADDR_3": "",
            "ADDR_4": "",
            "ADDR_5": "",
            "ADDR_6": "",
            "ADDR_7": "",
            "ADDR_8": "",
            "ADDR_9": "",
            "ADDR_10": ADDR_1 # Move ADDR_1 to the address you want to test
        },
        "emulator": EMULATOR_DEVICE,
    },
]
```
There are plans to create system tests which will test all channels automatically without the need to manually change the address parameters. Because of the complexity of doing this, the work has been placed into a separate issue which can be found [HERE](https://github.com/ISISComputingGroup/IBEX/issues/7055)

## Testing Instructions
- Please follow testing instructions in [#7026](https://github.com/ISISComputingGroup/IBEX/issues/7026).