### PR TITLE
Ticket8341_set_alarm_severity_based_on_macro

### DIFF
--- a/common_tests/tpgx00.py
+++ b/common_tests/tpgx00.py
@@ -13,11 +13,11 @@ from itertools import product
 
 @unique
 class ChannelStatus(Enum):
-    DATA_OK     = ("Measured data okay", "NO_ALARM")
-    UNDERRANGE  = ("Underrange", "MINOR")
-    OVERRANGE   = ("Overrange", "MINOR")
+    DATA_OK = ("Measured data okay", "NO_ALARM")
+    UNDERRANGE = ("Underrange", "MINOR")
+    OVERRANGE = ("Overrange", "MINOR")
     POINT_ERROR = ("Point error", "MAJOR")
-    POINT_OFF   = ("Point switched off", "MAJOR")
+    POINT_OFF = ("Point switched off", "MAJOR")
     NO_HARDWARE = ("No hardware", "INVALID")
 
     def __new__(cls, value, sevr):
@@ -26,19 +26,22 @@ class ChannelStatus(Enum):
         obj.sevr = sevr
         return obj
 
+
 CHANNELS = "A1", "A2", "B1", "B2"
 TEST_PRESSURES = 1.23, -10.23, 8, 1e-6, 1e+6
 
+
 class ErrorStatus(Enum):
-    NO_ERROR      = "No error"
-    DEVICE_ERROR  = "Device error"
-    NO_HARDWARE   = "No hardware"
+    NO_ERROR = "No error"
+    DEVICE_ERROR = "Device error"
+    NO_HARDWARE = "No hardware"
     INVALID_PARAM = "Invalid parameter"
-    SYNTAX_ERROR  = "Syntax error"
+    SYNTAX_ERROR = "Syntax error"
+
 
 class SFStatus(Enum):
     OFF = 0
-    ON  = 1
+    ON = 1
 
 
 class Tpgx00Base():
@@ -54,18 +57,19 @@ class Tpgx00Base():
         pass
 
     def setUp(self):
-        self._lewis, self._ioc = get_running_lewis_and_ioc("tpgx00", self.get_prefix())
-        self.ca = ChannelAccess(20, device_prefix=self.get_prefix(), default_wait_time=0.0)
-        
+        self._lewis, self._ioc = get_running_lewis_and_ioc(
+            "tpgx00", self.get_prefix())
+        self.ca = ChannelAccess(
+            20, device_prefix=self.get_prefix(), default_wait_time=0.0)
+
         # Reset switching function
         self._set_switching_function("1")
         self._set_switching_function_thresholds(0.0, 0.0, 1)
 
         # Reset pressure status for each channel to okay
         for channel in CHANNELS:
-            self._lewis.backdoor_run_function_on_device("backdoor_set_pressure_status", [channel, ChannelStatus.DATA_OK.name])
-        
-            
+            self._lewis.backdoor_run_function_on_device("backdoor_set_pressure_status", [
+                                                        channel, ChannelStatus.DATA_OK.name])
 
     def tearDown(self):
         self._connect_emulator()
@@ -75,7 +79,7 @@ class Tpgx00Base():
         pv = "SIM:PRESSURE"
         self._lewis.backdoor_set_on_device(prop, expected_pressure)
         self._ioc.set_simulated_value(pv, expected_pressure)
-    
+
     def _set_switching_function(self, function):
         self.ca.set_pv_value("FUNCTION", function)
 
@@ -84,23 +88,31 @@ class Tpgx00Base():
         self.ca.set_pv_value("FUNCTION:HIGH:SP", threshold_high)
         self.ca.set_pv_value("FUNCTION:ASSIGN:SP", circuit_assignment)
         self.ca.process_pv("FUNCTION:ASSIGN:SP:OUT")
-    
+
     def _check_switching_function_thresholds(self, function, threshold_low, threshold_high, circuit_assignment):
-        self.ca.assert_that_pv_is_number("FUNCTION:" + function + ":LOW:SP:RBV", threshold_low, timeout=15)
-        self.ca.assert_that_pv_is_number("FUNCTION:" + function + ":HIGH:SP:RBV", threshold_high, timeout=15)
-        self.ca.assert_that_pv_is("FUNCTION:" + function + ":ASSIGN:SP:RBV", circuit_assignment, timeout=15)
+        self.ca.assert_that_pv_is_number(
+            "FUNCTION:" + function + ":LOW:SP:RBV", threshold_low, timeout=15)
+        self.ca.assert_that_pv_is_number(
+            "FUNCTION:" + function + ":HIGH:SP:RBV", threshold_high, timeout=15)
+        self.ca.assert_that_pv_is(
+            "FUNCTION:" + function + ":ASSIGN:SP:RBV", circuit_assignment, timeout=15)
 
     def _check_alarm_status_rbvs(self, alarm):
         for channel in self.get_switching_fns():
