### PR TITLE
Refactor and generalise TPG300 IOC tests

### DIFF
--- a/common_tests/tpgx00.py
+++ b/common_tests/tpgx00.py
@@ -1,0 +1,163 @@
+import unittest
+import contextlib
+import abc
+
+from parameterized import parameterized
+
+from utils.channel_access import ChannelAccess
+from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
+from itertools import product
+
+CHANNELS = "A1", "A2", "B1", "B2"
+TEST_PRESSURES = 1.23, -10.23, 8, 1e-6, 1e+6
+
+
+class Tpgx00Base(unittest.TestCase):
+    """
+    Tests for the TPG300.
+    """
+    @abc.abstractmethod
+    def get_prefix(self):
+        pass
+
+    @abc.abstractmethod
+    def get_units(self):
+        pass
+
+    def setUp(self):
+        print(f"\nprefix: {self.get_prefix()}")
+        self._lewis, self._ioc = get_running_lewis_and_ioc("tpg300", self.get_prefix())
+        self.ca = ChannelAccess(20, device_prefix=self.get_prefix(), default_wait_time=0.0)
+
+    def tearDown(self):
+        self._connect_emulator()
+
+    def _set_pressure(self, expected_pressure, channel):
+        prop = "pressure_{}".format(channel.lower())
+        pv = "SIM:PRESSURE"
+        self._lewis.backdoor_set_on_device(prop, expected_pressure)
+        self._ioc.set_simulated_value(pv, expected_pressure)
+
+    def _connect_emulator(self):
+        self._lewis.backdoor_run_function_on_device("connect")
+
+    def _disconnect_emulator(self):
+        self._lewis.backdoor_run_function_on_device("disconnect")
+
+    def test_that_GIVEN_a_connected_emulator_WHEN_ioc_started_THEN_ioc_is_not_disabled(self):
+        self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")
+
+    @skip_if_recsim("Requires emulator")
+    def test_that_GIVEN_a_connected_emulator_WHEN_units_are_set_THEN_unit_is_the_same_as_backdoor(self):
+        for unit in self.get_units():
+            expected_unit = unit.name
+            self.ca.set_pv_value("UNITS:SP", expected_unit)
+            self._lewis.assert_that_emulator_value_is("backdoor_get_unit", str(unit.value))
+            self.ca.assert_that_pv_is("UNITS:SP", expected_unit)
+            self.ca.assert_that_pv_is("UNITS", expected_unit)
+
+    def test_that_GIVEN_a_connected_emulator_and_pressure_value_WHEN_set_pressure_is_set_THEN_the_ioc_is_updated(self):
+        for expected_pressure, channel in product(TEST_PRESSURES, CHANNELS):
+            pv = "PRESSURE_{}".format(channel)
+            self._set_pressure(expected_pressure, channel)
+            self.ca.assert_that_pv_is(pv, expected_pressure)
+
+    @skip_if_recsim("Recsim is unable to simulate a disconnected device")
+    def test_that_GIVEN_a_disconnected_emulator_WHEN_getting_pressure_THEN_INVALID_alarm_shows(self):
+        self._disconnect_emulator()
+
+        for channel in CHANNELS:
+            pv = "PRESSURE_{}".format(channel)
+            self.ca.assert_that_pv_alarm_is(pv, self.ca.Alarms.INVALID)
+
+    def set_switching_function(self, function):
+        self.ca.set_pv_value("FUNCTION", function)
+
+    def set_switching_function_thresholds(self, threshold_low, threshold_high, circuit_assignment):
+        self.ca.set_pv_value("FUNCTION:LOW:SP", threshold_low)
+        self.ca.set_pv_value("FUNCTION:HIGH:SP", threshold_high)
+        self.ca.set_pv_value("FUNCTION:ASSIGN:SP", circuit_assignment)
+        self.ca.process_pv("FUNCTION:ASSIGN:SP:OUT")
+
+    def check_switching_function_thresholds(self, function, thresholds, check_pv_is=True):
+        assignments = ("No assignment", "A1", "A2", "B1", "B1", "A1 self-monitor", "A2 self-monitor", "B1 self-monitor", "B1 self-monitor")
+        if check_pv_is:
+            assignment = assignments[thresholds[2]]
+            self.ca.assert_that_pv_is_number("FUNCTION:" + function + ":LOW:SP:RBV", thresholds[0], 0.001)
+            self.ca.assert_that_pv_is_number("FUNCTION:" + function + ":HIGH:SP:RBV", thresholds[1], 0.001)
+            self.ca.assert_that_pv_is("FUNCTION:" + function + ":ASSIGN:SP:RBV", assignment)
+
+    @parameterized.expand([
+        (('2', 0.5E2, 1.7E-5, 2), (0.5E2, 1.7E-5, 2)),
+        (('A', 0.5534E55, 1.25E-5, 6), (5.5E54, 1.25E-5, 6)),
+        (('B', 12E-215, 0.0, 3), (9.9E-99, 0.0, 3))
+    ])
+    @skip_if_recsim("Requires emulator")
+    def test_GIVEN_function_thresholds_set_THEN_thresholds_readback_correct(self, function_set, function_read):
+        self.set_switching_function("1")
+        self.set_switching_function_thresholds(0.0, 0.0, 1)
+        self.set_switching_function(function_set[0])
+        self.set_switching_function_thresholds(function_set[1], function_set[2], function_set[3])
+        self.check_switching_function_thresholds(str(function_set[0]), function_read)
+        self.set_switching_function("1")
+        self.check_switching_function_thresholds("1", (0.0, 0.0, 1))
+
+    def check_switching_function_statuses(self, expected_statuses):
+        self.ca.assert_that_pv_is("FUNCTION:STATUS:1:RB", str(expected_statuses[0]))
+        self.ca.assert_that_pv_is("FUNCTION:STATUS:2:RB", str(expected_statuses[1]))
+        self.ca.assert_that_pv_is("FUNCTION:STATUS:3:RB", str(expected_statuses[2]))
+        self.ca.assert_that_pv_is("FUNCTION:STATUS:4:RB", str(expected_statuses[3]))
+
+    @skip_if_recsim("Requires emulator")
+    def test_GIVEN_function_status_set_THEN_readback_correct(self):
+        function_statuses = [0, 0, 1, 1, 0, 1]
+        self._lewis.backdoor_run_function_on_device("backdoor_set_switching_function_status", [function_statuses])
+        self.check_switching_function_statuses(function_statuses)
+
+    @skip_if_recsim("Requires emulator")
+    def test_GIVEN_thresholds_settings_and_pressure_above_THEN_check_if_violation_detected(self):
+        self._set_pressure(0, "A2")
+        self.set_switching_function("3")
+        self.set_switching_function_thresholds(5E2, 7.5E4, 2)
+        self.ca.assert_that_pv_is("FUNCTION:3:THRESHOLD:BELOW", 1)
+        self._set_pressure(6.43, "A2")
+        self.ca.assert_that_pv_is("FUNCTION:3:THRESHOLD:BELOW", 1)
+        self._set_pressure(501.0, "A2")
+        self.ca.assert_that_pv_is("FUNCTION:3:THRESHOLD:BELOW", 0)
+
+    @contextlib.contextmanager
+    def _disconnect_device(self):
+        self._disconnect_emulator()
+        try:
+            yield
+        finally:
+            self._connect_emulator()
+
+    def check_alarm_status_rbvs(self, alarm):
+        for channel in ("SEL", "1", "2", "3", "4", "A", "B"):
+            self.ca.assert_that_pv_alarm_is("FUNCTION:" + channel + ":RB", alarm)
+            self.ca.assert_that_pv_alarm_is("FUNCTION:" + channel + ":LOW:SP:RBV", alarm)
+            self.ca.assert_that_pv_alarm_is("FUNCTION:" + channel + ":HIGH:SP:RBV", alarm)
+            self.ca.assert_that_pv_alarm_is("FUNCTION:" + channel + ":ASSIGN:SP:RBV", alarm)
+
+    def check_alarm_status_function_statuses(self, alarm):
+        self.ca.assert_that_pv_alarm_is("FUNCTION:STATUS:RB", alarm)
+        for channel in ("1", "2", "3", "4"):
+            self.ca.assert_that_pv_alarm_is("FUNCTION:STATUS:" + channel + ":RB", alarm)
+
+
+    @skip_if_recsim("Requires emulator")
+    def test_WHEN_device_disconnected_THEN_rbv_values_go_into_alarm(self):
+        self.check_alarm_status_rbvs(self.ca.Alarms.NONE)
+        with self._disconnect_device():
+            self.check_alarm_status_rbvs(self.ca.Alarms.INVALID)
+
+        self.check_alarm_status_rbvs(self.ca.Alarms.NONE)
+
+    @skip_if_recsim("Requires emulator")
+    def test_WHEN_device_disconnected_THEN_function_statuses_go_into_alarm(self):
+        self.check_alarm_status_function_statuses(self.ca.Alarms.NONE)
+        with self._disconnect_device():
+            self.check_alarm_status_function_statuses(self.ca.Alarms.INVALID)
+
+        self.check_alarm_status_function_statuses(self.ca.Alarms.NONE)

