### PR TITLE
Ticket #7385: Add arch. skip mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ AttributeError: 'obj' object has no attribute '__name__'
 
 This can be avoided by calling the decorator like ` @skip_if_recsim("In rec sim this test fails") `
 
-### ### Avoiding tests affecting other tests
+### Avoiding tests affecting other tests
 
 * When run by the IOC test framework, the IOC + emulator state persists between tests
 * For simple tests/emulators this is not typically an issue, but for complex emulators this can cause tests to pass when run on their own but fail when run as part of a suite, or fail intermittently. This can be very hard to debug!

--- a/run_tests.py
+++ b/run_tests.py
@@ -237,7 +237,7 @@ def get_build_architecture():
     Utility function to get the architecture of the current build 
 
     Returns:
-        string: Architecture of the current build (e.g., "x64" or "x86")
+        BuildArchitectures: Architecture of the current build (e.g., "x64" or "x86")
     """
 
     with open(r'..\\..\\..\\epics_host_arch.txt', 'r') as build_arch:

--- a/run_tests.py
+++ b/run_tests.py
@@ -155,6 +155,9 @@ def load_and_run_tests(test_names, failfast, report_coverage, ask_before_running
 
     test_results = []
 
+    arch = get_build_architecture()
+    print("Running tests for arch {}".format(arch.name))
+
     for mode in modes:
         if tests_mode is not None and mode != tests_mode:
             continue
@@ -163,9 +166,8 @@ def load_and_run_tests(test_names, failfast, report_coverage, ask_before_running
 
         for module in modules_to_be_tested_in_current_mode:
             # Skip tests that cannot be run with a 32-bit architecture
-            arch = get_build_architecture()
             if arch not in module.architectures:
-                print(f"Skipped module tests.{module.name} in {TestModes.name(mode)}: suite not available with a {BuildArchitectures.name(arch)} build architecture")
+                print(f"Skipped module tests.{module.name} in {TestModes.name(mode)}: suite not available with a {BuildArchitectures.archname(arch)} build architecture")
                 continue
 
             clean_environment()

--- a/run_tests.py
+++ b/run_tests.py
@@ -161,6 +161,12 @@ def load_and_run_tests(test_names, failfast, report_coverage, ask_before_running
         modules_to_be_tested_in_current_mode = [module for module in modules_to_be_tested if mode in module.modes]
 
         for module in modules_to_be_tested_in_current_mode:
+            # Skip tests that cannot be run with a 32-bit architecture
+            arch = get_build_architecture()
+            if arch not in module.architectures:
+                print(f"Skipped module tests.{module.name} in {TestModes.name(mode)}: suite not available with a {BuildArchitectures.name(arch)} build architecture")
+                continue
+
             clean_environment()
             device_launchers, device_directories = make_device_launchers_from_module(module.file, mode)
             tested_ioc_directories.update(device_directories)
@@ -225,6 +231,23 @@ def report_test_coverage_for_devices(tested_directories):
     for test in missing_tests:
         print(test)
 
+def get_build_architecture():
+    """
+    Utility function to get the architecture of the current build 
+
+    Returns:
+        string: Architecture of the current build (e.g., "x64" or "x86")
+    """
+
+    with open(r'..\\..\\..\\epics_host_arch.txt', 'r') as build_arch:
+        content = build_arch.read()
+
+        if 'x86' in content:
+            return BuildArchitectures._32BIT
+        elif 'x64' in content:
+            return BuildArchitectures._64BIT
+        else:
+            return ''
 
 class ReportFailLoadTestsuiteTestCase(unittest.TestCase):
     """

