### PR TITLE
Fix refl tests

### DIFF
--- a/test_config/good_for_refl/refl/config.py
+++ b/test_config/good_for_refl/refl/config.py
@@ -41,8 +41,8 @@ def get_beamline(macros):
     add_parameter(AxisParameter("SMAngle", sm_comp, ChangeAxis.ANGLE), [polarised])
     add_parameter(InBeamParameter("SMInBeam", sm_comp), modes=[nr, polarised], mode_inits=[(polarised, True)])
     add_driver(
-        IocDriver(sm_comp, ChangeAxis.POSITION, MotorPVWrapper("MOT:MTR0107"), out_of_beam_positions=[SM_OUT_POS]))
-    add_driver(IocDriver(sm_comp, ChangeAxis.ANGLE, MotorPVWrapper("MOT:MTR0208")))
+        IocDriver(sm_comp, ChangeAxis.POSITION, MotorPVWrapper("MOT:MTR0107"), out_of_beam_positions=[SM_OUT_POS], synchronised=False))
+    add_driver(IocDriver(sm_comp, ChangeAxis.ANGLE, MotorPVWrapper("MOT:MTR0208"), synchronised=False))
 
     # THETA
     theta = add_component(ThetaComponent("ThetaComp", PositionAndAngle(0.0, 2 * SPACING, 90)))

--- a/tests/refl.py
+++ b/tests/refl.py
@@ -88,6 +88,8 @@ IOCS = [
             "GALILCONFIGDIR": test_config_path.replace("\\", "/"),
         },
         "inits": {
+            "MTR0208.VMAX": INITIAL_VELOCITY,
+            "MTR0208.VELO": INITIAL_VELOCITY,
             "MTR0208.ERES": 0.001,
             "MTR0208.MRES": 0.001
         },


### PR DESCRIPTION
The tests sometimes leave the velocity in a funny state, these changes ensure they are reset regularly. This issue should only occur in IOC tests as the velocity autosave file is cleared everytime they are run which may lead to issues on startup, whereas on real instruments the autosave file persists