-            self.ca.assert_that_pv_alarm_is("FUNCTION:" + channel + ":RB", alarm)
-            self.ca.assert_that_pv_alarm_is("FUNCTION:" + channel + ":LOW:SP:RBV", alarm)
-            self.ca.assert_that_pv_alarm_is("FUNCTION:" + channel + ":HIGH:SP:RBV", alarm)
-            self.ca.assert_that_pv_alarm_is("FUNCTION:" + channel + ":ASSIGN:SP:RBV", alarm)
+            self.ca.assert_that_pv_alarm_is(
+                "FUNCTION:" + channel + ":RB", alarm)
+            self.ca.assert_that_pv_alarm_is(
+                "FUNCTION:" + channel + ":LOW:SP:RBV", alarm)
+            self.ca.assert_that_pv_alarm_is(
+                "FUNCTION:" + channel + ":HIGH:SP:RBV", alarm)
+            self.ca.assert_that_pv_alarm_is(
+                "FUNCTION:" + channel + ":ASSIGN:SP:RBV", alarm)
 
     def _check_alarm_status_function_statuses(self, alarm):
         self.ca.assert_that_pv_alarm_is("FUNCTION:STATUS:RB", alarm)
         for channel in ("1", "2", "3", "4"):
-            self.ca.assert_that_pv_alarm_is("FUNCTION:STATUS:" + channel + ":RB", alarm)
+            self.ca.assert_that_pv_alarm_is(
+                "FUNCTION:STATUS:" + channel + ":RB", alarm)
 
     def _connect_emulator(self):
         self._lewis.backdoor_run_function_on_device("connect")
@@ -113,7 +125,6 @@ class Tpgx00Base():
         finally:
             self._connect_emulator()
 
-
     def test_that_GIVEN_a_connected_emulator_WHEN_ioc_started_THEN_ioc_is_not_disabled(self):
         self.ca.assert_that_pv_is("DISABLE", "COMMS ENABLED")
 
@@ -122,7 +133,8 @@ class Tpgx00Base():
         for unit in self.get_units():
             expected_unit = unit.name
             self.ca.set_pv_value("UNITS:SP", expected_unit)
-            self._lewis.assert_that_emulator_value_is("backdoor_get_unit", str(expected_unit))
+            self._lewis.assert_that_emulator_value_is(
+                "backdoor_get_unit", str(expected_unit))
             self.ca.assert_that_pv_is("UNITS:SP", expected_unit)
             self.ca.assert_that_pv_is("UNITS", expected_unit)
 
@@ -138,7 +150,7 @@ class Tpgx00Base():
         pv = "PRESSURE_{}".format(channel)
         self.ca.assert_that_pv_alarm_is(pv, self.ca.Alarms.NONE)
         with self._disconnect_device():
-                self.ca.assert_that_pv_alarm_is(pv, self.ca.Alarms.INVALID)
+            self.ca.assert_that_pv_alarm_is(pv, self.ca.Alarms.INVALID)
 
         self.ca.assert_that_pv_alarm_is(pv, self.ca.Alarms.NONE)
 
@@ -146,11 +158,15 @@ class Tpgx00Base():
     @skip_if_recsim("Requires emulator")
     def test_GIVEN_pressure_status_changed_THEN_pressure_status_and_pressure_severity_updated(self, _, channel):
         for status in ChannelStatus:
-            self._lewis.backdoor_run_function_on_device("backdoor_set_pressure_status", [channel, status.name])
+            self._lewis.backdoor_run_function_on_device(
+                "backdoor_set_pressure_status", [channel, status.name])
             self._set_pressure(TEST_PRESSURES[0], channel)
-            self.ca.assert_that_pv_is(f"PRESSURE_{channel}_STAT", status.value, timeout=15)
-            self.ca.assert_that_pv_is(f"PRESSURE_{channel}_STAT.SEVR", status.sevr, timeout=15)
-            self.ca.assert_that_pv_is(f"PRESSURE_{channel}.SEVR", status.sevr, timeout=15)
+            self.ca.assert_that_pv_is(
+                f"PRESSURE_{channel}_STAT", status.value, timeout=15)
+            self.ca.assert_that_pv_is(
+                f"PRESSURE_{channel}_STAT.SEVR", status.sevr, timeout=15)
+            self.ca.assert_that_pv_is(
+                f"PRESSURE_{channel}.SEVR", status.sevr, timeout=15)
 
     # Only test using switching function values in [1-4]; these are values that are valid between both models. Invalid values are checked in the
     # individual submodules.