--- a/common_tests/tpgx00.py
+++ b/common_tests/tpgx00.py
@@ -27,6 +27,12 @@ class GuageStatus(Enum):
         obj.sevr = sevr
         return obj
 
+@unique
+class SFStatus(Enum):
+    OFF = 0
+    ON  = 1
+
+
 CHANNELS = "A1", "A2", "B1", "B2"
 TEST_PRESSURES = 1.23, -10.23, 8, 1e-6, 1e+6
 
@@ -49,7 +55,7 @@ class Tpgx00Base():
         
         # Reset pressure status for each channel to okay
         for channel in CHANNELS:
-            self._lewis.backdoor_run_function_on_device("backdoor_set_pressure_status", [channel, GAUGE_STATUS["Measured data okay"]])
+            self._lewis.backdoor_run_function_on_device("backdoor_set_pressure_status", [channel, GuageStatus.DATA_OK.value])
 
     def tearDown(self):
         self._connect_emulator()
@@ -142,14 +148,14 @@ class Tpgx00Base():
         self._check_switching_function_thresholds("1", (0.0, 0.0, 1))
 
     def _check_switching_function_statuses(self, expected_statuses):
-        self.ca.assert_that_pv_is("FUNCTION:STATUS:1:RB", str(expected_statuses[0]))
-        self.ca.assert_that_pv_is("FUNCTION:STATUS:2:RB", str(expected_statuses[1]))
-        self.ca.assert_that_pv_is("FUNCTION:STATUS:3:RB", str(expected_statuses[2]))
-        self.ca.assert_that_pv_is("FUNCTION:STATUS:4:RB", str(expected_statuses[3]))
+        self.ca.assert_that_pv_is("FUNCTION:STATUS:1:RB", str(SFStatus[expected_statuses[0]].value))
+        self.ca.assert_that_pv_is("FUNCTION:STATUS:2:RB", str(SFStatus[expected_statuses[1]].value))
+        self.ca.assert_that_pv_is("FUNCTION:STATUS:3:RB", str(SFStatus[expected_statuses[2]].value))
+        self.ca.assert_that_pv_is("FUNCTION:STATUS:4:RB", str(SFStatus[expected_statuses[3]].value))
 
     @skip_if_recsim("Requires emulator")
     def test_GIVEN_function_status_set_THEN_readback_correct(self):
