### PR TITLE
Test Tektronix afg3xxx When SCAN Macro in Passive Mode

### DIFF
--- a/tests/tekafg3XXX.py
+++ b/tests/tekafg3XXX.py
@@ -28,7 +28,7 @@ class Tekafg3XXXTests(unittest.TestCase):
     """
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("tekafg3XXX", DEVICE_PREFIX)
-        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX, default_wait_time=0.0)
+        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX, default_wait_time=0.0, default_timeout=10)
         self._lewis.backdoor_set_on_device('connected', True)
 
     def test_GIVEN_nothing_WHEN_get_identity_THEN_identity_returned(self):
@@ -42,9 +42,9 @@ class Tekafg3XXXTests(unittest.TestCase):
         self._lewis.assert_that_emulator_value_is("triggered", 'True')
 
     def _assert_rbv_set(self, pv_name, expected_value):
-        with self.ca.assert_that_pv_monitor_is(f"OUTPUT1:{pv_name}:SP:RBV", expected_value), \
-        self.ca.assert_that_pv_monitor_is(f"OUTPUT1:{pv_name}", expected_value) :
-            self.ca.set_pv_value(f"OUTPUT1:{pv_name}:SP", str(expected_value))
+        self.ca.set_pv_value(f"OUTPUT1:{pv_name}:SP", str(expected_value))
+        self.ca.assert_that_pv_is(f"OUTPUT1:{pv_name}", expected_value)
+        self.ca.assert_that_pv_is(f"OUTPUT1:{pv_name}:SP:RBV", expected_value)
 
     def test_GIVEN_scan_macro_set_passive_WHEN_sp_changed_THEN_sp_rbv_changed(self):
         self._assert_rbv_set("FUNC", "RAMP")

--- a/tests/tekafg3XXX.py
+++ b/tests/tekafg3XXX.py
@@ -11,7 +11,9 @@ IOCS = [
     {
         "name": DEVICE_PREFIX,
         "directory": get_default_ioc_dir("TEKAFG3XXX"),
-        "macros": {},
+        "macros": {
+            "SCAN" : "Passive"
+        },
         "emulator": "tekafg3XXX",
     },
 ]
@@ -38,3 +40,32 @@ class Tekafg3XXXTests(unittest.TestCase):
         self._lewis.backdoor_set_and_assert_set("triggered", 'False')
         self.ca.set_pv_value("TRIGGER", True)
         self._lewis.assert_that_emulator_value_is("triggered", 'True')
+
+    def _assert_rbv_set(self, pv_name, expected_value):
+        with self.ca.assert_that_pv_monitor_is(f"OUTPUT1:{pv_name}:SP:RBV", expected_value), \
+        self.ca.assert_that_pv_monitor_is(f"OUTPUT1:{pv_name}", expected_value) :
+            self.ca.set_pv_value(f"OUTPUT1:{pv_name}:SP", str(expected_value))
+
+    def test_GIVEN_scan_macro_set_passive_WHEN_sp_changed_THEN_sp_rbv_changed(self):
+        self._assert_rbv_set("FUNC", "RAMP")
+        self._assert_rbv_set("IMPEDANCE", 4.0)
+        self._assert_rbv_set("POLARITY", "INV")
+        self._assert_rbv_set("VOLT", 10.0)
+        self._assert_rbv_set("VOLT:UNITS", "VRMS")
+        self._assert_rbv_set("VOLT:LOWLIMIT", 1.0)
+        self._assert_rbv_set("VOLT:HIGHLIMIT", 3.0)
+        self._assert_rbv_set("VOLT:LOW", 2.0)
+        self._assert_rbv_set("VOLT:HIGH", 1.5)
+        self._assert_rbv_set("VOLT:OFFSET", 10)
+        self._assert_rbv_set("FREQ", 5.0)
+        self._assert_rbv_set("PHASE", 4)
+        self._assert_rbv_set("BURST_STATUS", "OFF")
+        self._assert_rbv_set("BURST_MODE", "GAT")
+        self._assert_rbv_set("BURST_NCYCLES", 40)
+        self._assert_rbv_set("BURST_TDELAY", 9)
+        self._assert_rbv_set("FREQ_MODE", "SWE")
+        self._assert_rbv_set("SWEEP_SPAN", 30)
+        self._assert_rbv_set("SWEEP_START", 20)
+        self._assert_rbv_set("SWEEP_STOP", 40)
+        self._assert_rbv_set("SWEEP_HTIME", 1)
+        self._assert_rbv_set("SWEEP_MODE", "AUTO")


### PR DESCRIPTION
Added a test for the PVs with a scan set by macro to ensure that they update their RBVs when in passive mode.

Partially Resolves ISISComputingGroup/IBEX#7352