### PR TITLE
Remove usage of six

### DIFF
--- a/common_tests/fermichopper.py
+++ b/common_tests/fermichopper.py
@@ -3,7 +3,6 @@ from contextlib import contextmanager
 from time import sleep
 
 import itertools
-import six
 
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import IOCRegister
@@ -26,8 +25,7 @@ class ErrorStrings(object):
     CONTROLLER_OVERSPEED = "Controller reports speed limit exceeded"
 
 
-@six.add_metaclass(ABCMeta)
-class FermichopperBase(object):
+class FermichopperBase(object, metaclass=ABCMeta):
     """
     Tests for the Fermi Chopper IOC.
     """

--- a/common_tests/instron_base.py
+++ b/common_tests/instron_base.py
@@ -1,7 +1,6 @@
 import abc
 import math
 import time
-import six
 
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import IOCRegister
@@ -21,8 +20,7 @@ LOTS_OF_CYCLES = 999999
 CHANNELS = {"Position": 1, "Stress": 2, "Strain": 3}
 
 
-@six.add_metaclass(abc.ABCMeta)
-class InstronBase(object):
+class InstronBase(object, metaclass=abc.ABCMeta):
     """
     Tests for the Instron IOC.
     """

--- a/common_tests/jaws_manager_utils.py
+++ b/common_tests/jaws_manager_utils.py
@@ -1,6 +1,5 @@
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import IOCRegister
-import six
 import abc
 
 UNDERLYING_GAP_SP = "MOT:JAWS{}:{}GAP:SP"
@@ -8,8 +7,7 @@ UNDERLYING_CENT_SP = "MOT:JAWS{}:{}CENT:SP"
 MOD_GAP = "JAWMAN:MOD:{}GAP:SP"
 
 
-@six.add_metaclass(abc.ABCMeta)
-class JawsManagerBase(object):
+class JawsManagerBase(object, metaclass=abc.ABCMeta):
     """
     Base classes for all jaws manager tests.
     """

--- a/common_tests/moxa12XX.py
+++ b/common_tests/moxa12XX.py
@@ -1,4 +1,3 @@
-import six
 
 from abc import ABCMeta, abstractmethod
 
@@ -7,8 +6,7 @@ from utils.testing import get_running_lewis_and_ioc
 from itertools import product
 
 
-@six.add_metaclass(ABCMeta)
-class Moxa12XXBase(object):
+class Moxa12XXBase(object, metaclass=ABCMeta):
     """
     Tests for a moxa ioLogik e1240. (8x DC Voltage/Current measurements)
     """

--- a/common_tests/riken_changeover.py
+++ b/common_tests/riken_changeover.py
@@ -1,4 +1,3 @@
-import six
 from abc import ABCMeta, abstractmethod
 from utils.channel_access import ChannelAccess
 
@@ -8,8 +7,7 @@ except ImportError:
     from contextlib2 import ExitStack  # PY2
 
 
