### PR TITLE
Better error reporting

### DIFF
--- a/utils/emulator_launcher.py
+++ b/utils/emulator_launcher.py
@@ -513,6 +513,11 @@ class LewisLauncher(EmulatorLauncher):
                 print("Lewis backdoor command {1} did not finish!")
                 self._logFile.write("Lewis backdoor command {1} did not finish!")
                 self._logFile.flush()
+
+            for line in p.stdout:
+                if b"failed to create process" in line.lower():
+                    raise IOError(f"Failed to spawn lewis-control.exe for backdoor set {lewis_command}.")
+
             return [line.strip() for line in p.stdout]
         except subprocess.CalledProcessError as ex:
             for loc in [sys.stderr, self._logFile]:

--- a/utils/emulator_launcher.py
+++ b/utils/emulator_launcher.py
@@ -510,8 +510,8 @@ class LewisLauncher(EmulatorLauncher):
                 sleep(0.1)
             else:
                 p.terminate()
-                print("Lewis backdoor command {1} did not finish!")
-                self._logFile.write("Lewis backdoor command {1} did not finish!")
+                print(f"Lewis backdoor command {lewis_command_line} did not finish!")
+                self._logFile.write(f"Lewis backdoor command {lewis_command_line} did not finish!")
                 self._logFile.flush()
 
             for line in p.stdout:
@@ -521,8 +521,8 @@ class LewisLauncher(EmulatorLauncher):
             return [line.strip() for line in p.stdout]
         except subprocess.CalledProcessError as ex:
             for loc in [sys.stderr, self._logFile]:
-                loc.write("Error using backdoor: {0}\n".format(ex.output))
-                loc.write("Error code {0}\n".format(ex.returncode))
+                loc.write(f"Error using backdoor: {ex.output}\n")
+                loc.write(f"Error code {ex.returncode}\n")
             self._logFile.flush()
             raise ex
 

--- a/utils/emulator_launcher.py
+++ b/utils/emulator_launcher.py
@@ -510,11 +510,15 @@ class LewisLauncher(EmulatorLauncher):
                 sleep(0.1)
             else:
                 p.terminate()
-                print("Lewis backdoor did not finish!")
+                print("Lewis backdoor command {1} did not finish!")
+                self._logFile.write("Lewis backdoor command {1} did not finish!")
+                self._logFile.flush()
             return [line.strip() for line in p.stdout]
         except subprocess.CalledProcessError as ex:
-            sys.stderr.write("Error using backdoor: {0}\n".format(ex.output))
-            sys.stderr.write("Error code {0}\n".format(ex.returncode))
+            for loc in [sys.stderr, self._logFile]:
+                loc.write("Error using backdoor: {0}\n".format(ex.output))
+                loc.write("Error code {0}\n".format(ex.returncode))
+            self._logFile.flush()
             raise ex
 
     def backdoor_emulator_disconnect_device(self):


### PR DESCRIPTION
Report lewis errors more thoroughly (to the log as well as `stderr`)

The "failed to create process" error can be caused when python is moved after being installed. Annoylngly it still returns success in this case so we have to parse the stdout for the `failed to create process` line.