### PR TITLE
Fix motionsetpoint tests

### DIFF
--- a/run_all_tests_split.bat
+++ b/run_all_tests_split.bat
@@ -2,13 +2,17 @@
 setlocal EnableDelayedExpansion
 
 REM glob is case insensitive on windows but on linux would need [a-hA-H]* etc
-REM have had issues with instrona and ngpsu, so split here
+REM have had issues with instrona and ngpsu, hence split here at i and n
+
+set final_errcode=0
 
 for %%i in ( "a-h" "i" "j-m" "n" "o-z" ) do (
     call %~dp0run_all_tests.bat -tf "[%%~i]*"
     if !errorlevel! NEQ 0 (
-        @echo ERROR code !errorlevel! returned from run_all_tests.bat
-        exit /b !errorlevel!
+        @echo ERROR code !errorlevel! returned from [%%i] tests in run_all_tests_split.bat
+        @echo ERROR will continue running tests, but will return overall failure code at end
+        set final_errcode=!errorlevel!
     )
 )
-exit /b 0
+
+exit /b !final_errcode!

--- a/tests/motion_setpoints.py
+++ b/tests/motion_setpoints.py
@@ -2,6 +2,7 @@ import unittest
 from parameterized import parameterized
 from operator import add
 import os
+import posixpath
 
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
@@ -468,9 +469,12 @@ class MotionSetpointsTests(unittest.TestCase):
             self.motor_ca.assert_that_pv_is(f"MTR010{coord+1}.RBV", new_position)
 
     def test_GIVEN_files_WHEN_file_names_checked_THEN_current_names_correct(self):
-        # Motion setpoints changes path separators to / so replace them before asserting
-        self.ca1D.assert_that_pv_is("FILENAME", str(os.path.join(test_path, "lookup1D.txt")).replace(os.sep, '/'))
-        self.ca2D.assert_that_pv_is("FILENAME", str(os.path.join(test_path,"lookup2D.txt")).replace(os.sep, '/'))
-        self.ca10D.assert_that_pv_is("FILENAME", str(os.path.join(test_path,"lookup10D.txt")).replace(os.sep, '/'))
-        self.caDN.assert_that_pv_is("FILENAME", str(os.path.join(test_path,"duplicate_names.txt")).replace(os.sep, '/'))
-        self.caDP.assert_that_pv_is("FILENAME", str(os.path.join(test_path,"duplicate_positions.txt")).replace(os.sep, '/'))
+        # Motion setpoints changes path separators to / so use posixpath for asserting
+        # can't use test_path as it calls realpath and we have directory junctions on test servers
+        lookup_path = posixpath.join(os.getenv("EPICS_KIT_ROOT").replace(os.sep, '/'),
+                                   "support", "motionSetPoints", "master", "settings")
+        self.ca1D.assert_that_pv_is("FILENAME", str(posixpath.join(lookup_path, "lookup1D.txt")))
+        self.ca2D.assert_that_pv_is("FILENAME", str(posixpath.join(lookup_path,"lookup2D.txt")))
+        self.ca10D.assert_that_pv_is("FILENAME", str(posixpath.join(lookup_path,"lookup10D.txt")))
+        self.caDN.assert_that_pv_is("FILENAME", str(posixpath.join(lookup_path,"duplicate_names.txt")))
+        self.caDP.assert_that_pv_is("FILENAME", str(posixpath.join(lookup_path,"duplicate_positions.txt")))


### PR DESCRIPTION
As system test server uses directory junctions, need to avoid using "realpath" or get mismatch