-        function_statuses = [0, 0, 1, 1, 0, 1]
+        function_statuses = ["OFF", "OFF", "ON", "ON", "OFF", "ON"]
         self._lewis.backdoor_run_function_on_device("backdoor_set_switching_function_status", [function_statuses])
         self._check_switching_function_statuses(function_statuses)
 

--- a/common_tests/tpgx00.py
+++ b/common_tests/tpgx00.py
@@ -1,12 +1,31 @@
 import unittest
 import contextlib
 import abc
+import itertools
+from enum import Enum, unique
 
 from parameterized import parameterized
 
 from utils.channel_access import ChannelAccess
 from utils.testing import get_running_lewis_and_ioc, skip_if_recsim, parameterized_list
 from itertools import product
+
+
+@unique
+class GuageStatus(Enum):
+    DATA_OK     = (0, "Measured data okay", "NO_ALARM")
+    UNDERRANGE  = (1, "Underrange", "MINOR")
+    OVERRANGE   = (2, "Overrange", "MINOR")
+    POINT_ERR   = (3, "Point error", "MAJOR")
+    POINT_OFF   = (4, "Point switched off", "MAJOR")
+    NO_HARDWARE = (5, "No hardware", "INVALID")
+
+    def __new__(cls, value, desc, sevr):
+        obj = object.__new__(cls)
+        obj._value_ = value
+        obj.desc = desc
+        obj.sevr = sevr
+        return obj
 
 CHANNELS = "A1", "A2", "B1", "B2"
 TEST_PRESSURES = 1.23, -10.23, 8, 1e-6, 1e+6
@@ -27,6 +46,10 @@ class Tpgx00Base():
     def setUp(self):
         self._lewis, self._ioc = get_running_lewis_and_ioc("tpgx00", self.get_prefix())
         self.ca = ChannelAccess(20, device_prefix=self.get_prefix(), default_wait_time=0.0)
+        
+        # Reset pressure status for each channel to okay
+        for channel in CHANNELS:
+            self._lewis.backdoor_run_function_on_device("backdoor_set_pressure_status", [channel, GAUGE_STATUS["Measured data okay"]])
 
     def tearDown(self):
         self._connect_emulator()
@@ -60,11 +83,11 @@ class Tpgx00Base():
             self.ca.assert_that_pv_is("UNITS:SP", expected_unit)
             self.ca.assert_that_pv_is("UNITS", expected_unit)
 
-    def test_that_GIVEN_a_connected_emulator_and_pressure_value_WHEN_set_pressure_is_set_THEN_the_ioc_is_updated(self):
-        for expected_pressure, channel in product(TEST_PRESSURES, CHANNELS):
-            pv = "PRESSURE_{}".format(channel)
-            self._set_pressure(expected_pressure, channel)
-            self.ca.assert_that_pv_is(pv, expected_pressure)
+    @parameterized.expand(parameterized_list(itertools.product(TEST_PRESSURES, CHANNELS)))
+    def test_that_GIVEN_a_connected_emulator_and_pressure_value_WHEN_set_pressure_is_set_THEN_the_ioc_is_updated(self, _, expected_pressure, channel):
+        pv = "PRESSURE_{}".format(channel)
+        self._set_pressure(expected_pressure, channel)
+        self.ca.assert_that_pv_is(pv, expected_pressure)
 
     @parameterized.expand(parameterized_list(CHANNELS))
     @skip_if_recsim("Recsim is unable to simulate a disconnected device")
@@ -76,16 +99,26 @@ class Tpgx00Base():
 
         self.ca.assert_that_pv_alarm_is(pv, self.ca.Alarms.NONE)
 
-    def set_switching_function(self, function):
+    @parameterized.expand(parameterized_list(CHANNELS))
+    @skip_if_recsim("Requires emulator")
+    def test_GIVEN_pressure_status_changed_THEN_pressure_status_and_pressure_severity_updated(self, _, channel):
+        for status in GuageStatus:
+            self._lewis.backdoor_run_function_on_device("backdoor_set_pressure_status", [channel, status.value])
+            self._set_pressure(TEST_PRESSURES[0], channel)
+            self.ca.assert_that_pv_is(f"PRESSURE_{channel}_STAT", status.desc, timeout=15)
+            self.ca.assert_that_pv_is(f"PRESSURE_{channel}_STAT.SEVR", status.sevr, timeout=15)
+            self.ca.assert_that_pv_is(f"PRESSURE_{channel}.SEVR", status.sevr, timeout=15)
+
+    def _set_switching_function(self, function):
         self.ca.set_pv_value("FUNCTION", function)
 
-    def set_switching_function_thresholds(self, threshold_low, threshold_high, circuit_assignment):
+    def _set_switching_function_thresholds(self, threshold_low, threshold_high, circuit_assignment):
         self.ca.set_pv_value("FUNCTION:LOW:SP", threshold_low)
         self.ca.set_pv_value("FUNCTION:HIGH:SP", threshold_high)
         self.ca.set_pv_value("FUNCTION:ASSIGN:SP", circuit_assignment)
         self.ca.process_pv("FUNCTION:ASSIGN:SP:OUT")
 