-@six.add_metaclass(ABCMeta)
-class RikenChangeover(object):
+class RikenChangeover(object, metaclass=ABCMeta):
     """
     Tests for a riken changeover.
 

--- a/common_tests/tpgx6x.py
+++ b/common_tests/tpgx6x.py
@@ -1,7 +1,5 @@
 import abc
 
-import six
-
 from utils.channel_access import ChannelAccess
 from utils.testing import get_running_lewis_and_ioc
 
@@ -38,8 +36,7 @@ class ErrorStrings(object):
     IDENTIFICATION_ERROR = "Identification Error"
 
 
-@six.add_metaclass(abc.ABCMeta)
-class TpgBase(object):
+class TpgBase(object, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def get_prefix(self):

--- a/common_tests/tti_common.py
+++ b/common_tests/tti_common.py
@@ -1,13 +1,11 @@
 import abc
 
-import six
 from parameterized import parameterized
 
 from utils.testing import skip_if_recsim
 
 
-@six.add_metaclass(abc.ABCMeta)
-class TtiCommon(object):
+class TtiCommon(object, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def get_off_state_name(self):

--- a/run_tests.py
+++ b/run_tests.py
@@ -10,7 +10,6 @@ import unittest
 from typing import List, Any
 import importlib
 
-import six
 import xmlrunner
 import glob
 
@@ -218,7 +217,7 @@ def prompt_user_to_run_tests(test_names, device_launchers):
     valid_answers = ["Y", "N"]
     print("Run tests? [{}]: {}".format('/'.join(valid_answers), test_names))
     while True:
-        answer = six.moves.input().upper()
+        answer = input().upper()
         if answer == "" or answer[0] not in valid_answers:
             print("Valid answers are: {}".format(" or ".join(valid_answers)))
         elif answer[0] == "N":
@@ -354,10 +353,6 @@ def run_tests(prefix, module_name, tests_to_run, device_launchers, failfast_swit
 
 
 if __name__ == '__main__':
-    if six.PY2:
-        print("IOC system tests should now be run under python 3. Aborting.")
-        sys.exit(-1)
-
     parser = argparse.ArgumentParser(
         description='Test an IOC under emulation by running tests against it')
     parser.add_argument('-l', '--list-devices',

--- a/tests/edwardstic.py
+++ b/tests/edwardstic.py
@@ -1,5 +1,4 @@
 import unittest
-import six
 
 from abc import ABCMeta, abstractmethod
 
@@ -43,8 +42,7 @@ def get_common_channel_access():
     return ChannelAccess(device_prefix=DEVICE_PREFIX, default_timeout=15)
 
 
-@six.add_metaclass(ABCMeta)
-class EdwardsTICBase(object):
+class EdwardsTICBase(object, metaclass=ABCMeta):
     @abstractmethod
     def get_base_PV(self):
         """
@@ -160,8 +158,7 @@ class EdwardsTICBase(object):
         # Assert alarms clear on reconnection
         self._check_alert_and_priority_PVs(ChannelAccess.Alarms.NONE)
 
-@six.add_metaclass(ABCMeta)
-class GaugeTestBase(EdwardsTICBase):
+class GaugeTestBase(EdwardsTICBase, metaclass=ABCMeta):
 
     @abstractmethod
     def get_gauge_number(self):

--- a/tests/zfcntrl.py
+++ b/tests/zfcntrl.py
@@ -5,8 +5,6 @@ import operator
 import unittest
 from time import sleep
 
-import six
-
 from parameterized import parameterized
 
 from utils.channel_access import ChannelAccess
@@ -457,7 +455,7 @@ class ZeroFieldTests(unittest.TestCase):
     def test_GIVEN_manual_mode_and_just_outside_tolerance_WHEN_magnetometer_is_overloaded_THEN_status_overloaded_and_setpoint_field_is_na(self):
         fields = {"X": 55, "Y": 66, "Z": 77}
         self._set_simulated_measured_fields(fields, overload=True)
-        self._set_user_setpoints({k: v + 1.01 * STABILITY_TOLERANCE for k, v in six.iteritems(fields)})
+        self._set_user_setpoints({k: v + 1.01 * STABILITY_TOLERANCE for k, v in fields.items()})
 
         self._assert_at_setpoint(AtSetpointStatuses.NA)
         self._assert_status(Statuses.MAGNETOMETER_OVERLOAD)
@@ -465,7 +463,7 @@ class ZeroFieldTests(unittest.TestCase):
     def test_GIVEN_manual_mode_and_just_within_tolerance_WHEN_magnetometer_is_overloaded_THEN_status_overloaded_and_setpoint_field_is_na(self):
         fields = {"X": 55, "Y": 66, "Z": 77}
         self._set_simulated_measured_fields(fields, overload=True)
-        self._set_user_setpoints({k: v + 0.99 * STABILITY_TOLERANCE for k, v in six.iteritems(fields)})
+        self._set_user_setpoints({k: v + 0.99 * STABILITY_TOLERANCE for k, v in fields.items()})
 
         self._assert_at_setpoint(AtSetpointStatuses.NA)
         self._assert_status(Statuses.MAGNETOMETER_OVERLOAD)
@@ -523,7 +521,7 @@ class ZeroFieldTests(unittest.TestCase):
         self._set_simulated_measured_fields(fields, overload=False)
 
         # For this test we need changing fields so that we can detect that the writes failed
