### PR TITLE
Reset emultor to send good ID at test end

### DIFF
--- a/tests/skf_g5_chopper.py
+++ b/tests/skf_g5_chopper.py
@@ -38,14 +38,18 @@ class SkfG5ChopperTests(unittest.TestCase):
         self._lewis, self._ioc = get_running_lewis_and_ioc(DEVICE_NAME, DEVICE_PREFIX)
         self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX)
 
-    @unstable_test(max_retries=5, wait_between_runs=10)
+    # sending invalid transaction ids can cause lots of ioc timeouts and can cause a big buildup
+    # of pending reads in the ioc if it is expecting valid ones. So make sure we reset emulator to 
+    # an OK state at end of test so when ioc restarts for next test it doesn't get stuck
+    def tearDown(self):
+        self._lewis.backdoor_set_on_device("send_ok_transid", True)
+
     def test_GIVEN_correct_transaction_id_WHEN_not_skipping_THEN_state_correct(self):
         self._lewis.backdoor_set_on_device("send_ok_transid", True)
         expected = 56
         self._lewis.backdoor_set_on_device("freq", expected)
-        self.ca.assert_that_pv_is("FREQ", expected, timeout=5)
+        self.ca.assert_that_pv_is("FREQ", expected, timeout=15)
 
-    @unstable_test(max_retries=5, wait_between_runs=10)
     def test_GIVEN_incorrect_transaction_id_WHEN_not_skipping_THEN_state_incorrect(self):
         self._lewis.backdoor_set_on_device("send_ok_transid", False)
         initial = self.ca.get_pv_value("FREQ")
@@ -55,11 +59,11 @@ class SkfG5ChopperTests(unittest.TestCase):
         self.ca.assert_that_pv_is("FREQ", initial, timeout=5)
     
     @parameterized.expand([True, False])
-    @unstable_test(max_retries=5, wait_between_runs=10)
     def test_GIVEN_incorrect_transaction_id_WHEN_skipping_check_THEN_state_correct(self, send_correct_transaction_id):
         self._lewis.backdoor_set_on_device("send_ok_transid", send_correct_transaction_id)
         with self._ioc.start_with_macros({"SKIP_TRANSACTION_ID": 1, "NAME": "TEST_CHOPPER", "OPEN": OPEN, "CLOSED": CLOSED,}, pv_to_wait_for=PV_TO_WAIT_FOR):
             expected = 12
+            self.ca.assert_that_pv_is_not("FREQ", expected, timeout=5)
             self._lewis.backdoor_set_on_device("freq", expected)
-            self.ca.assert_that_pv_is("FREQ", expected, timeout=5)
-
+            self.ca.assert_that_pv_is("FREQ", expected, timeout=30)
+            self._lewis.backdoor_set_on_device("freq", expected + 1) # so not remembered in emulator for next test


### PR DESCRIPTION
Reset sending transaction id to good at test end, otherwise when IOC next starts it can get a queue of timing out requests 