### PR TITLE
start instetc before main ioc

### DIFF
--- a/tests/muontpar.py
+++ b/tests/muontpar.py
@@ -19,17 +19,17 @@ test_config_path = os.path.abspath(
 
 IOCS = [
     {
-        "name": DEVICE_PREFIX,
-        "directory": get_default_ioc_dir("MUONTPAR"),
-        "pv_for_existence": "FILE_DIR",
-        "macros": {"EDITOR_TPAR_FILE_DIR": test_config_path},
-    },
-        {
         # INSTETC is required to control manager mode.
         "name": "INSTETC",
         "directory": get_default_ioc_dir("INSTETC"),
         "custom_prefix": "CS",
         "pv_for_existence": "MANAGER",
+    },
+    {
+        "name": DEVICE_PREFIX,
+        "directory": get_default_ioc_dir("MUONTPAR"),
+        "pv_for_existence": "FILE_DIR",
+        "macros": {"EDITOR_TPAR_FILE_DIR": test_config_path},
     },
 ]
 

--- a/tests/muontpar.py
+++ b/tests/muontpar.py
@@ -47,6 +47,7 @@ TEST_TPAR = """
 """
 TEST_TPAR_FILENAME = "test_write.tpar"
 
+
 class MuonTPARTests(unittest.TestCase):
     """
     Tests for the muon tpar IOC.
@@ -101,4 +102,3 @@ class MuonTPARTests(unittest.TestCase):
         self.ca.assert_that_pv_is("UNSAVED_CHANGES", "No")
         with open(os.path.join(test_config_path, file_name), "r") as tpar_file:
             self.ca.assert_that_pv_is("LINES_ARRAY:SP", tpar_file.read())
-


### PR DESCRIPTION
makes sure manager mode pv is available earlier - possible race condition if not