-    def check_switching_function_thresholds(self, function, thresholds, check_pv_is=True):
+    def _check_switching_function_thresholds(self, function, thresholds, check_pv_is=True):
         assignments = ("No assignment", "A1", "A2", "B1", "B1", "A1 self-monitor", "A2 self-monitor", "B1 self-monitor", "B1 self-monitor")
         if check_pv_is:
             assignment = assignments[thresholds[2]]
@@ -100,15 +133,15 @@ class Tpgx00Base():
     ])
     @skip_if_recsim("Requires emulator")
     def test_GIVEN_function_thresholds_set_THEN_thresholds_readback_correct(self, function_set, function_read):
-        self.set_switching_function("1")
-        self.set_switching_function_thresholds(0.0, 0.0, 1)
-        self.set_switching_function(function_set[0])
-        self.set_switching_function_thresholds(function_set[1], function_set[2], function_set[3])
-        self.check_switching_function_thresholds(str(function_set[0]), function_read)
-        self.set_switching_function("1")
-        self.check_switching_function_thresholds("1", (0.0, 0.0, 1))
+        self._set_switching_function("1")
+        self._set_switching_function_thresholds(0.0, 0.0, 1)
+        self._set_switching_function(function_set[0])
+        self._set_switching_function_thresholds(function_set[1], function_set[2], function_set[3])
+        self._check_switching_function_thresholds(str(function_set[0]), function_read)
+        self._set_switching_function("1")
+        self._check_switching_function_thresholds("1", (0.0, 0.0, 1))
 
-    def check_switching_function_statuses(self, expected_statuses):
+    def _check_switching_function_statuses(self, expected_statuses):
         self.ca.assert_that_pv_is("FUNCTION:STATUS:1:RB", str(expected_statuses[0]))
         self.ca.assert_that_pv_is("FUNCTION:STATUS:2:RB", str(expected_statuses[1]))
         self.ca.assert_that_pv_is("FUNCTION:STATUS:3:RB", str(expected_statuses[2]))
@@ -118,27 +151,27 @@ class Tpgx00Base():
     def test_GIVEN_function_status_set_THEN_readback_correct(self):
         function_statuses = [0, 0, 1, 1, 0, 1]
         self._lewis.backdoor_run_function_on_device("backdoor_set_switching_function_status", [function_statuses])
-        self.check_switching_function_statuses(function_statuses)
+        self._check_switching_function_statuses(function_statuses)
 
     @skip_if_recsim("Requires emulator")
     def test_GIVEN_thresholds_settings_and_pressure_above_THEN_check_if_violation_detected(self):
         self._set_pressure(0, "A2")
-        self.set_switching_function("3")
-        self.set_switching_function_thresholds(5E2, 7.5E4, 2)
+        self._set_switching_function("3")
+        self._set_switching_function_thresholds(5E2, 7.5E4, 2)
         self.ca.assert_that_pv_is("FUNCTION:3:THRESHOLD:BELOW", 1)
         self._set_pressure(6.43, "A2")
         self.ca.assert_that_pv_is("FUNCTION:3:THRESHOLD:BELOW", 1)
         self._set_pressure(501.0, "A2")
         self.ca.assert_that_pv_is("FUNCTION:3:THRESHOLD:BELOW", 0)
 
-    def check_alarm_status_rbvs(self, alarm):
+    def _check_alarm_status_rbvs(self, alarm):
         for channel in ("SEL", "1", "2", "3", "4", "A", "B"):
             self.ca.assert_that_pv_alarm_is("FUNCTION:" + channel + ":RB", alarm)
             self.ca.assert_that_pv_alarm_is("FUNCTION:" + channel + ":LOW:SP:RBV", alarm)
             self.ca.assert_that_pv_alarm_is("FUNCTION:" + channel + ":HIGH:SP:RBV", alarm)
             self.ca.assert_that_pv_alarm_is("FUNCTION:" + channel + ":ASSIGN:SP:RBV", alarm)
 
-    def check_alarm_status_function_statuses(self, alarm):
+    def _check_alarm_status_function_statuses(self, alarm):
         self.ca.assert_that_pv_alarm_is("FUNCTION:STATUS:RB", alarm)
         for channel in ("1", "2", "3", "4"):
             self.ca.assert_that_pv_alarm_is("FUNCTION:STATUS:" + channel + ":RB", alarm)
@@ -146,16 +179,17 @@ class Tpgx00Base():
 
     @skip_if_recsim("Requires emulator")
     def test_WHEN_device_disconnected_THEN_rbv_values_go_into_alarm(self):
-        self.check_alarm_status_rbvs(self.ca.Alarms.NONE)
+        self._check_alarm_status_rbvs(self.ca.Alarms.NONE)
         with self._disconnect_device():
-            self.check_alarm_status_rbvs(self.ca.Alarms.INVALID)
+            self._check_alarm_status_rbvs(self.ca.Alarms.INVALID)
 
-        self.check_alarm_status_rbvs(self.ca.Alarms.NONE)
+        self._check_alarm_status_rbvs(self.ca.Alarms.NONE)
 
     @skip_if_recsim("Requires emulator")
     def test_WHEN_device_disconnected_THEN_function_statuses_go_into_alarm(self):
