### PR TITLE
Ticket_8284_Allow_certain_values_to_be_editable_without_restarting_IOC

### DIFF
--- a/tests/mclennan.py
+++ b/tests/mclennan.py
@@ -159,21 +159,16 @@ class MclennanTests(unittest.TestCase):
         macros = IOC_MACROS
         macros["MOTOR_ASG"] = "WASL0" 
         with self._ioc.start_with_macros(macros, pv_to_wait_for=PV_TO_WAIT_FOR):
-            try:
+            with self.assertRaises(WriteAccessException, msg="HVEL should not be able to be set based on the default ASG level (WASL0)"):
                 self.ca_motor.set_pv_value(MTR1_HVEL, 0.1) # testing HVEL because it is part of the group of PVs that the ASG and ASLs control
-            except WriteAccessException as Exception:
-                # this is the error we want to occur
-                pass
                 
     def test_WHEN_MOTOR_ASG_is_NOT_SET_THEN_prevent_HVEL_setting(self):
         # when MOTOR_ASG macro does not exist the db record should default to using WASL0
         macros = IOC_MACROS
+        del macros["MOTOR_ASG"]
         with self._ioc.start_with_macros(macros, pv_to_wait_for=PV_TO_WAIT_FOR):
-            try:
+            with self.assertRaises(WriteAccessException, msg="HVEL should not be able to be set based on the default ASG level (WASL0)"):
                 self.ca_motor.set_pv_value(MTR1_HVEL, 0.1)
-            except WriteAccessException as Exception:
-                # this is the error we want to occur here
-                pass
 
     def test_WHEN_MOTOR_ASG_is_DEFAULT_THEN_allow_HVEL_setting(self):
         macros = IOC_MACROS

--- a/tests/mclennan.py
+++ b/tests/mclennan.py
@@ -4,6 +4,7 @@ from utils.ioc_launcher import get_default_ioc_dir, ProcServLauncher
 from utils.test_modes import TestModes
 from utils.testing import get_running_lewis_and_ioc, parameterized_list
 from parameterized import parameterized
+from genie_python.channel_access_exceptions import WriteAccessException
 
 DEVICE_PREFIX = "MCLEN_01"
 EMULATOR_NAME = "mclennan"
@@ -31,18 +32,18 @@ POLL_RATE = 1
 CREEP_SPEED = 700
 
 IOC_MACROS = {
-            "MTRCTRL": "01",
-            "AXIS1": "yes",
-            "AXIS2": "yes",
-            "NAME1": MTR1_NAME,
-            "NAME2": MTR2_NAME,
-            "POLL_RATE": POLL_RATE,
-            "CMOD1": "OPEN",
-            "CMOD2": "CLOSED",            
-            "HOME1": 3, # SNL home
-            "HOME2": 2,  # builtin controller home to datum
-            "CRSP1" : CREEP_SPEED,
-            "CRSP2" : CREEP_SPEED,
+    "MTRCTRL": "01",
+    "AXIS1": "yes",
+    "AXIS2": "yes",
+    "NAME1": MTR1_NAME,
+    "NAME2": MTR2_NAME,
+    "POLL_RATE": POLL_RATE,
+    "CMOD1": "OPEN",
+    "CMOD2": "CLOSED",
+    "HOME1": 3,  # SNL home
+    "HOME2": 2,  # builtin controller home to datum
+    "CRSP1": CREEP_SPEED,
+    "CRSP2": CREEP_SPEED,
 }
 
 PV_TO_WAIT_FOR = "AXIS1"
@@ -67,9 +68,12 @@ class MclennanTests(unittest.TestCase):
     """
     Tests for the Mclennan IOC.
     """
+
     def setUp(self):
-        self._lewis, self._ioc = get_running_lewis_and_ioc(EMULATOR_NAME, DEVICE_PREFIX)
-        self.ca = ChannelAccess(device_prefix=DEVICE_PREFIX, default_timeout=10)
+        self._lewis, self._ioc = get_running_lewis_and_ioc(
+            EMULATOR_NAME, DEVICE_PREFIX)
+        self.ca = ChannelAccess(
+            device_prefix=DEVICE_PREFIX, default_timeout=10)
         self.ca_motor = ChannelAccess(default_timeout=30, device_prefix="MOT")
         self.ca_motor.set_pv_value(MTR1_STOP, 1, sleep_after_set=1)
         self.ca_motor.set_pv_value(MTR2_STOP, 1, sleep_after_set=1)
@@ -88,7 +92,8 @@ class MclennanTests(unittest.TestCase):
 
             self.ca_motor.assert_that_pv_value_is_increasing(MTR1_RBV, 1)
             self.ca_motor.assert_that_pv_is(MTR1_MOVN, 1)
-            self.ca_motor.assert_that_pv_value_is_unchanged(MTR1_MOVN, POLL_RATE * 1.5)
+            self.ca_motor.assert_that_pv_value_is_unchanged(
+                MTR1_MOVN, POLL_RATE * 1.5)
 
     def test_WHEN_motor_position_changes_outside_IBEX_THEN_motor_position_updated(self):
         test_position = -10
@@ -98,7 +103,8 @@ class MclennanTests(unittest.TestCase):
         self.ca_motor.assert_that_pv_is_number(MTR1_RBV, test_position)
 
     def test_WHEN_velocity_changes_WHEN_sending_builtin_home_THEN_creep_speed_is_changed_then_set_back_after_home(self):