@@ -163,8 +179,10 @@ class Tpgx00Base():
     def test_GIVEN_function_thresholds_set_THEN_thresholds_readback_correct(self, switching_func, set_threshold_low, set_threshold_hi, read_threshold_low, read_threshold_hi):
         for circuit_assign in self.get_sf_assignment():
             self._set_switching_function(switching_func)
-            self._set_switching_function_thresholds(set_threshold_low, set_threshold_hi, circuit_assign.value)
-            self._check_switching_function_thresholds(str(switching_func), read_threshold_low, read_threshold_hi, circuit_assign.desc)
+            self._set_switching_function_thresholds(
+                set_threshold_low, set_threshold_hi, circuit_assign.value)
+            self._check_switching_function_thresholds(
+                str(switching_func), read_threshold_low, read_threshold_hi, circuit_assign.desc)
 
     @skip_if_recsim("Requires emulator")
     def test_GIVEN_thresholds_settings_and_pressure_above_THEN_check_if_violation_detected(self):
@@ -172,7 +190,8 @@ class Tpgx00Base():
         self._set_switching_function("3")
         # Use enum value 4 for circuit assignment as this is an edge case; it should yield different states for the two models.
         switching_fn_4 = self.get_sf_assignment()(4)
-        self._set_switching_function_thresholds(5E2, 7.5E4, switching_fn_4.value)
+        self._set_switching_function_thresholds(
+            5E2, 7.5E4, switching_fn_4.value)
         self.ca.assert_that_pv_is("FUNCTION:3:THRESHOLD:BELOW", 1)
         self._set_pressure(6.43, switching_fn_4.desc)
         self.ca.assert_that_pv_is("FUNCTION:3:THRESHOLD:BELOW", 1)
@@ -188,27 +207,70 @@ class Tpgx00Base():
         self._check_alarm_status_rbvs(self.ca.Alarms.NONE)
 
     def _check_switching_function_statuses(self, expected_statuses):
-        self.ca.assert_that_pv_is("FUNCTION:STATUS:1:RB", str(SFStatus[expected_statuses[0]].value))
-        self.ca.assert_that_pv_is("FUNCTION:STATUS:2:RB", str(SFStatus[expected_statuses[1]].value))
-        self.ca.assert_that_pv_is("FUNCTION:STATUS:3:RB", str(SFStatus[expected_statuses[2]].value))
-        self.ca.assert_that_pv_is("FUNCTION:STATUS:4:RB", str(SFStatus[expected_statuses[3]].value))
+        self.ca.assert_that_pv_is("FUNCTION:STATUS:1:RB", str(
+            SFStatus[expected_statuses[0]].value))
+        self.ca.assert_that_pv_is("FUNCTION:STATUS:2:RB", str(
+            SFStatus[expected_statuses[1]].value))
+        self.ca.assert_that_pv_is("FUNCTION:STATUS:3:RB", str(
+            SFStatus[expected_statuses[2]].value))
+        self.ca.assert_that_pv_is("FUNCTION:STATUS:4:RB", str(
+            SFStatus[expected_statuses[3]].value))
 
     @skip_if_recsim("Requires emulator")
     def test_GIVEN_function_status_set_THEN_readback_correct(self):
         function_statuses = ["OFF", "OFF", "ON", "ON", "OFF", "ON"]
-        self._lewis.backdoor_run_function_on_device("backdoor_set_switching_function_status", [function_statuses])
+        self._lewis.backdoor_run_function_on_device(
+            "backdoor_set_switching_function_status", [function_statuses])
         self._check_switching_function_statuses(function_statuses)
 
     @skip_if_recsim("Requires emulator")
     def test_WHEN_error_set_by_device_THEN_readback_correct(self):
         for error in ErrorStatus:
-            self._lewis.backdoor_run_function_on_device("backdoor_set_error_status", [error.name])
+            self._lewis.backdoor_run_function_on_device(
+                "backdoor_set_error_status", [error.name])
             self.ca.assert_that_pv_is("ERROR", error.value)
-    
+
     @skip_if_recsim("Requires emulator")
     def test_WHEN_device_disconnected_THEN_function_statuses_go_into_alarm(self):
         self._check_alarm_status_function_statuses(self.ca.Alarms.NONE)
         with self._disconnect_device():
             self._check_alarm_status_function_statuses(self.ca.Alarms.INVALID)
-        
+
         self._check_alarm_status_function_statuses(self.ca.Alarms.NONE)