--- a/run_tests.py
+++ b/run_tests.py
@@ -240,7 +240,7 @@ def get_build_architecture():
         BuildArchitectures: Architecture of the current build (e.g., "x64" or "x86")
     """
 
-    with open(r'..\\..\\..\\epics_host_arch.txt', 'r') as build_arch:
+    with open('../../../epics_host_arch.txt', 'r') as build_arch:
         content = build_arch.read()
 
         if 'x86' in content:

--- a/run_tests.py
+++ b/run_tests.py
@@ -23,6 +23,7 @@ from utils.emulator_launcher import LewisLauncher, NullEmulatorLauncher, MultiLe
 from utils.ioc_launcher import IocLauncher, EPICS_TOP, IOCS_DIR
 from utils.free_ports import get_free_ports
 from utils.test_modes import TestModes
+from utils.build_architectures import BuildArchitectures
 
 
 def clean_environment():

--- a/run_utils.py
+++ b/run_utils.py
@@ -100,3 +100,18 @@ def check_test_modes(module):
     return modes
 
 
+def check_build_architectures(module):
+    """
+    Checks for which build architectures the test can run in.
+    If not specified, default to both 64 and 32 bit allowed.
+
+    :param module: Module to check which architectures the test can run in
+    :return: set: Architectures the test can be run in
+    """
+    try:
+        architectures = set(module.BUILD_ARCHITECTURES)
+    except AttributeError:
+        architectures = set([BuildArchitectures._64BIT, BuildArchitectures._32BIT])
+
+    return architectures
+

--- a/run_utils.py
+++ b/run_utils.py
@@ -2,6 +2,7 @@ import importlib
 import os
 from contextlib import contextmanager
 
+from utils.build_architectures import BuildArchitectures
 
 def package_contents(package_path):
     """
@@ -49,6 +50,7 @@ class ModuleTests(object):
         self.tests = None
         self.__file = self.__get_file_reference()
         self.__modes = self.__get_modes()
+        self.__architectures = self.__get_architectures()
 
     @property
     def name(self):
@@ -65,6 +67,11 @@ class ModuleTests(object):
         """ Returns a reference to the module file. """
         return self.__file
 
+    @property
+    def architectures(self):
+        """ Returns the architectures the test can be run in. """
+        return self.__architectures
+
     def __get_file_reference(self):
         module = load_module("tests.{}".format(self.__name))
         return module
@@ -73,6 +80,11 @@ class ModuleTests(object):
         if not self.__file:
             self.__get_file_reference()
         return check_test_modes(self.__file)
+    
+    def __get_architectures(self):
+        if not self.__file:
+            self.__get_file_reference()
+        return check_build_architectures(self.__file)
 
 
 def load_module(name):

--- a/tests/astrium.py
+++ b/tests/astrium.py
@@ -2,6 +2,7 @@ import unittest
 from parameterized import parameterized
 
 from utils.test_modes import TestModes
+from utils.build_architectures import BuildArchitectures
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.testing import skip_if_recsim, skip_if_devsim, parameterized_list
@@ -25,6 +26,7 @@ VALID_PHASE_DELAYS = [0.0, 0.01, 123.45, 999.99]
 
 # Devsim for this device is not a usual lewis emulator but puts the actual IOC into a sort of simulation mode.
 TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
+BUILD_ARCHITECTURES = [BuildArchitectures._64BIT]
 
 
 class AstriumTests(unittest.TestCase):

--- a/tests/fermichopper_maps.py
+++ b/tests/fermichopper_maps.py
@@ -1,5 +1,6 @@
 import unittest
 from utils.test_modes import TestModes
+from utils.build_architectures import BuildArchitectures
 from utils.ioc_launcher import get_default_ioc_dir
 from common_tests.fermichopper import FermichopperBase
 