-        self._set_user_setpoints({k: v + 10 * STABILITY_TOLERANCE for k, v in six.iteritems(fields)})
+        self._set_user_setpoints({k: v + 10 * STABILITY_TOLERANCE for k, v in fields.items()})
         # ... and we also need large limits so that we see that the writes failed as opposed to a limits error
         self._set_output_limits(
             lower_limits={k: -999999 for k in FIELD_AXES},
@@ -609,7 +607,7 @@ class ZeroFieldTests(unittest.TestCase):
         fields = {"X": 5, "Y": 0, "Z": -5}
 
         adjustment_amount = 10 * STABILITY_TOLERANCE  # To ensure that it is not considered stable to start with
-        measured_fields = {k: measured_field_modifier(v, adjustment_amount) for k, v in six.iteritems(fields)}
+        measured_fields = {k: measured_field_modifier(v, adjustment_amount) for k, v in fields.items()}
 
         self._set_scaling_factors(scaling_factor, scaling_factor, scaling_factor, fiddle=1)
         self._set_simulated_measured_fields(measured_fields, overload=False)

--- a/utils/emulator_launcher.py
+++ b/utils/emulator_launcher.py
@@ -12,7 +12,6 @@ import sys
 from datetime import datetime
 from time import sleep, time
 from functools import partial
-import six
 from dataclasses import dataclass
 from typing import List, Any, Dict
 
@@ -66,8 +65,7 @@ class EmulatorRegister(object):
         del cls.RunningEmulators[name]
 
 
-@six.add_metaclass(abc.ABCMeta)
-class EmulatorLauncher(object):
+class EmulatorLauncher(object, metaclass=abc.ABCMeta):
 
     def __init__(self, test_name, device, emulator_path, var_dir, port, options):
         """

--- a/utils/ioc_launcher.py
+++ b/utils/ioc_launcher.py
@@ -10,8 +10,6 @@ import psutil
 from time import sleep
 from abc import ABCMeta
 
-import six
-
 from utils.channel_access import ChannelAccess
 from utils.free_ports import get_free_ports
 from utils.log_file import log_filename, LogFileManager
@@ -119,8 +117,7 @@ class IOCRegister(object):
         cls.RunningIOCs[name] = ioc
 
 
-@six.add_metaclass(ABCMeta)
-class BaseLauncher(object):
+class BaseLauncher(object, metaclass=ABCMeta):
     """
     Launcher base, this is the base class for a launcher of application under test.
     """

--- a/utils/testing.py
+++ b/utils/testing.py
@@ -2,8 +2,6 @@ import functools
 import unittest
 from time import sleep
 
-import six
-
 from utils.ioc_launcher import IOCRegister, IocLauncher
 from utils.emulator_launcher import EmulatorRegister, LewisLauncher
 
@@ -141,7 +139,7 @@ def skip_if_condition(condition, reason):
         reason (str): The reason for skipping the test
     """
     def decorator(func):
-        @six.wraps(func)
+        @functools.wraps(func)
         def wrapper(*args, **kwargs):
             if condition():
                 raise unittest.SkipTest(reason)
@@ -173,7 +171,7 @@ def add_method(method):
         method (func): The method to add to the class decorated. Should be callable.
     """
 
-    @six.wraps(method)
+    @functools.wraps(method)
     def wrapper(class_to_decorate):
         setattr(class_to_decorate, method.__name__, method)
         return class_to_decorate
@@ -218,7 +216,7 @@ def unstable_test(max_retries=2, error_class=AssertionError, wait_between_runs=0
         wait_between_runs: number of seconds to wait between each failed attempt at running the test
     """
     def decorator(func):
-        @six.wraps(func)
+        @functools.wraps(func)
         def wrapper(self, *args, **kwargs):
             try:
                 return func(self, *args, **kwargs)  # Initial attempt to run the test "normally"


### PR DESCRIPTION
### Description of work

Remove all references to Six

### To test
[Ticket](https://github.com/ISISComputingGroup/IBEX/issues/8297)

### Acceptance criteria

- [ ] Git grep finds no `import six`.
- [ ] Tests changed do not cause any new test failures.