### PR TITLE
Ticket8289 Add generic way to close emulator

### DIFF
--- a/utils/emulator_launcher.py
+++ b/utils/emulator_launcher.py
@@ -780,9 +780,13 @@ class CommandLineEmulatorLauncher(EmulatorLauncher):
         children = self._process.children(recursive=True)
         for child in children:
             if child is not None:
-                child.terminate()
+                if child.is_running():
+                    child.terminate()
+                child.wait()
         if self._process is not None:
-            self._process.terminate()
+            if self._process.is_running():
+                self._process.terminate()
+            self._process.wait()
         if self._log_file is not None:
             self._log_file.close()
 

--- a/utils/emulator_launcher.py
+++ b/utils/emulator_launcher.py
@@ -776,6 +776,11 @@ class CommandLineEmulatorLauncher(EmulatorLauncher):
             self._process.wait()
 
     def _close(self):
+        print("Closing commandline emulator.")
+        children = self._process.children(recursive=True)
+        for child in children:
+            if child is not None:
+                child.terminate()
         if self._process is not None:
             self._process.terminate()
         if self._log_file is not None:

--- a/utils/emulator_launcher.py
+++ b/utils/emulator_launcher.py
@@ -6,6 +6,7 @@ import contextlib
 import abc
 import os
 import subprocess
+import psutil
 
 import sys
 from datetime import datetime
@@ -509,7 +510,7 @@ class LewisLauncher(EmulatorLauncher):
         self._logFile.flush()
         print("Started Lewis with '{0}'\n".format(
             " ".join(lewis_command_line)))
-        self._process = subprocess.Popen(lewis_command_line,
+        self._process = psutil.Popen(lewis_command_line,
                                          creationflags=subprocess.CREATE_NEW_CONSOLE,
                                          stdout=self._logFile,
                                          stderr=subprocess.STDOUT)
@@ -587,7 +588,7 @@ class LewisLauncher(EmulatorLauncher):
             time_stamp, " ".join(lewis_command_line)))
         self._logFile.flush()
         try:
-            p = subprocess.Popen(
+            p = psutil.Popen(
                 lewis_command_line, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
             for i in range(1, 40):
                 code = p.poll()
@@ -765,7 +766,7 @@ class CommandLineEmulatorLauncher(EmulatorLauncher):
             cwd = self._emulator_path
         else:
             cwd = None
-        self._process = subprocess.Popen(command_line,
+        self._process = psutil.Popen(command_line,
                                          cwd=cwd,
                                          creationflags=subprocess.CREATE_NEW_CONSOLE,
                                          stdout=self._log_file,

--- a/utils/tests/commandline_nested_test.bat
+++ b/utils/tests/commandline_nested_test.bat
@@ -1,0 +1,2 @@
+start cmd.exe /c commandline_test.bat
+pause

--- a/utils/tests/commandline_test.bat
+++ b/utils/tests/commandline_test.bat
@@ -1,0 +1,3 @@
+start cmd.exe
+start cmd.exe
+pause

--- a/utils/tests/test_emulator_launcher.py
+++ b/utils/tests/test_emulator_launcher.py
@@ -1,0 +1,62 @@
+import os
+import unittest
+import psutil
+from time import sleep
+from hamcrest import assert_that, is_, equal_to, has_length
+from ..emulator_launcher import CommandLineEmulatorLauncher
+
+
+class TestEmulatorLauncher(unittest.TestCase):
+    def test_that_GIVEN_a_commandline_emulator_opens_THEN_it_closes_properly(self):
+        emulator = (
+            CommandLineEmulatorLauncher("test_that_GIVEN_a_commandline_emulator_opens_THEN_it_closes_properly",
+                                        "commandline_emulator",
+                                        "commandline_test.bat",
+                                        "",
+                                        "",
+                                    {"emulator_command_line":"cmd.exe"}))
+        emulator._open()
+        assert_that(emulator._process.is_running(), is_(equal_to(True)))
+        sleep(1)  # Time for any subprocesses to open
+        assert_that(emulator._process.children(recursive=True), is_(has_length(1)))
+        emulator._close()
+        assert_that(emulator._process.is_running(), is_(equal_to(False)))
+        assert_that(emulator._process.children(recursive=True), is_(equal_to([])))
+
+    def test_that_GIVEN_a_commandline_emulator_opens_AND_has_child_proceses_THEN_all_closes_properly(self):
+        emulator = (
+            CommandLineEmulatorLauncher("test_that_GIVEN_a_commandline_emulator_opens_THEN_it_closes_properly",
+                                        "commandline_emulator",
+                                        os.path.join(os.getcwd(),"utils","tests"),
+                                        "",
+                                        "",
+                                        {"emulator_command_line": "cmd.exe /c commandline_test.bat",
+                                            "emulator_cwd_emulator_path": True}))
+        emulator._open()
+        assert_that(emulator._process.is_running(), is_(equal_to(True)))
+        sleep(1)  # Time for any subprocesses to open
+        assert_that(emulator._process.children(recursive=True), has_length(5))
+        emulator._close()
+        assert_that(emulator._process.is_running(), is_(equal_to(False)))
+        assert_that(emulator._process.children(recursive=True), is_(equal_to([])))
+
+    def test_that_GIVEN_a_commandline_emulator_opens_AND_has_nested_child_proceses_THEN_all_closes_properly(self):
+        emulator = (
+            CommandLineEmulatorLauncher("test_that_GIVEN_a_commandline_emulator_opens_THEN_it_closes_properly",
+                                        "commandline_emulator",
+                                        os.path.join(os.getcwd(),"utils","tests"),
+                                        "",
+                                        "",
+                                        {"emulator_command_line": "cmd.exe /c commandline_nested_test.bat",
+                                            "emulator_cwd_emulator_path": True}))
+        emulator._open()
+        assert_that(emulator._process.is_running(), is_(equal_to(True)))
+        sleep(1)  # Time for any subprocesses to open
+        assert_that(emulator._process.children(recursive=True), has_length(7))
+        emulator._close()
+        assert_that(emulator._process.is_running(), is_(equal_to(False)))
+        assert_that(emulator._process.children(recursive=True), is_(equal_to([])))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/tests/test_emulator_launcher.py
+++ b/utils/tests/test_emulator_launcher.py
@@ -1,8 +1,9 @@
 import os
 import unittest
-import psutil
+
 from time import sleep
 from hamcrest import assert_that, is_, equal_to, has_length
+
 from ..emulator_launcher import CommandLineEmulatorLauncher
 
 


### PR DESCRIPTION
## Ticket
https://github.com/ISISComputingGroup/IBEX/issues/8289

Added general solution to close commandline emulators from IOCTestFramework using psutil to ensure childprocesses are killed.
Also added tests for solution

## To Test
Run new unit tests and ensure no cmd windows left open.
Run lndyisw tests on the new branch and ensure the emulator is not left running.