-        self._lewis.assert_that_emulator_value_is("creep_speed2", str(CREEP_SPEED))
+        self._lewis.assert_that_emulator_value_is(
+            "creep_speed2", str(CREEP_SPEED))
         vel = 0.2
         macros = IOC_MACROS
         macros['HVEL2'] = vel
@@ -106,12 +112,15 @@ class MclennanTests(unittest.TestCase):
             self.ca_motor.assert_that_pv_is_number(MTR2_HVEL, vel, timeout=30)
             self.ca_motor.set_pv_value(MTR2_HOMR, 1)
             mres = self.ca_motor.get_pv_value(MTR2_MRES)
-            self._lewis.assert_that_emulator_value_is("creep_speed2", str(int(vel/mres)))
+            self._lewis.assert_that_emulator_value_is(
+                "creep_speed2", str(int(vel/mres)))
             self.ca_motor.set_pv_value(MTR2, 1)
-            self._lewis.assert_that_emulator_value_is("creep_speed2", str(CREEP_SPEED))
+            self._lewis.assert_that_emulator_value_is(
+                "creep_speed2", str(CREEP_SPEED))
 
     def test_WHEN_velocity_changes_WHEN_sending_SNL_home_THEN_creep_speed_is_not_changed(self):
-        self._lewis.assert_that_emulator_value_is("creep_speed1", str(CREEP_SPEED))
+        self._lewis.assert_that_emulator_value_is(
+            "creep_speed1", str(CREEP_SPEED))
         vel = 0.2
         macros = IOC_MACROS
         macros['HVEL1'] = vel
@@ -119,12 +128,15 @@ class MclennanTests(unittest.TestCase):
             self.ca_motor.assert_that_pv_is_number(MTR1_HVEL, vel, timeout=30)
             self.ca_motor.set_pv_value(MTR1_HOMR, 1)
             mres = self.ca_motor.get_pv_value(MTR1_MRES)
-            self._lewis.assert_that_emulator_value_is("creep_speed1", str(CREEP_SPEED))
+            self._lewis.assert_that_emulator_value_is(
+                "creep_speed1", str(CREEP_SPEED))
             self.ca_motor.set_pv_value(MTR1, 1)
-            self._lewis.assert_that_emulator_value_is("creep_speed1", str(CREEP_SPEED))
+            self._lewis.assert_that_emulator_value_is(
+                "creep_speed1", str(CREEP_SPEED))
 
     def test_WHEN_sending_home_with_high_velocity_THEN_creep_speed_is_capped(self):
-        self._lewis.assert_that_emulator_value_is("creep_speed2", str(CREEP_SPEED))
+        self._lewis.assert_that_emulator_value_is(
+            "creep_speed2", str(CREEP_SPEED))
         vel = 100
         macros = IOC_MACROS
         macros['HVEL2'] = vel
@@ -134,10 +146,39 @@ class MclennanTests(unittest.TestCase):
             # Should be capped at the max creep speed (800)
             self._lewis.assert_that_emulator_value_is("creep_speed2", str(800))
             self.ca_motor.set_pv_value(MTR2, 1)
-            self._lewis.assert_that_emulator_value_is("creep_speed2", str(CREEP_SPEED))
+            self._lewis.assert_that_emulator_value_is(
+                "creep_speed2", str(CREEP_SPEED))
 
     def test_WHEN_sending_SNL_home_THEN_prevent_status_call(self):
         self.ca_motor.set_pv_value(MTR1_HOMR, 1)
         # Setting STATUS to 1 and to check that the MOVN stays at 1 regardless
         self.ca_motor.set_pv_value(MTR1_SAFE_STUP, 1)
         self.ca_motor.assert_that_pv_is(MTR1_MOVN, 1)
+
+    def test_WHEN_MOTOR_ASG_is_WASL0_THEN_prevent_HVEL_setting(self):
+        macros = IOC_MACROS
+        macros["MOTOR_ASG"] = "WASL0" 
+        with self._ioc.start_with_macros(macros, pv_to_wait_for=PV_TO_WAIT_FOR):
+            try:
+                self.ca_motor.set_pv_value(MTR1_HVEL, 0.1) # testing HVEL because it is part of the group of PVs that the ASG and ASLs control
+            except WriteAccessException as Exception:
+                # this is the error we want to occur
+                pass
+                
+    def test_WHEN_MOTOR_ASG_is_NOT_SET_THEN_prevent_HVEL_setting(self):
+        # when MOTOR_ASG macro does not exist the db record should default to using WASL0
+        macros = IOC_MACROS
+        with self._ioc.start_with_macros(macros, pv_to_wait_for=PV_TO_WAIT_FOR):
+            try:
+                self.ca_motor.set_pv_value(MTR1_HVEL, 0.1)
+            except WriteAccessException as Exception:
+                # this is the error we want to occur here
+                pass
+
+    def test_WHEN_MOTOR_ASG_is_DEFAULT_THEN_allow_HVEL_setting(self):
+        macros = IOC_MACROS
+        macros["MOTOR_ASG"] = "DEFAULT" # set in globals.txt WASL0/DEFAULT
+        with self._ioc.start_with_macros(macros, pv_to_wait_for=PV_TO_WAIT_FOR):
+            self.ca_motor.set_pv_value(MTR1_HVEL, 0.1)
+            # don't want try and except here as they SHOULD have write access
+


### PR DESCRIPTION
Added tests to check that the new MOTOR_ASG macro works correctly.

- https://github.com/ISISComputingGroup/IBEX/issues/8284