+
+    @parameterized.expand([
+        ("1"),
+        ("2"),
+    ])
+    @skip_if_recsim("Requires emulator")
+    def test_WHEN_underrange_macro_is_set_THEN_alarm_is_none(self, channel):
+        with self._ioc.start_with_macros({"TPG_UNDERRANGE_ALARM_SEVERITY_CHAN" + channel: "NO_ALARM",
+                                          }, pv_to_wait_for="PRESSURE_A" + channel + "_STAT"):
+
+            self._lewis.backdoor_run_function_on_device("backdoor_set_pressure_status", [
+                                                        "A" + channel, ChannelStatus.UNDERRANGE.name])
+            self._lewis.backdoor_run_function_on_device("backdoor_set_pressure_status", [
+                                                        "B" + channel, ChannelStatus.UNDERRANGE.name])
+
+            self.ca.assert_that_pv_alarm_is(
+                "PRESSURE_A" + channel + "_STAT", self.ca.Alarms.NONE)
+            self.ca.assert_that_pv_alarm_is(
+                "PRESSURE_B" + channel + "_STAT", self.ca.Alarms.NONE)
+
+    @parameterized.expand([
+        ("1"),
+        ("2"),
+    ])
+    @skip_if_recsim("Requires emulator")
+    def test_WHEN_underrange_macro_is_not_set_THEN_alarm_is_minor(self, channel):
+        with self._ioc.start_with_macros({}, pv_to_wait_for="PRESSURE_A" + channel + "_STAT"):
+
+            self._lewis.backdoor_run_function_on_device("backdoor_set_pressure_status", [
+                                                        "A" + channel, ChannelStatus.UNDERRANGE.name])
+            self._lewis.backdoor_run_function_on_device("backdoor_set_pressure_status", [
+                                                        "B" + channel, ChannelStatus.UNDERRANGE.name])
+
+            self.ca.assert_that_pv_alarm_is(
+                "PRESSURE_A" + channel + "_STAT", self.ca.Alarms.MINOR)
+            self.ca.assert_that_pv_alarm_is(
+                "PRESSURE_B" + channel + "_STAT", self.ca.Alarms.MINOR)

--- a/tests/tpg300.py
+++ b/tests/tpg300.py
@@ -5,7 +5,7 @@ from parameterized import parameterized
 from genie_python.genie_cachannel_wrapper import InvalidEnumStringException
 
 from common_tests.tpgx00 import Tpgx00Base
-from utils.ioc_launcher import get_default_ioc_dir
+from utils.ioc_launcher import get_default_ioc_dir, ProcServLauncher
 from utils.test_modes import TestModes
 from utils.testing import skip_if_recsim, parameterized_list
 from enum import Enum
@@ -15,14 +15,15 @@ DEVICE_PREFIX = "TPG300_01"
 
 IOCS = [
     {
-    "name": DEVICE_PREFIX,
-    "directory": get_default_ioc_dir("TPG300"),
-    "macros": {
-        "MODEL": "300"
-    },
-    "emulator": "tpgx00",
-    "lewis_protocol": "tpg300",
-    "pv_for_existence": "UNITS",
+        "name": DEVICE_PREFIX,
+        "directory": get_default_ioc_dir("TPG300"),
+        "macros": {
+            "MODEL": "300",
+        },
+        "emulator": "tpgx00",
+        "lewis_protocol": "tpg300",
+        "pv_for_existence": "UNITS",
+        "ioc_launcher_class": ProcServLauncher,
     },
 ]
 
@@ -33,11 +34,11 @@ SWITCHING_FUNCTIONS = ("SEL", "1", "2", "3", "4", "A", "B")
 
 
 class SFAssignment(Enum):
-    OFF         = (0, "No assignment")
-    A1          = (1, "A1")
-    A2          = (2, "A2")
-    B1          = (3, "B1")
-    B2          = (4, "B1")
+    OFF = (0, "No assignment")
+    A1 = (1, "A1")
+    A2 = (2, "A2")
+    B1 = (3, "B1")
+    B2 = (4, "B1")
     A1_SELF_MON = (5, "A1 self-monitor")
     A2_SELF_MON = (6, "A2 self-monitor")
     B1_SELF_MON = (7, "B1 self-monitor")
@@ -63,12 +64,12 @@ class Tpg300Tests(Tpgx00Base, unittest.TestCase):
 
     def get_prefix(self):
         return DEVICE_PREFIX
-        
+
     def get_units(self):
         return Units
 
     def get_sf_assignment(self):
         return SFAssignment
-    
+
     def get_switching_fns(self):
         return SWITCHING_FUNCTIONS


### PR DESCRIPTION
Changed IOC launcher for the TPG to be a procserve one so I could use start_ioc_with_macros to test the new macros of the IOC.

Added 2 new tests to check that when the macro is set for a specific group the alarm severity is set correctly and behaves as expected.

- https://github.com/ISISComputingGroup/IBEX/issues/8341