### PR TITLE
Rework test to cover SP behaviour

### DIFF
--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -66,9 +66,7 @@ class Tpg300Tests(unittest.TestCase):
         for unit in Units:
             expected_unit = unit.name
             self.ca.set_pv_value("UNITS:SP", expected_unit)
-            device_unit_val = int(self._lewis.backdoor_run_function_on_device("backdoor_get_unit")[0])
-
-            self.assertEqual(device_unit_val, unit.value)
+            self._lewis.assert_that_emulator_value_is("backdoor_get_unit", str(unit.value))
             self.ca.assert_that_pv_is("UNITS:SP", expected_unit)
             self.ca.assert_that_pv_is("UNITS", expected_unit)
 

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -52,10 +52,6 @@ class Tpg300Tests(unittest.TestCase):
         self._lewis.backdoor_set_on_device(prop, expected_pressure)
         self._ioc.set_simulated_value(pv, expected_pressure)
 
-    def _set_units(self, unit):
-        self._lewis.backdoor_run_function_on_device("backdoor_set_unit", [unit.value])
-        self.ca.set_pv_value("SIM:UNITS", unit.name)
-
     def _connect_emulator(self):
         self._lewis.backdoor_run_function_on_device("connect")
 
@@ -68,9 +64,12 @@ class Tpg300Tests(unittest.TestCase):
     @skip_if_recsim("Requires emulator")
     def test_that_GIVEN_a_connected_emulator_WHEN_units_are_set_THEN_unit_is_the_same_as_backdoor(self):
         for unit in Units:
-            self._set_units(unit)
-
             expected_unit = unit.name
+            self.ca.set_pv_value("UNITS:SP", expected_unit)
+            device_unit_val = int(self._lewis.backdoor_run_function_on_device("backdoor_get_unit")[0])
+
+            self.assertEqual(device_unit_val, unit.value)
+            self.ca.assert_that_pv_is("UNITS:SP", expected_unit)
             self.ca.assert_that_pv_is("UNITS", expected_unit)
 
     def test_that_GIVEN_a_connected_emulator_and_pressure_value_WHEN_set_pressure_is_set_THEN_the_ioc_is_updated(self):


### PR DESCRIPTION
Small change to a test for unit setting behaviour. Old test made no use of UNIT:SP, instead just setting this by the backdoor and ensuring UNIT read back correctly. This meant that an issue with UNIT:SP was not detected until hardware testing. The new test sets the Value using the SP, then ensures that the values on the emulator, UNIT and UNIT:SP all match nicely.

## Ticket
[Ticket 7255 - TPG300: fix and re-test switching functions on hardware](https://github.com/ISISComputingGroup/IBEX/issues/7255)

## Acceptance Criteria
- [ ] The code is of an acceptable quality
- [ ] In conjunction with the emulator changes, the required behaviour is tested by this test (fails on master, passes on 7255 branch)