### PR TITLE
Open ioc and emulator log files in append mode

### DIFF
--- a/utils/emulator_launcher.py
+++ b/utils/emulator_launcher.py
@@ -346,7 +346,7 @@ class EmulatorLauncher(object, metaclass=abc.ABCMeta):
 
         if msg is None:
             msg = (
-                "Expected function '{}' to evaluate to True " "when reading emulator property '{}'."
+                "Expected function '{}' to evaluate to True when reading emulator property '{}'."
             ).format(func.__name__, emulator_property)
 
         err = self._wait_for_emulator_lambda(partial(wrapper, msg), timeout)
@@ -400,8 +400,7 @@ class EmulatorLauncher(object, metaclass=abc.ABCMeta):
 
         if msg is None:
             msg = (
-                "Expected function '{}' to evaluate to False "
-                "when reading emulator property '{}'."
+                "Expected function '{}' to evaluate to False when reading emulator property '{}'."
             ).format(func.__name__, emulator_property)
 
         err = self._wait_for_emulator_lambda(partial(wrapper, msg), timeout)
@@ -628,7 +627,7 @@ class LewisLauncher(EmulatorLauncher):
         :param port: the port on which to run lewis
         :return:
         """
-        self._logFile = open(self._log_filename(), "w")
+        self._logFile = open(self._log_filename(), "a")
         self._control_port = str(get_free_ports(1)[0])
         lewis_command_line = [
             self._python_path,
@@ -960,7 +959,7 @@ class CommandLineEmulatorLauncher(EmulatorLauncher):
             log_filename(
                 self._test_name, "cmdemulator", self._device, TestModes.RECSIM, self._var_dir
             ),
-            "w",
+            "a",
         )
         self._call_command_line(self.command_line.format(port=self._port))
 

--- a/utils/ioc_launcher.py
+++ b/utils/ioc_launcher.py
@@ -207,7 +207,7 @@ class BaseLauncher(object, metaclass=ABCMeta):
 
             self.create_macros_file()
 
-            self.log_file_manager = LogFileManager(self.log_file_name)
+            self.log_file_manager = LogFileManager(self.log_file_name, "a")
             self.log_file_manager.log_file_w.write(
                 "Started IOC with '{0}'".format(" ".join(self.command_line))
             )

--- a/utils/log_file.py
+++ b/utils/log_file.py
@@ -41,8 +41,8 @@ class LogFileManager(object):
     Class to manage the access of log files
     """
 
-    def __init__(self, filename: str) -> None:
-        self.log_file_w = open(filename, "w", 1)
+    def __init__(self, filename: str, write_mode: str = "w") -> None:
+        self.log_file_w = open(filename, write_mode, 1)
         self.log_file_r = open(filename, "r")
 
     def read_log(self) -> list[str]:


### PR DESCRIPTION
Open emulator and ioc logs in append mode, this means we capture all output if the emulator or ioc is relaunched. 