@@ -22,6 +23,8 @@ IOCS = [
 
 
 TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
+# VISA not yet available on 32 bit
+BUILD_ARCHITECTURES = [BuildArchitectures._64BIT]
 
 
 class MapsFermiChopperTests(FermichopperBase, unittest.TestCase):

--- a/tests/fermichopper_merlin.py
+++ b/tests/fermichopper_merlin.py
@@ -1,5 +1,6 @@
 import unittest
 from utils.test_modes import TestModes
+from utils.build_architectures import BuildArchitectures
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.testing import skip_if_recsim, assert_log_messages
 from common_tests.fermichopper import FermichopperBase, ErrorStrings
@@ -22,6 +23,8 @@ IOCS = [
 
 
 TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
+# VISA not yet available on 32 bit
+BUILD_ARCHITECTURES = [BuildArchitectures._64BIT]
 
 
 class MerlinFermiChopperTests(FermichopperBase, unittest.TestCase):

--- a/tests/instron_stress_rig.py
+++ b/tests/instron_stress_rig.py
@@ -3,6 +3,7 @@ import unittest
 from common_tests.instron_base import InstronBase
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
+from utils.build_architectures import BuildArchitectures
 
 # Device prefix
 from utils.testing import skip_if_recsim
@@ -19,6 +20,8 @@ IOCS = [
 ]
 
 TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
+# VISA not yet available on 32 bit
+BUILD_ARCHITECTURES = [BuildArchitectures._64BIT]
 
 
 class InstronTests(InstronBase, unittest.TestCase):

--- a/tests/keithley_2001.py
+++ b/tests/keithley_2001.py
@@ -5,6 +5,7 @@ import unittest
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir, IOCRegister
 from utils.test_modes import TestModes
+from utils.build_architectures import BuildArchitectures
 from utils.testing import get_running_lewis_and_ioc, add_method, parameterized_list, skip_if_recsim
 
 
@@ -23,6 +24,8 @@ IOCS = [
 ]
 
 TEST_MODES = [TestModes.DEVSIM, TestModes.RECSIM]
+# VISA not yet available on 32 bit
+BUILD_ARCHITECTURES = [BuildArchitectures._64BIT]
 
 MAX_NUMBER_OF_CHANNELS = 10
 CHANNEL_LIST = range(1, MAX_NUMBER_OF_CHANNELS + 1)

--- a/tests/mk3chopper.py
+++ b/tests/mk3chopper.py
@@ -3,6 +3,7 @@ import unittest
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import IOCRegister, get_default_ioc_dir
 from utils.test_modes import TestModes
+from utils.build_architectures import BuildArchitectures
 from utils.testing import skip_if_devsim
 
 DEVICE_PREFIX = "MK3CHOPR_01"
@@ -19,7 +20,8 @@ IOCS = [
 
 
 TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
-
+# VISA not yet available on 32 bit
+BUILD_ARCHITECTURES = [BuildArchitectures._64BIT]
 
 class Mk3chopperTests(unittest.TestCase):
 

--- a/tests/sans2d_vacuum.py
+++ b/tests/sans2d_vacuum.py
@@ -6,6 +6,7 @@ from utils.ioc_launcher import IOCRegister, get_default_ioc_dir, EPICS_TOP
 from parameterized import parameterized
 
 from utils.test_modes import TestModes
+from utils.build_architectures import BuildArchitectures
 from utils.testing import parameterized_list
 
 IOCS = [
@@ -33,6 +34,7 @@ IOCS = [
 
 
 TEST_MODES = [TestModes.RECSIM]
+BUILD_ARCHITECTURES = [BuildArchitectures._64BIT]
 
 
 class Sans2dVacuumSystemTests(unittest.TestCase):

--- a/utils/build_architectures.py
+++ b/utils/build_architectures.py
@@ -1,0 +1,26 @@
+"""
+Possible build configs
+"""
+from enum import Enum
+
+
+class BuildArchitectures(Enum):
+    """
+    Build configuration types with which a set of unit tests can be run.
+    """
+    _64BIT = 1
+    _32BIT = 2
+
+    @staticmethod
+    def name(arch):
+        """
+        Returns: nice name of architecture
+        """
+        if arch == BuildArchitectures._64BIT:
+            return "64 bit"
+        elif arch == BuildArchitectures._32BIT:
+            return "32 bit"
+        elif arch is None:
+            return "test build archs not set!!!!"
+        else:
+            return "Unknown"

--- a/utils/build_architectures.py
+++ b/utils/build_architectures.py
@@ -12,7 +12,7 @@ class BuildArchitectures(Enum):
     _32BIT = 2
 
     @staticmethod
-    def name(arch):
+    def archname(arch):
         """
         Returns: nice name of architecture
         """


### PR DESCRIPTION
[Ticket #7385](https://github.com/ISISComputingGroup/IBEX/issues/7385)

- Added mechanism to skip certain suites on 32-bit builds. 
- Added this skip on tests which are not suitable to be run on 32-bit build.
- Updated README with appropriate documentation (my editor has rather audaciously taken it upon itself to fix all the spaces in the file, which is why there's so many menial changes. My actual edit begins on line 205)