-        self.check_alarm_status_function_statuses(self.ca.Alarms.NONE)
+        self._check_alarm_status_function_statuses(self.ca.Alarms.NONE)
         with self._disconnect_device():
-            self.check_alarm_status_function_statuses(self.ca.Alarms.INVALID)
+            self._check_alarm_status_function_statuses(self.ca.Alarms.INVALID)
 
-        self.check_alarm_status_function_statuses(self.ca.Alarms.NONE)
+        self._check_alarm_status_function_statuses(self.ca.Alarms.NONE)
+

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -62,19 +62,6 @@ class InvalidUnits(Enum):
     Ampere = 6
 
 
-class ErrorStatus(Enum):
-    NO_ERROR      = "No error"
-    DEVICE_ERROR  = "Device error"
-    NO_HARDWARE   = "No hardware"
-    INVALID_PARAM = "Invalid parameter"
-    SYNTAX_ERROR  = "Syntax error"
-
-
-class SFStatus(Enum):
-    OFF = 0
-    ON  = 1
-
-
 class Tpg300Tests(Tpgx00Base, unittest.TestCase):
     """
     Tests for the TPG300.
@@ -100,31 +87,3 @@ class Tpg300Tests(Tpgx00Base, unittest.TestCase):
         self.ca.assert_that_pv_is_not("UNITS", unit_name)
         self._lewis.assert_that_emulator_value_is_not("backdoor_get_unit", str(unit_name))
         self.ca.assert_that_pv_alarm_is("UNITS:SP", "INVALID")   
-
-    # These tests would usually live in tpgx00 to be tested on both devices but this functionality only 
-    # works on the 300 for now 
-    def _check_switching_function_statuses(self, expected_statuses):
-        self.ca.assert_that_pv_is("FUNCTION:STATUS:1:RB", str(SFStatus[expected_statuses[0]].value))
-        self.ca.assert_that_pv_is("FUNCTION:STATUS:2:RB", str(SFStatus[expected_statuses[1]].value))
-        self.ca.assert_that_pv_is("FUNCTION:STATUS:3:RB", str(SFStatus[expected_statuses[2]].value))
-        self.ca.assert_that_pv_is("FUNCTION:STATUS:4:RB", str(SFStatus[expected_statuses[3]].value))
-
-    @skip_if_recsim("Requires emulator")
-    def test_GIVEN_function_status_set_THEN_readback_correct(self):
-        function_statuses = ["OFF", "OFF", "ON", "ON", "OFF", "ON"]
-        self._lewis.backdoor_run_function_on_device("backdoor_set_switching_function_status", [function_statuses])
-        self._check_switching_function_statuses(function_statuses)
-
-    @skip_if_recsim("Requires emulator")
-    def test_WHEN_error_set_by_device_THEN_readback_correct(self):
-        for error in ErrorStatus:
-            self._lewis.backdoor_run_function_on_device("backdoor_set_error_status", [error.name])
-            self.ca.assert_that_pv_is("ERROR", error.value)
-    
-    @skip_if_recsim("Requires emulator")
-    def test_WHEN_device_disconnected_THEN_function_statuses_go_into_alarm(self):
-        self._check_alarm_status_function_statuses(self.ca.Alarms.NONE)
-        with self._disconnect_device():
-            self._check_alarm_status_function_statuses(self.ca.Alarms.INVALID)
-        
-        self._check_alarm_status_function_statuses(self.ca.Alarms.NONE)

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -13,7 +13,8 @@ IOCS = [
     "name": DEVICE_PREFIX,
     "directory": get_default_ioc_dir("TPG300"),
     "macros": {},
-    "emulator": "tpg300",
+    "emulator": "tpgx00",
+    "lewis_protocol": "tpg300",
     },
 ]
 
@@ -37,3 +38,4 @@ class Tpg300Tests(Tpgx00Base, unittest.TestCase):
         
     def get_units(self):
         return Units
+

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -30,6 +30,7 @@ TEST_MODES = [TestModes.DEVSIM, TestModes.RECSIM]
 
 SWITCHING_FUNCTIONS = ("SEL", "1", "2", "3", "4", "A", "B")
 
+
 class SFAssignment(Enum):
     OFF         = (0, "No assignment")
     A1          = (1, "A1")
@@ -53,11 +54,25 @@ class Units(Enum):
     Torr = 2
     Pa = 3
 
+
 class InvalidUnits(Enum):
     hPascal = 0
     Micron = 4
     Volt = 5
     Ampere = 6
+
+
+class ErrorStatus(Enum):
+    NO_ERROR      = "No error"
+    DEVICE_ERROR  = "Device error"
+    NO_HARDWARE   = "No hardware"
+    INVALID_PARAM = "Invalid parameter"
+    SYNTAX_ERROR  = "Syntax error"
+
+
+class SFStatus(Enum):
+    OFF = 0
+    ON  = 1
 
 
 class Tpg300Tests(Tpgx00Base, unittest.TestCase):
@@ -87,3 +102,30 @@ class Tpg300Tests(Tpgx00Base, unittest.TestCase):
             self._lewis.assert_that_emulator_value_is_not("backdoor_get_unit", str(expected_unit))
             self.ca.assert_that_pv_alarm_is("UNITS:SP", "INVALID")   
 
+    # These tests would usually live in tpgx00 to be tested on both devices but this functionality only 
+    # works on the 300 for now 
+    def _check_switching_function_statuses(self, expected_statuses):
+        self.ca.assert_that_pv_is("FUNCTION:STATUS:1:RB", str(SFStatus[expected_statuses[0]].value))
+        self.ca.assert_that_pv_is("FUNCTION:STATUS:2:RB", str(SFStatus[expected_statuses[1]].value))
+        self.ca.assert_that_pv_is("FUNCTION:STATUS:3:RB", str(SFStatus[expected_statuses[2]].value))
+        self.ca.assert_that_pv_is("FUNCTION:STATUS:4:RB", str(SFStatus[expected_statuses[3]].value))
+
+    @skip_if_recsim("Requires emulator")
+    def test_GIVEN_function_status_set_THEN_readback_correct(self):
+        function_statuses = ["OFF", "OFF", "ON", "ON", "OFF", "ON"]
+        self._lewis.backdoor_run_function_on_device("backdoor_set_switching_function_status", [function_statuses])
+        self._check_switching_function_statuses(function_statuses)
+
+    @skip_if_recsim("Requires emulator")
+    def test_WHEN_error_set_by_device_THEN_readback_correct(self):
+        for error in ErrorStatus:
+            self._lewis.backdoor_run_function_on_device("backdoor_set_error_status", [error.name])
+            self.ca.assert_that_pv_is("ERROR", error.value)
+    
+    @skip_if_recsim("Requires emulator")
+    def test_WHEN_device_disconnected_THEN_function_statuses_go_into_alarm(self):
+        self._check_alarm_status_function_statuses(self.ca.Alarms.NONE)
+        with self._disconnect_device():
+            self._check_alarm_status_function_statuses(self.ca.Alarms.INVALID)
+        
+        self._check_alarm_status_function_statuses(self.ca.Alarms.NONE)

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -22,6 +22,7 @@ IOCS = [
     },
     "emulator": "tpgx00",
     "lewis_protocol": "tpg300",
+    "pv_for_existence": "UNITS",
     },
 ]
 

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -7,7 +7,7 @@ from genie_python.genie_cachannel_wrapper import InvalidEnumStringException
 from common_tests.tpgx00 import Tpgx00Base
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
-from utils.testing import skip_if_recsim
+from utils.testing import skip_if_recsim, parameterized_list
 from enum import Enum
 
 
@@ -92,15 +92,14 @@ class Tpg300Tests(Tpgx00Base, unittest.TestCase):
     def get_switching_fns(self):
         return SWITCHING_FUNCTIONS
     
+    
+    @parameterized.expand(parameterized_list([unit.value for unit in InvalidUnits]))
     @skip_if_recsim("Requires emulator")
-    def test_WHEN_invalid_unit_set_THEN_pv_goes_into_alarm(self):
-        for unit in InvalidUnits:
-            expected_unit = unit.name
-            with self.assertRaises(InvalidEnumStringException):
-                self.ca.set_pv_value("UNITS:SP", expected_unit)
-            self.ca.assert_that_pv_is_not("UNITS", expected_unit)
-            self._lewis.assert_that_emulator_value_is_not("backdoor_get_unit", str(expected_unit))
-            self.ca.assert_that_pv_alarm_is("UNITS:SP", "INVALID")   
+    def test_WHEN_invalid_unit_set_THEN_pv_goes_into_alarm(self, _, unit_name):
+        self.ca.set_pv_value("UNITS:SP", unit_name)
+        self.ca.assert_that_pv_is_not("UNITS", unit_name)
+        self._lewis.assert_that_emulator_value_is_not("backdoor_get_unit", str(unit_name))
+        self.ca.assert_that_pv_alarm_is("UNITS:SP", "INVALID")   
 
     # These tests would usually live in tpgx00 to be tested on both devices but this functionality only 
     # works on the 300 for now 

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -12,7 +12,9 @@ IOCS = [
     {
     "name": DEVICE_PREFIX,
     "directory": get_default_ioc_dir("TPG300"),
-    "macros": {},
+    "macros": {
+        "MODEL": "300"
+    },
     "emulator": "tpgx00",
     "lewis_protocol": "tpg300",
     },

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -55,13 +55,6 @@ class Units(Enum):
     Pa = 3
 
 
-class InvalidUnits(Enum):
-    hPascal = 0
-    Micron = 4
-    Volt = 5
-    Ampere = 6
-
-
 class Tpg300Tests(Tpgx00Base, unittest.TestCase):
     """
     Tests for the TPG300.
@@ -78,12 +71,3 @@ class Tpg300Tests(Tpgx00Base, unittest.TestCase):
     
     def get_switching_fns(self):
         return SWITCHING_FUNCTIONS
-    
-    
-    @parameterized.expand(parameterized_list([unit.value for unit in InvalidUnits]))
-    @skip_if_recsim("Requires emulator")
-    def test_WHEN_invalid_unit_set_THEN_pv_goes_into_alarm(self, _, unit_name):
-        self.ca.set_pv_value("UNITS:SP", unit_name)
-        self.ca.assert_that_pv_is_not("UNITS", unit_name)
-        self._lewis.assert_that_emulator_value_is_not("backdoor_get_unit", str(unit_name))
-        self.ca.assert_that_pv_alarm_is("UNITS:SP", "INVALID")   

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -22,6 +22,24 @@ IOCS = [
 TEST_MODES = [TestModes.DEVSIM, TestModes.RECSIM]
 
 
+class SFAssignment(Enum):
+    OFF         = (0, "No assignment")
+    A1          = (1, "A1")
+    A2          = (2, "A2")
+    B1          = (3, "B1")
+    B2          = (4, "B1")
+    A1_SELF_MON = (5, "A1 self-monitor")
+    A2_SELF_MON = (6, "A2 self-monitor")
+    B1_SELF_MON = (7, "B1 self-monitor")
+    B2_SELF_MON = (8, "B1 self-monitor")
+
+    def __new__(cls, value, desc):
+        obj = object.__new__(cls)
+        obj._value_ = value
+        obj.desc = desc
+        return obj
+
+
 class Units(Enum):
     mbar = 1
     Torr = 2
@@ -38,4 +56,7 @@ class Tpg300Tests(Tpgx00Base, unittest.TestCase):
         
     def get_units(self):
         return Units
+
+    def get_sf_assignment(self):
+        return SFAssignment
 

--- a/tests/tpg500.py
+++ b/tests/tpg500.py
@@ -7,6 +7,7 @@ from enum import Enum
 
 
 DEVICE_PREFIX = "TPG300_01"
+# DEVICE_EMULATOR = "tpg500"
 
 IOCS = [
     {
@@ -22,18 +23,25 @@ TEST_MODES = [TestModes.DEVSIM, TestModes.RECSIM]
 
 
 class Units(Enum):
+    hPa = 0
     mbar = 1
     Torr = 2
     Pa = 3
+    Micron = 4
+    Volt = 5
+    Amp = 6
 
 
-class Tpg300Tests(Tpgx00Base, unittest.TestCase):
+class Tpg500Tests(Tpgx00Base, unittest.TestCase):
     """
-    Tests for the TPG300.
+    Tests for the TPG500.
     """
 
     def get_prefix(self):
         return DEVICE_PREFIX
-        
+
+    # def get_emulator(self):
+    #     return DEVICE_EMULATOR
+    
     def get_units(self):
         return Units

--- a/tests/tpg500.py
+++ b/tests/tpg500.py
@@ -12,7 +12,9 @@ IOCS = [
     {
     "name": DEVICE_PREFIX,
     "directory": get_default_ioc_dir("TPG300"),
-    "macros": {},
+    "macros": {
+        "MODEL": "500"
+    },
     "emulator": "tpgx00",
     "lewis_protocol": "tpg500",
     },
@@ -38,13 +40,13 @@ class SFAssignment(Enum):
 
 
 class Units(Enum):
-    hPa = 0
+    hPascal = 0
     mbar = 1
     Torr = 2
     Pa = 3
     Micron = 4
     Volt = 5
-    Amp = 6
+    Ampere = 6
 
 
 class Tpg500Tests(Tpgx00Base, unittest.TestCase):

--- a/tests/tpg500.py
+++ b/tests/tpg500.py
@@ -22,6 +22,7 @@ IOCS = [
     },
     "emulator": "tpgx00",
     "lewis_protocol": "tpg500",
+    "pv_for_existence": "UNITS",
     },
 ]
 

--- a/tests/tpg500.py
+++ b/tests/tpg500.py
@@ -22,6 +22,21 @@ IOCS = [
 TEST_MODES = [TestModes.DEVSIM, TestModes.RECSIM]
 
 
+class SFAssignment(Enum):
+    OFF         = (0, "Switched off")
+    A1          = (1, "A1")
+    A2          = (2, "A2")
+    B1          = (3, "B1")
+    B2          = (4, "B2")
+    ON          = (5, "Switched on")
+    
+    def __new__(cls, value, desc):
+        obj = object.__new__(cls)
+        obj._value_ = value
+        obj.desc = desc
+        return obj
+
+
 class Units(Enum):
     hPa = 0
     mbar = 1
@@ -42,4 +57,7 @@ class Tpg500Tests(Tpgx00Base, unittest.TestCase):
     
     def get_units(self):
         return Units
+
+    def get_sf_assignment(self):
+        return SFAssignment
 

--- a/tests/tpg500.py
+++ b/tests/tpg500.py
@@ -71,11 +71,6 @@ class Tpg500Tests(Tpgx00Base, unittest.TestCase):
         
     def get_switching_fns(self):
         return SWITCHING_FUNCTIONS
-    
-    def _check_alarm_status_function_statuses(self, alarm):
-        self.ca.assert_that_pv_is("FUNCTION:STATUS:RB", "Unavailable")
-        for channel in ("1", "2", "3", "4"):
-            self.ca.assert_that_pv_alarm_is("FUNCTION:STATUS:" + channel + ":RB", alarm)
 
     @parameterized.expand(parameterized_list(['A', 'B']))
     @skip_if_recsim("Requires emulator")
@@ -84,23 +79,3 @@ class Tpg500Tests(Tpgx00Base, unittest.TestCase):
             self.ca.set_pv_value("FUNCTION", switching_func)
         self.ca.assert_that_pv_is_not("FUNCTION", switching_func)
         self._lewis.assert_that_emulator_value_is_not("backdoor_get_switching_fn", switching_func)
-
-    # Tests to check the various inconsistencies between the 500 manual & hardware have been handled
-    @skip_if_recsim("Requires emulator")
-    def test_WHEN_ioc_is_on_THEN_error_status_invalid(self):
-        self.ca.assert_that_pv_alarm_is("ERROR", self.ca.Alarms.INVALID)
-    
-    @parameterized.expand(parameterized_list(["1", "2", "3", "4"]))
-    def test_WHEN_ioc_is_on_THEN_each_relay_contact_status_invalid(self, _, channel):
-        self.ca.assert_that_pv_alarm_is("FUNCTION:STATUS:" + channel + ":RB", self.ca.Alarms.INVALID)
-
-    @skip_if_recsim("Requires emulator")
-    def test_WHEN_device_disconnected_THEN_function_statuses_go_into_alarm(self):
-        self._check_alarm_status_function_statuses(self.ca.Alarms.INVALID)
-        with self._disconnect_device():
-            self._check_alarm_status_function_statuses(self.ca.Alarms.INVALID)
-        
-        self._check_alarm_status_function_statuses(self.ca.Alarms.INVALID)
-
-    def test_WHEN_ioc_is_on_THEN_status_rb_reports_unavailable(self):
-        self.ca.assert_that_pv_is("FUNCTION:STATUS:RB", "Unavailable")

--- a/tests/tpg500.py
+++ b/tests/tpg500.py
@@ -7,14 +7,14 @@ from enum import Enum
 
 
 DEVICE_PREFIX = "TPG300_01"
-# DEVICE_EMULATOR = "tpg500"
 
 IOCS = [
     {
     "name": DEVICE_PREFIX,
     "directory": get_default_ioc_dir("TPG300"),
     "macros": {},
-    "emulator": "tpg300",
+    "emulator": "tpgx00",
+    "lewis_protocol": "tpg500",
     },
 ]
 
@@ -39,9 +39,7 @@ class Tpg500Tests(Tpgx00Base, unittest.TestCase):
 
     def get_prefix(self):
         return DEVICE_PREFIX
-
-    # def get_emulator(self):
-    #     return DEVICE_EMULATOR
     
     def get_units(self):
         return Units
+

--- a/utils/emulator_launcher.py
+++ b/utils/emulator_launcher.py
@@ -221,6 +221,30 @@ class EmulatorLauncher(object):
 
         return self.assert_that_emulator_value_causes_func_to_return_true(
             emulator_property, lambda val: cast(val) == expected_value, timeout=timeout, msg=message)
+    
+    def assert_that_emulator_value_is_not(self, emulator_property, value, timeout=None, message=None,
+                                      cast=lambda val: val):
+        """
+        Assert that the emulator property does not have the passed value and that it does not become the passed value 
+        within the timeout.
+
+        Args:
+            emulator_property (string): emulator property to check
+            value: value to check against. Emulator backdoor always returns a string, so the value should be a string.
+            timeout (float): if it hasn't changed within this time raise assertion error
+            message (string): Extra message to print
+            cast (callable): function which casts the returned value to an appropriate type before
+                checking equality. E.g. to cast to float pass the float class as this argument.
+        Raises:
+            AssertionError: if emulator property *is* the passed value
+            UnableToConnectToPVException: if emulator property does not exist within timeout
+        """
+
+        if message is None:
+            message = "Expected PV to *not* have value {}.".format(format_value(value))
+
+        return self.assert_that_emulator_value_causes_func_to_return_false(
+            emulator_property, lambda val: cast(val) == value, timeout=timeout, msg=message)
 
     def assert_that_emulator_value_causes_func_to_return_true(
             self, emulator_property, func, timeout=None, msg=None):
@@ -260,6 +284,44 @@ class EmulatorLauncher(object):
         if err is not None:
             raise AssertionError(err)
 
+    def assert_that_emulator_value_causes_func_to_return_false(
+            self, emulator_property, func, timeout=None, msg=None):
+        """
+        Check that an emulator property does not satisfy a given function within some timeout.
+
+        Args:
+            emulator_property (string): emulator property to check
+            func: a function that takes one argument, the emulator property value, and returns True if the value is
+                valid (i.e. *not* the value we're checking).
+            timeout: time to wait for the PV to satisfy the function
+            msg: custom message to print on failure
+        Raises:
+            AssertionError: If the function does not evaluate to false within the given timeout
+        """
+
+        def wrapper(msg):
+            value = self.backdoor_get_from_device(emulator_property)
+            try:
+                return_value = func(value)
+            except Exception as e:
+                return "Exception was thrown while evaluating function '{}' on emulator property {}. " \
+                       "Exception was: {} {}".format(func.__name__,
+                                                     format_value(value), e.__class__.__name__, e.message)
+            if return_value:
+                return "{}{}{}".format(msg, os.linesep, "Final emulator property value was {}"
+                                       .format(format_value(value)))
+            else:
+                return None
+
+        if msg is None:
+            msg = "Expected function '{}' to evaluate to False when reading emulator property '{}'." \
+                .format(func.__name__, emulator_property)
+
+        err = self._wait_for_emulator_lambda(partial(wrapper, msg), timeout)
+
+        if err is not None:
+            raise AssertionError(err)
+        
     def _wait_for_emulator_lambda(self, wait_for_lambda, timeout):
         """
         Wait for a lambda containing a emulator property to become None; return value or timeout and return actual value.


### PR DESCRIPTION
### Description of work

- Rename module to `tpgx00`, move to common_tests
- Create new submodules `tpg300` and `tpg500`
- Various tidying and refactoring of older tests
- Add tests for added pressure status PVs
- Refactor tests inline with refactored emulator behaviour
- Add tests to check IOC behaviour with invalid commands 
   - Add `assert_that_emulator_value_is_not` method to `utils/emulator_launcher.py` to support this
- Add test for ERR command
- Move some general tests to `tpg300` whilst hardware issues with the TPG500 are being sorted (https://github.com/ISISComputingGroup/IBEX/issues/7860)

### Ticket

[#7458](https://github.com/ISISComputingGroup/IBEX/issues/7458)